### PR TITLE
Fixes for Android

### DIFF
--- a/java/java/src/main/java/org/whispersystems/libsignal/ecc/ECPublicKey.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/ecc/ECPublicKey.java
@@ -24,6 +24,13 @@ public class ECPublicKey implements Comparable<ECPublicKey> {
     this.handle = Native.ECPublicKey_Deserialize(serialized, 0);
   }
 
+  static public ECPublicKey fromPublicKey(byte[] key) {
+    byte[] with_type = new byte[33];
+    with_type[0] = 0x05;
+    System.arraycopy(key, 0, with_type, 1, 32);
+    return new ECPublicKey(Native.ECPublicKey_Deserialize(with_type, 0));
+  }
+
   public ECPublicKey(long nativeHandle) {
     if (nativeHandle == 0) {
       throw new NullPointerException();

--- a/java/java/src/main/java/org/whispersystems/libsignal/ecc/ECPublicKey.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/ecc/ECPublicKey.java
@@ -7,7 +7,6 @@
 package org.whispersystems.libsignal.ecc;
 
 import org.signal.client.internal.Native;
-import java.math.BigInteger;
 import java.util.Arrays;
 
 public class ECPublicKey implements Comparable<ECPublicKey> {
@@ -24,7 +23,7 @@ public class ECPublicKey implements Comparable<ECPublicKey> {
     this.handle = Native.ECPublicKey_Deserialize(serialized, 0);
   }
 
-  static public ECPublicKey fromPublicKey(byte[] key) {
+  static public ECPublicKey fromPublicKeyBytes(byte[] key) {
     byte[] with_type = new byte[33];
     with_type[0] = 0x05;
     System.arraycopy(key, 0, with_type, 1, 32);

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -266,7 +266,11 @@ pub unsafe extern "system" fn Java_org_signal_client_internal_Native_HKDF_1Deriv
             Some(env.convert_byte_array(salt)?)
         };
 
-        let info = env.convert_byte_array(info)?;
+        let info = if info.is_null() {
+            vec![]
+        } else {
+            env.convert_byte_array(info)?
+        };
 
         let hkdf = HKDF::new(version)?;
         let derived = if let Some(salt) = salt {


### PR DESCRIPTION
- Allow info to be null/empty in HKDF arguments. This is used during KBS attestation.
- Allow creating an ECPublicKey from the un-typed key bytes, also used when talking to KBS.