### PR TITLE
Automatically generate Native.java from the exported symbols of the Rust bridge

### DIFF
--- a/java/java/src/main/java/org/signal/internal/Native.java
+++ b/java/java/src/main/java/org/signal/internal/Native.java
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+// WARNING: this file was automatically generated
+
 package org.signal.client.internal;
 
 import org.whispersystems.libsignal.protocol.CiphertextMessage;
@@ -64,166 +66,131 @@ public final class Native {
 
   private Native() {}
 
-  public static native byte[] HKDF_DeriveSecrets(int version, byte[] inputKeyMaterial,
-                                                  byte[] salt, byte[] info, int outputLength);
+  public static native String DisplayableFingerprint_Format(byte[] local, byte[] remote);
 
-  public static native long ECPublicKey_Deserialize(byte[] data, int offset);
-  public static native byte[] ECPublicKey_Serialize(long handle);
-  public static native byte[] ECPublicKey_GetPublicKeyBytes(long handle);
-  public static native int ECPublicKey_Compare(long handle1, long handle2);
-  public static native boolean ECPublicKey_Verify(long handle, byte[] message, byte[] signature);
-  public static native void ECPublicKey_Destroy(long handle);
-
-  public static native long ECPrivateKey_Generate();
+  public static native byte[] ECPrivateKey_Agree(long privateKeyHandle, long publicKeyHandle);
   public static native long ECPrivateKey_Deserialize(byte[] data);
+  public static native void ECPrivateKey_Destroy(long handle);
+  public static native long ECPrivateKey_Generate();
+  public static native long ECPrivateKey_GetPublicKey(long handle);
   public static native byte[] ECPrivateKey_Serialize(long handle);
   public static native byte[] ECPrivateKey_Sign(long handle, byte[] message);
-  public static native byte[] ECPrivateKey_Agree(long handle, long pubkey_handle);
-  public static native long ECPrivateKey_GetPublicKey(long handle);
-  public static native void ECPrivateKey_Destroy(long handle);
 
-  public static native byte[] IdentityKeyPair_Serialize(long pubHandle, long privHandle);
+  public static native int ECPublicKey_Compare(long key1, long key2);
+  public static native long ECPublicKey_Deserialize(byte[] data, int offset);
+  public static native void ECPublicKey_Destroy(long handle);
+  public static native byte[] ECPublicKey_GetPublicKeyBytes(long handle);
+  public static native byte[] ECPublicKey_Serialize(long handle);
+  public static native boolean ECPublicKey_Verify(long handle, byte[] message, byte[] signature);
 
-  public static native long NumericFingerprintGenerator_New(int iterations, int version, byte[] localIdentifier, byte[] localKey, byte[] remoteIdentifier, byte[] remoteKey);
+  public static native byte[] GroupCipher_DecryptMessage(long senderKeyName, byte[] message, SenderKeyStore store);
+  public static native byte[] GroupCipher_EncryptMessage(long senderKeyName, byte[] message, SenderKeyStore store);
+
+  public static native long GroupSessionBuilder_CreateSenderKeyDistributionMessage(long senderKeyName, SenderKeyStore store);
+  public static native void GroupSessionBuilder_ProcessSenderKeyDistributionMessage(long senderKeyName, long senderKeyDistributionMessage, SenderKeyStore store);
+
+  public static native byte[] HKDF_DeriveSecrets(int version, byte[] inputKeyMaterial, byte[] salt, byte[] info, int outputLength);
+
+  public static native byte[] IdentityKeyPair_Serialize(long publicKeyHandle, long privateKeyHandle);
+
+  public static native void NumericFingerprintGenerator_Destroy(long handle);
   public static native String NumericFingerprintGenerator_GetDisplayString(long handle);
   public static native byte[] NumericFingerprintGenerator_GetScannableEncoding(long handle);
-  public static native void NumericFingerprintGenerator_Destroy(long handle);
-  public static native String DisplayableFingerprint_Format(byte[] localFingerprint, byte[] remoteFingerprint);
-  public static native boolean ScannableFingerprint_Compare(byte[] ourFingerprint, byte[] scannedFingerprint);
+  public static native long NumericFingerprintGenerator_New(int iterations, int version, byte[] localIdentifier, byte[] localKey, byte[] remoteIdentifier, byte[] remoteKey);
 
-  public static native long ProtocolAddress_New(String name, int device_id);
-  public static native long ProtocolAddress_Destroy(long handle);
-  public static native String ProtocolAddress_Name(long handle);
-  public static native int ProtocolAddress_DeviceId(long handle);
-
-  public static native long SignedPreKeyRecord_New(int id, long timestamp, long pubKeyHandle, long privKeyHandle, byte[] signature);
-  public static native long SignedPreKeyRecord_Deserialize(byte[] serialized);
-  public static native void SignedPreKeyRecord_Destroy(long handle);
-  public static native int SignedPreKeyRecord_GetId(long handle);
-  public static native long SignedPreKeyRecord_GetTimestamp(long handle);
-  public static native long SignedPreKeyRecord_GetPublicKey(long handle);
-  public static native long SignedPreKeyRecord_GetPrivateKey(long handle);
-  public static native byte[] SignedPreKeyRecord_GetSignature(long handle);
-  public static native byte[] SignedPreKeyRecord_GetSerialized(long handle);
-
-  public static native byte[] SessionState_InitializeAliceSession(long identityKeyPrivateHandle,
-                                                                  long identityKeyPublicHandle,
-                                                                  long baseKeyPrivateHandle,
-                                                                  long baseKeyPublicKeyHandle,
-                                                                  long theirIdentityKeyPublicHandle,
-                                                                  long theirSignedPreKeyPublicHandle,
-                                                                  long theirRatchetKeyPublicHandle);
-
-  public static native byte[] SessionState_InitializeBobSession(long identityKeyPrivateHandle,
-                                                                long identityKeyPublicHandle,
-                                                                long signedPreKeyPrivateHandle,
-                                                                long signedPreKeyPublicKeyHandle,
-                                                                long ephemeralKeyPrivateHandle,
-                                                                long ephemeralKeyPublicHandle,
-                                                                long theirIdentityKeyPublicHandle,
-                                                                long theirBaseKeyPublicHandle);
-
-  public static native long PreKeyBundle_New(int registrationId, int deviceId, int preKeyId, long preKeyPublicHandle,
-                                             int signedPreKeyId, long signedPreKeyPublicHandle, byte[] signedPreKeySignature, long identityKeyHandle);
   public static native void PreKeyBundle_Destroy(long handle);
-  public static native int PreKeyBundle_GetRegistrationId(long handle);
   public static native int PreKeyBundle_GetDeviceId(long handle);
+  public static native long PreKeyBundle_GetIdentityKey(long handle);
   public static native int PreKeyBundle_GetPreKeyId(long handle);
-  public static native int PreKeyBundle_GetSignedPreKeyId(long handle);
   public static native long PreKeyBundle_GetPreKeyPublic(long handle);
+  public static native int PreKeyBundle_GetRegistrationId(long handle);
+  public static native int PreKeyBundle_GetSignedPreKeyId(long handle);
   public static native long PreKeyBundle_GetSignedPreKeyPublic(long handle);
   public static native byte[] PreKeyBundle_GetSignedPreKeySignature(long handle);
-  public static native long PreKeyBundle_GetIdentityKey(long handle);
+  public static native long PreKeyBundle_New(int registrationId, int deviceId, int prekeyId, long prekeyHandle, int signedPrekeyId, long signedPrekeyHandle, byte[] signedPrekeySignature, long identityKeyHandle);
 
-  public static native long PreKeyRecord_New(int id, long pubKeyHandle, long privKeyHandle);
-  public static native long PreKeyRecord_Deserialize(byte[] serialized);
+  public static native long PreKeyRecord_Deserialize(byte[] data);
   public static native void PreKeyRecord_Destroy(long handle);
   public static native int PreKeyRecord_GetId(long handle);
-  public static native long PreKeyRecord_GetPublicKey(long handle);
   public static native long PreKeyRecord_GetPrivateKey(long handle);
+  public static native long PreKeyRecord_GetPublicKey(long handle);
   public static native byte[] PreKeyRecord_GetSerialized(long handle);
+  public static native long PreKeyRecord_New(int id, long pubKeyHandle, long privKeyHandle);
 
-  public static native CiphertextMessage SessionCipher_EncryptMessage(byte[] message, long remoteAddressHandle, SessionStore sessionStore, IdentityKeyStore identityKeyStore);
-  public static native byte[] SessionCipher_DecryptSignalMessage(long signalMessageHandle, long remoteAddressHandle, SessionStore sessionStore, IdentityKeyStore identityKeyStore);
-  public static native byte[] SessionCipher_DecryptPreKeySignalMessage(long preKeySignalMessageHandle, long remoteAddressHandle, SessionStore sessionStore,
-                                                                       IdentityKeyStore identityKeyStore, PreKeyStore preKeyStore, SignedPreKeyStore signedPreKeyStore);
-
-  public static native void SessionBuilder_ProcessPreKeyBundle(long preKeyBundleHandle,
-                                                               long remoteAddressHandle,
-                                                               SessionStore sessionStore,
-                                                               IdentityKeyStore identityKeyStore);
-
-  public static native long GroupSessionBuilder_CreateSenderKeyDistributionMessage(long senderKeyNameHandle,
-                                                                SenderKeyStore senderKeyStore);
-  public static native void GroupSessionBuilder_ProcessSenderKeyDistributionMessage(long senderKeyNameHandle,
-                                                                 long senderKeyDistributionMessageHandle,
-                                                                 SenderKeyStore senderKeyStore);
-
-  public static native byte[] GroupCipher_EncryptMessage(long senderKeyNameHandle, byte[] paddedPlaintext, SenderKeyStore senderKeyStore);
-  public static native byte[] GroupCipher_DecryptMessage(long senderKeyNameHandle, byte[] ciphertext, SenderKeyStore senderKeyStore);
-
-  public static native long SignalMessage_Deserialize(byte[] serialized);
-  public static native long SignalMessage_New(int messageVersion,
-                                              byte[] macKey,
-                                              long senderRatchetKeyHandle,
-                                              int counter,
-                                              int previousCounter,
-                                              byte[] ciphertext,
-                                              long senderIdentityKeyHandle,
-                                              long receiverIdentityKeyHandle);
-  public static native void SignalMessage_Destroy(long handle);
-  public static native byte[] SignalMessage_GetSenderRatchetKey(long handle);
-  public static native int SignalMessage_GetMessageVersion(long handle);
-  public static native int SignalMessage_GetCounter(long handle);
-  public static native byte[] SignalMessage_GetBody(long handle);
-  public static native byte[] SignalMessage_GetSerialized(long handle);
-  public static native boolean SignalMessage_VerifyMac(long messageHandle, long senderIdentityKeyHandle, long receiverIdentityKeyHandle, byte[] macKey);
-
-  public static native long PreKeySignalMessage_Deserialize(byte[] serialized);
-  public static native long PreKeySignalMessage_New(int messageVersion,
-                                                    int registrationId,
-                                                    int preKeyId,
-                                                    int signedPreKeyId,
-                                                    long baseKeyHandle,
-                                                    long identityKeyHandle,
-                                                    long signalMessageHandle);
-
+  public static native long PreKeySignalMessage_Deserialize(byte[] data);
   public static native void PreKeySignalMessage_Destroy(long handle);
-  public static native int PreKeySignalMessage_GetVersion(long handle);
-  public static native int PreKeySignalMessage_GetRegistrationId(long handle);
-  public static native int PreKeySignalMessage_GetPreKeyId(long handle);
-  public static native int PreKeySignalMessage_GetSignedPreKeyId(long handle);
   public static native byte[] PreKeySignalMessage_GetBaseKey(long handle);
   public static native byte[] PreKeySignalMessage_GetIdentityKey(long handle);
-  public static native byte[] PreKeySignalMessage_GetSignalMessage(long handle);
+  public static native int PreKeySignalMessage_GetPreKeyId(long handle);
+  public static native int PreKeySignalMessage_GetRegistrationId(long handle);
   public static native byte[] PreKeySignalMessage_GetSerialized(long handle);
+  public static native byte[] PreKeySignalMessage_GetSignalMessage(long handle);
+  public static native int PreKeySignalMessage_GetSignedPreKeyId(long handle);
+  public static native int PreKeySignalMessage_GetVersion(long handle);
+  public static native long PreKeySignalMessage_New(int messageVersion, int registrationId, int preKeyId, int signedPreKeyId, long baseKeyHandle, long identityKeyHandle, long signalMessageHandle);
 
-  public static native long SenderKeyName_New(String groupid, String senderName, int senderDeviceId);
-  public static native void SenderKeyName_Destroy(long handle);
-  public static native String SenderKeyName_GetSenderName(long handle);
-  public static native int SenderKeyName_GetSenderDeviceId(long handle);
-  public static native String SenderKeyName_GetGroupId(long handle);
+  public static native void ProtocolAddress_Destroy(long handle);
+  public static native int ProtocolAddress_DeviceId(long handle);
+  public static native String ProtocolAddress_Name(long handle);
+  public static native long ProtocolAddress_New(String name, int deviceId);
 
-  public static native long SenderKeyRecord_New();
-  public static native long SenderKeyRecord_Deserialize(byte[] serialized);
-  public static native void SenderKeyRecord_Destroy(long handle);
-  public static native byte[] SenderKeyRecord_GetSerialized(long handle);
-
-  public static native long SenderKeyMessage_Deserialize(byte[] serialized);
-  public static native long SenderKeyMessage_New(int keyId, int iteration, byte[] ciphertext, long pkHandle);
-  public static native void SenderKeyMessage_Destroy(long handle);
-  public static native int SenderKeyMessage_GetKeyId(long handle);
-  public static native int SenderKeyMessage_GetIteration(long handle);
-  public static native byte[] SenderKeyMessage_GetCipherText(long handle);
-  public static native byte[] SenderKeyMessage_GetSerialized(long handle);
-  public static native boolean SenderKeyMessage_VerifySignature(long handle, long pkHandle);
+  public static native boolean ScannableFingerprint_Compare(byte[] fprint1, byte[] fprint2);
 
   public static native long SenderKeyDistributionMessage_Deserialize(byte[] data);
-  public static native long SenderKeyDistributionMessage_New(int id, int iteration, byte[] chainkey, long pkHandle);
-  public static native long SenderKeyDistributionMessage_Destroy(long handle);
-  public static native int SenderKeyDistributionMessage_GetIteration(long handle);
-  public static native int SenderKeyDistributionMessage_GetId(long handle);
+  public static native void SenderKeyDistributionMessage_Destroy(long handle);
   public static native byte[] SenderKeyDistributionMessage_GetChainKey(long handle);
-  public static native byte[] SenderKeyDistributionMessage_GetSignatureKey(long handle);
+  public static native int SenderKeyDistributionMessage_GetId(long handle);
+  public static native int SenderKeyDistributionMessage_GetIteration(long handle);
   public static native byte[] SenderKeyDistributionMessage_GetSerialized(long handle);
+  public static native byte[] SenderKeyDistributionMessage_GetSignatureKey(long handle);
+  public static native long SenderKeyDistributionMessage_New(int keyId, int iteration, byte[] chainkey, long pkHandle);
+
+  public static native long SenderKeyMessage_Deserialize(byte[] data);
+  public static native void SenderKeyMessage_Destroy(long handle);
+  public static native byte[] SenderKeyMessage_GetCipherText(long handle);
+  public static native int SenderKeyMessage_GetIteration(long handle);
+  public static native int SenderKeyMessage_GetKeyId(long handle);
+  public static native byte[] SenderKeyMessage_GetSerialized(long handle);
+  public static native long SenderKeyMessage_New(int keyId, int iteration, byte[] ciphertext, long pkHandle);
+  public static native boolean SenderKeyMessage_VerifySignature(long handle, long pubkeyHandle);
+
+  public static native void SenderKeyName_Destroy(long handle);
+  public static native String SenderKeyName_GetGroupId(long handle);
+  public static native int SenderKeyName_GetSenderDeviceId(long handle);
+  public static native String SenderKeyName_GetSenderName(long handle);
+  public static native long SenderKeyName_New(String groupId, String senderName, int senderDeviceId);
+
+  public static native long SenderKeyRecord_Deserialize(byte[] data);
+  public static native void SenderKeyRecord_Destroy(long handle);
+  public static native byte[] SenderKeyRecord_GetSerialized(long handle);
+  public static native long SenderKeyRecord_New();
+
+  public static native void SessionBuilder_ProcessPreKeyBundle(long bundle, long protocolAddress, SessionStore sessionStore, IdentityKeyStore identityKeyStore);
+
+  public static native byte[] SessionCipher_DecryptPreKeySignalMessage(long message, long protocolAddress, SessionStore sessionStore, IdentityKeyStore identityKeyStore, PreKeyStore prekeyStore, SignedPreKeyStore signedPrekeyStore);
+  public static native byte[] SessionCipher_DecryptSignalMessage(long message, long protocolAddress, SessionStore sessionStore, IdentityKeyStore identityKeyStore);
+  public static native CiphertextMessage SessionCipher_EncryptMessage(byte[] message, long protocolAddress, SessionStore sessionStore, IdentityKeyStore identityKeyStore);
+
+  public static native byte[] SessionState_InitializeAliceSession(long identityKeyPrivate, long identityKeyPublic, long basePrivate, long basePublic, long theirIdentityKey, long theirSignedPrekey, long theirRatchetKey);
+  public static native byte[] SessionState_InitializeBobSession(long identityKeyPrivate, long identityKeyPublic, long signedPrekeyPrivate, long signedPrekeyPublic, long ephPrivate, long ephPublic, long theirIdentityKey, long theirBaseKey);
+
+  public static native long SignalMessage_Deserialize(byte[] data);
+  public static native void SignalMessage_Destroy(long handle);
+  public static native byte[] SignalMessage_GetBody(long handle);
+  public static native int SignalMessage_GetCounter(long handle);
+  public static native int SignalMessage_GetMessageVersion(long handle);
+  public static native byte[] SignalMessage_GetSenderRatchetKey(long handle);
+  public static native byte[] SignalMessage_GetSerialized(long handle);
+  public static native long SignalMessage_New(int messageVersion, byte[] macKey, long senderRatchetKey, int counter, int previousCounter, byte[] ciphertext, long senderIdentityKey, long receiverIdentityKey);
+  public static native boolean SignalMessage_VerifyMac(long handle, long senderIdentityKey, long receiverIdentityKey, byte[] macKey);
+
+  public static native long SignedPreKeyRecord_Deserialize(byte[] data);
+  public static native void SignedPreKeyRecord_Destroy(long handle);
+  public static native int SignedPreKeyRecord_GetId(long handle);
+  public static native long SignedPreKeyRecord_GetPrivateKey(long handle);
+  public static native long SignedPreKeyRecord_GetPublicKey(long handle);
+  public static native byte[] SignedPreKeyRecord_GetSerialized(long handle);
+  public static native byte[] SignedPreKeyRecord_GetSignature(long handle);
+  public static native long SignedPreKeyRecord_GetTimestamp(long handle);
+  public static native long SignedPreKeyRecord_New(int id, long timestamp, long pubKeyHandle, long privKeyHandle, byte[] signature);
 }

--- a/rust/bridge/jni/bin/Native.java.in
+++ b/rust/bridge/jni/bin/Native.java.in
@@ -1,0 +1,70 @@
+//
+// Copyright (C) 2020 Signal Messenger, LLC.
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+// WARNING: this file was automatically generated
+
+package org.signal.client.internal;
+
+import org.whispersystems.libsignal.protocol.CiphertextMessage;
+import org.whispersystems.libsignal.state.IdentityKeyStore;
+import org.whispersystems.libsignal.state.SessionStore;
+import org.whispersystems.libsignal.state.PreKeyStore;
+import org.whispersystems.libsignal.state.SignedPreKeyStore;
+import org.whispersystems.libsignal.groups.state.SenderKeyStore;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+
+public final class Native {
+  private static void copyToTempFileAndLoad(InputStream in, String extension) throws IOException {
+    File tempFile = Files.createTempFile("resource", extension).toFile();
+    tempFile.deleteOnExit();
+
+    try (OutputStream out = new FileOutputStream(tempFile)) {
+      byte[] buffer = new byte[4096];
+      int read;
+
+      while ((read = in.read(buffer)) != -1) {
+        out.write(buffer, 0, read);
+      }
+    }
+    System.load(tempFile.getAbsolutePath());
+  }
+
+  /*
+  If a .so and/or .dylib is embedded within this jar as a resource file, attempt
+  to copy it to a temporary file and then load it. This allows the jar to be
+  used even without a libsignal_jni shared library existing on the filesystem.
+  */
+  private static void loadLibrary() {
+    try {
+      String  osName    = System.getProperty("os.name").toLowerCase(java.util.Locale.ROOT);
+      boolean isMacOs   = osName.startsWith("mac os");
+      String  extension = isMacOs ? ".dylib" : ".so";
+
+      try (InputStream in = Native.class.getResourceAsStream("/libsignal_jni" + extension)) {
+        if (in != null) {
+          copyToTempFileAndLoad(in, extension);
+        } else {
+          System.loadLibrary("signal_jni");
+        }
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  static {
+    loadLibrary();
+  }
+
+  private Native() {}
+
+  // INSERT DECLS HERE
+}

--- a/rust/bridge/jni/bin/gen_java_decl.py
+++ b/rust/bridge/jni/bin/gen_java_decl.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2020 Signal Messenger, LLC.
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+
+import os
+import subprocess
+import re
+import sys
+
+our_abs_dir = os.path.dirname(os.path.realpath(__file__))
+
+cbindgen = subprocess.Popen(['cbindgen'], cwd=os.path.join(our_abs_dir, '..'), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+(stdout, stderr) = cbindgen.communicate()
+
+stdout = str(stdout.decode('utf8'))
+stderr = str(stderr.decode('utf8'))
+
+ignore_this_warning = re.compile("WARN: Can't find .*\. This usually means that this type was incompatible or not found\.")
+
+unknown_warning = False
+
+for l in stderr.split('\n'):
+    if l == "":
+        continue
+
+    if ignore_this_warning.match(l):
+        continue
+
+    print(l)
+    unknown_warning = True
+
+if unknown_warning:
+    sys.exit(1)
+
+java_decl = re.compile('([a-zA-Z]+) Java_org_signal_client_internal_Native_([A-Z][a-zA-Z]+)_1([A-Za-z0-9]+)\(JNIEnv .?env, JClass class_(, .*)?\);')
+
+def translate_to_java(typ):
+    # jobject is not given here; instead use a type
+    type_map = {
+        "void": "void",
+        "jstring": "String",
+        "JString": "String",
+        "jbyteArray": "byte[]",
+        "ObjectHandle": "long",
+        "jint": "int",
+        "jlong": "long",
+        "jboolean": "boolean",
+    }
+
+    if typ in type_map:
+        return type_map[typ]
+
+    # Assume anything prefixed with Java refers to an object
+    if typ.startswith('Java'):
+        return typ[4:]
+
+    raise Exception("Don't know what to do with a", typ)
+
+cur_type = None
+decls = []
+
+for line in stdout.split('\n'):
+    if line == '':
+        continue
+
+    match = java_decl.match(line)
+    if match is None:
+        raise Exception("Could not understand", line)
+
+    (ret_type, this_type, method_name, args) = match.groups()
+
+    # Add newlines between groups of functions for readability
+    if cur_type is None or this_type != cur_type:
+        decls.append("")
+        cur_type = this_type
+
+    java_fn_name = '%s_%s' % (this_type, method_name)
+    java_ret_type = translate_to_java(ret_type)
+    java_args = []
+
+    if args != None:
+        for arg in args.split(', ')[1:]:
+            (arg_type,arg_name) = arg.split(' ')
+            java_arg_type = translate_to_java(arg_type)
+            java_args.append('%s %s' % (java_arg_type, arg_name))
+
+    decls.append("  public static native %s %s(%s);" % (java_ret_type, java_fn_name, ", ".join(java_args)))
+
+template_file = open(os.path.join(our_abs_dir, 'Native.java.in')).read()
+
+contents = template_file.replace('\n  // INSERT DECLS HERE', "\n".join(decls))
+
+native_java = os.path.join(our_abs_dir, '../../../../java/java/src/main/java/org/signal/internal/Native.java')
+
+if not os.access(native_java, os.F_OK):
+    raise Exception("Didn't find Native.java where it was expected")
+
+fh = open(native_java, 'w')
+fh.write(contents)
+fh.close()
+

--- a/rust/bridge/jni/cbindgen.toml
+++ b/rust/bridge/jni/cbindgen.toml
@@ -1,0 +1,18 @@
+#
+# Copyright (C) 2020 Signal Messenger, LLC.
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+
+language = "C"
+no_includes = true
+
+[export]
+item_types = ["functions"]
+
+[fn]
+args = "horizontal"
+sort_by = "Name"
+rename_args = "camelCase"
+
+[parse.expand]
+crates = ["libsignal-jni"]

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -18,8 +18,15 @@ mod util;
 
 use crate::util::*;
 
+type JavaSessionStore = jobject;
+type JavaIdentityKeyStore = jobject;
+type JavaPreKeyStore = jobject;
+type JavaSignedPreKeyStore = jobject;
+type JavaCiphertextMessage = jobject;
+type JavaSenderKeyStore = jobject;
+
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_ProtocolAddress_1New(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ProtocolAddress_1New(
     env: JNIEnv,
     _class: JClass,
     name: JString,
@@ -42,7 +49,7 @@ jni_fn_get_jint!(Java_org_signal_client_internal_Native_ProtocolAddress_1DeviceI
                  |obj: &ProtocolAddress| { Ok(obj.device_id()) });
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_ECPublicKey_1Deserialize(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ECPublicKey_1Deserialize(
     env: JNIEnv,
     _class: JClass,
     data: jbyteArray,
@@ -57,7 +64,7 @@ pub unsafe extern "system" fn Java_org_signal_client_internal_Native_ECPublicKey
 }
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_ECPublicKey_1Compare(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ECPublicKey_1Compare(
     env: JNIEnv,
     _class: JClass,
     key1: ObjectHandle,
@@ -82,7 +89,7 @@ jni_fn_get_jbytearray!(Java_org_signal_client_internal_Native_ECPublicKey_1GetPu
                        PublicKey::public_key_bytes);
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_ECPublicKey_1Verify(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ECPublicKey_1Verify(
     env: JNIEnv,
     _class: JClass,
     handle: ObjectHandle,
@@ -105,7 +112,7 @@ jni_fn_get_jbytearray!(Java_org_signal_client_internal_Native_ECPrivateKey_1Seri
                        |k: &PrivateKey| Ok(k.serialize()));
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_ECPrivateKey_1Generate(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ECPrivateKey_1Generate(
     env: JNIEnv,
     _class: JClass,
 ) -> ObjectHandle {
@@ -120,7 +127,7 @@ jni_fn_get_new_boxed_obj!(Java_org_signal_client_internal_Native_ECPrivateKey_1G
                           |k: &PrivateKey| k.public_key());
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_ECPrivateKey_1Sign(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ECPrivateKey_1Sign(
     env: JNIEnv,
     _class: JClass,
     handle: ObjectHandle,
@@ -136,7 +143,7 @@ pub unsafe extern "system" fn Java_org_signal_client_internal_Native_ECPrivateKe
 }
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_ECPrivateKey_1Agree(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ECPrivateKey_1Agree(
     env: JNIEnv,
     _class: JClass,
     private_key_handle: ObjectHandle,
@@ -153,7 +160,7 @@ pub unsafe extern "system" fn Java_org_signal_client_internal_Native_ECPrivateKe
 jni_fn_destroy!(Java_org_signal_client_internal_Native_ECPrivateKey_1Destroy destroys PrivateKey);
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_IdentityKeyPair_1Serialize(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_IdentityKeyPair_1Serialize(
     env: JNIEnv,
     _class: JClass,
     public_key_handle: ObjectHandle,
@@ -169,7 +176,7 @@ pub unsafe extern "system" fn Java_org_signal_client_internal_Native_IdentityKey
 }
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_DisplayableFingerprint_1Format(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_DisplayableFingerprint_1Format(
     env: JNIEnv,
     _class: JClass,
     local: jbyteArray,
@@ -185,7 +192,7 @@ pub unsafe extern "system" fn Java_org_signal_client_internal_Native_Displayable
 }
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_NumericFingerprintGenerator_1New(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_NumericFingerprintGenerator_1New(
     env: JNIEnv,
     _class: JClass,
     iterations: jint,
@@ -229,7 +236,7 @@ jni_fn_get_jbytearray!(Java_org_signal_client_internal_Native_NumericFingerprint
                        |f: &Fingerprint| f.scannable.serialize());
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_ScannableFingerprint_1Compare(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ScannableFingerprint_1Compare(
     env: JNIEnv,
     _class: JClass,
     fprint1: jbyteArray,
@@ -245,7 +252,7 @@ pub unsafe extern "system" fn Java_org_signal_client_internal_Native_ScannableFi
 }
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_HKDF_1DeriveSecrets(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_HKDF_1DeriveSecrets(
     env: JNIEnv,
     _class: JClass,
     version: jint,
@@ -286,7 +293,7 @@ pub unsafe extern "system" fn Java_org_signal_client_internal_Native_HKDF_1Deriv
 jni_fn_deserialize!(Java_org_signal_client_internal_Native_SignalMessage_1Deserialize is SignalMessage::try_from);
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_SignalMessage_1New(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SignalMessage_1New(
     env: JNIEnv,
     _class: JClass,
     message_version: jint,
@@ -341,7 +348,7 @@ jni_fn_get_jint!(Java_org_signal_client_internal_Native_SignalMessage_1GetCounte
                  |msg: &SignalMessage| { Ok(msg.counter()) });
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_SignalMessage_1VerifyMac(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SignalMessage_1VerifyMac(
     env: JNIEnv,
     _class: JClass,
     handle: ObjectHandle,
@@ -368,7 +375,7 @@ pub unsafe extern "system" fn Java_org_signal_client_internal_Native_SignalMessa
 jni_fn_deserialize!(Java_org_signal_client_internal_Native_PreKeySignalMessage_1Deserialize is PreKeySignalMessage::try_from);
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_PreKeySignalMessage_1New(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_PreKeySignalMessage_1New(
     env: JNIEnv,
     _class: JClass,
     message_version: jint,
@@ -415,7 +422,7 @@ jni_fn_get_jint!(Java_org_signal_client_internal_Native_PreKeySignalMessage_1Get
 
 // Special logic to handle optionality:
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_PreKeySignalMessage_1GetPreKeyId(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_PreKeySignalMessage_1GetPreKeyId(
     env: JNIEnv,
     _class: JClass,
     handle: ObjectHandle,
@@ -447,7 +454,7 @@ jni_fn_get_jbytearray!(Java_org_signal_client_internal_Native_PreKeySignalMessag
 jni_fn_deserialize!(Java_org_signal_client_internal_Native_SenderKeyMessage_1Deserialize is SenderKeyMessage::try_from);
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_SenderKeyMessage_1New(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SenderKeyMessage_1New(
     env: JNIEnv,
     _class: JClass,
     key_id: jint,
@@ -483,7 +490,7 @@ jni_fn_get_jbytearray!(Java_org_signal_client_internal_Native_SenderKeyMessage_1
                        |m: &SenderKeyMessage| Ok(m.serialized().to_vec()));
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_SenderKeyMessage_1VerifySignature(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SenderKeyMessage_1VerifySignature(
     env: JNIEnv,
     _class: JClass,
     handle: ObjectHandle,
@@ -498,7 +505,7 @@ pub unsafe extern "system" fn Java_org_signal_client_internal_Native_SenderKeyMe
 }
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_SenderKeyDistributionMessage_1New(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SenderKeyDistributionMessage_1New(
     env: JNIEnv,
     _class: JClass,
     key_id: jint,
@@ -534,7 +541,7 @@ jni_fn_get_jbytearray!(Java_org_signal_client_internal_Native_SenderKeyDistribut
                        |m: &SenderKeyDistributionMessage| Ok(m.serialized().to_vec()));
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_PreKeyBundle_1New(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_PreKeyBundle_1New(
     env: JNIEnv,
     _class: JClass,
     registration_id: jint,
@@ -591,7 +598,7 @@ jni_fn_get_jint!(Java_org_signal_client_internal_Native_PreKeyBundle_1GetSignedP
 
 // Special logic for optional here:
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_PreKeyBundle_1GetPreKeyId(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_PreKeyBundle_1GetPreKeyId(
     env: JNIEnv,
     _class: JClass,
     handle: ObjectHandle,
@@ -620,7 +627,7 @@ jni_fn_get_jbytearray!(Java_org_signal_client_internal_Native_PreKeyBundle_1GetS
 /* SignedPreKeyRecord */
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_SignedPreKeyRecord_1New(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SignedPreKeyRecord_1New(
     env: JNIEnv,
     _class: JClass,
     id: jint,
@@ -649,7 +656,7 @@ jni_fn_get_jint!(Java_org_signal_client_internal_Native_SignedPreKeyRecord_1GetI
                  |m: &SignedPreKeyRecord| m.id());
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_SignedPreKeyRecord_1GetTimestamp(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SignedPreKeyRecord_1GetTimestamp(
     env: JNIEnv,
     _class: JClass,
     handle: ObjectHandle,
@@ -677,7 +684,7 @@ jni_fn_destroy!(Java_org_signal_client_internal_Native_SignedPreKeyRecord_1Destr
 /* PreKeyRecord */
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_PreKeyRecord_1New(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_PreKeyRecord_1New(
     env: JNIEnv,
     _class: JClass,
     id: jint,
@@ -715,7 +722,7 @@ jni_fn_destroy!(Java_org_signal_client_internal_Native_PreKeyRecord_1Destroy des
 /* SenderKeyName */
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_SenderKeyName_1New(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SenderKeyName_1New(
     env: JNIEnv,
     _class: JClass,
     group_id: JString,
@@ -743,7 +750,7 @@ jni_fn_get_jint!(Java_org_signal_client_internal_Native_SenderKeyName_1GetSender
                  |m: &SenderKeyName| Ok(m.sender()?.device_id()));
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_SenderKeyRecord_1New(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SenderKeyRecord_1New(
     env: JNIEnv,
     _class: JClass,
 ) -> ObjectHandle {
@@ -1239,13 +1246,13 @@ impl<'a> SessionStore for JniSessionStore<'a> {
 }
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_SessionBuilder_1ProcessPreKeyBundle(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SessionBuilder_1ProcessPreKeyBundle(
     env: JNIEnv,
     _class: JClass,
     bundle: ObjectHandle,
     protocol_address: ObjectHandle,
-    session_store: jobject,
-    identity_key_store: jobject,
+    session_store: JavaSessionStore,
+    identity_key_store: JavaIdentityKeyStore,
 ) {
     run_ffi_safe(&env, || {
         let bundle = native_handle_cast::<PreKeyBundle>(bundle)?;
@@ -1269,14 +1276,14 @@ pub unsafe extern "system" fn Java_org_signal_client_internal_Native_SessionBuil
 }
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_SessionCipher_1EncryptMessage(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SessionCipher_1EncryptMessage(
     env: JNIEnv,
     _class: JClass,
     message: jbyteArray,
     protocol_address: ObjectHandle,
-    session_store: jobject,
-    identity_key_store: jobject,
-) -> jobject {
+    session_store: JavaSessionStore,
+    identity_key_store: JavaIdentityKeyStore,
+) -> JavaCiphertextMessage {
     run_ffi_safe(&env, || {
         let message = env.convert_byte_array(message)?;
         let protocol_address = native_handle_cast::<ProtocolAddress>(protocol_address)?;
@@ -1313,13 +1320,13 @@ pub unsafe extern "system" fn Java_org_signal_client_internal_Native_SessionCiph
 }
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_SessionCipher_1DecryptSignalMessage(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SessionCipher_1DecryptSignalMessage(
     env: JNIEnv,
     _class: JClass,
     message: ObjectHandle,
     protocol_address: ObjectHandle,
-    session_store: jobject,
-    identity_key_store: jobject,
+    session_store: JavaSessionStore,
+    identity_key_store: JavaIdentityKeyStore,
 ) -> jbyteArray {
     run_ffi_safe(&env, || {
         let message = native_handle_cast::<SignalMessage>(message)?;
@@ -1343,15 +1350,15 @@ pub unsafe extern "system" fn Java_org_signal_client_internal_Native_SessionCiph
 }
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_SessionCipher_1DecryptPreKeySignalMessage(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SessionCipher_1DecryptPreKeySignalMessage(
     env: JNIEnv,
     _class: JClass,
     message: ObjectHandle,
     protocol_address: ObjectHandle,
-    session_store: jobject,
-    identity_key_store: jobject,
-    prekey_store: jobject,
-    signed_prekey_store: jobject,
+    session_store: JavaSessionStore,
+    identity_key_store: JavaIdentityKeyStore,
+    prekey_store: JavaPreKeyStore,
+    signed_prekey_store: JavaSignedPreKeyStore,
 ) -> jbyteArray {
     run_ffi_safe(&env, || {
         let message = native_handle_cast::<PreKeySignalMessage>(message)?;
@@ -1463,11 +1470,11 @@ impl<'a> SenderKeyStore for JniSenderKeyStore<'a> {
 }
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_GroupSessionBuilder_1CreateSenderKeyDistributionMessage(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_GroupSessionBuilder_1CreateSenderKeyDistributionMessage(
     env: JNIEnv,
     _class: JClass,
     sender_key_name: ObjectHandle,
-    store: jobject,
+    store: JavaSenderKeyStore,
 ) -> ObjectHandle {
     run_ffi_safe(&env, || {
         let sender_key_name = native_handle_cast::<SenderKeyName>(sender_key_name)?;
@@ -1485,12 +1492,12 @@ pub unsafe extern "system" fn Java_org_signal_client_internal_Native_GroupSessio
 }
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_GroupSessionBuilder_1ProcessSenderKeyDistributionMessage(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_GroupSessionBuilder_1ProcessSenderKeyDistributionMessage(
     env: JNIEnv,
     _class: JClass,
     sender_key_name: ObjectHandle,
     sender_key_distribution_message: ObjectHandle,
-    store: jobject,
+    store: JavaSenderKeyStore,
 ) {
     run_ffi_safe(&env, || {
         let sender_key_name = native_handle_cast::<SenderKeyName>(sender_key_name)?;
@@ -1509,12 +1516,12 @@ pub unsafe extern "system" fn Java_org_signal_client_internal_Native_GroupSessio
 }
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_GroupCipher_1EncryptMessage(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_GroupCipher_1EncryptMessage(
     env: JNIEnv,
     _class: JClass,
     sender_key_name: ObjectHandle,
     message: jbyteArray,
-    store: jobject,
+    store: JavaSenderKeyStore,
 ) -> jbyteArray {
     run_ffi_safe(&env, || {
         let sender_key_name = native_handle_cast::<SenderKeyName>(sender_key_name)?;
@@ -1536,12 +1543,12 @@ pub unsafe extern "system" fn Java_org_signal_client_internal_Native_GroupCipher
 }
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_GroupCipher_1DecryptMessage(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_GroupCipher_1DecryptMessage(
     env: JNIEnv,
     _class: JClass,
     sender_key_name: ObjectHandle,
     message: jbyteArray,
-    store: jobject,
+    store: JavaSenderKeyStore,
 ) -> jbyteArray {
     run_ffi_safe(&env, || {
         let sender_key_name = native_handle_cast::<SenderKeyName>(sender_key_name)?;
@@ -1562,7 +1569,7 @@ pub unsafe extern "system" fn Java_org_signal_client_internal_Native_GroupCipher
 // The following are just exposed to make it possible to retain some of the Java tests:
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_SessionState_1InitializeAliceSession(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SessionState_1InitializeAliceSession(
     env: JNIEnv,
     _class: JClass,
     identity_key_private: ObjectHandle,
@@ -1609,7 +1616,7 @@ pub unsafe extern "system" fn Java_org_signal_client_internal_Native_SessionStat
 }
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_signal_client_internal_Native_SessionState_1InitializeBobSession(
+pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SessionState_1InitializeBobSession(
     env: JNIEnv,
     _class: JClass,
     identity_key_private: ObjectHandle,

--- a/rust/bridge/jni/src/util.rs
+++ b/rust/bridge/jni/src/util.rs
@@ -478,7 +478,7 @@ pub fn jobject_from_native_handle<'a>(
 macro_rules! jni_fn_deserialize {
     ( $nm:ident is $func:path ) => {
         #[no_mangle]
-        pub unsafe extern "system" fn $nm(
+        pub unsafe extern "C" fn $nm(
             env: JNIEnv,
             _class: JClass,
             data: jbyteArray,
@@ -495,7 +495,7 @@ macro_rules! jni_fn_deserialize {
 macro_rules! jni_fn_get_new_boxed_obj {
     ( $nm:ident($rt:ty) from $typ:ty, $body:expr ) => {
         #[no_mangle]
-        pub unsafe extern "system" fn $nm(
+        pub unsafe extern "C" fn $nm(
             env: JNIEnv,
             _class: JClass,
             handle: ObjectHandle,
@@ -512,7 +512,7 @@ macro_rules! jni_fn_get_new_boxed_obj {
 macro_rules! jni_fn_get_new_boxed_optional_obj {
     ( $nm:ident($rt:ty) from $typ:ty, $body:expr ) => {
         #[no_mangle]
-        pub unsafe extern "system" fn $nm(
+        pub unsafe extern "C" fn $nm(
             env: JNIEnv,
             _class: JClass,
             handle: ObjectHandle,
@@ -534,11 +534,7 @@ macro_rules! jni_fn_get_new_boxed_optional_obj {
 macro_rules! jni_fn_get_jint {
     ( $nm:ident($typ:ty) using $body:expr ) => {
         #[no_mangle]
-        pub unsafe extern "system" fn $nm(
-            env: JNIEnv,
-            _class: JClass,
-            handle: ObjectHandle,
-        ) -> jint {
+        pub unsafe extern "C" fn $nm(env: JNIEnv, _class: JClass, handle: ObjectHandle) -> jint {
             run_ffi_safe(&env, || {
                 let obj = native_handle_cast::<$typ>(handle)?;
                 jint_from_u32($body(obj))
@@ -551,7 +547,7 @@ macro_rules! jni_fn_get_jint {
 macro_rules! jni_fn_get_jboolean {
     ( $nm:ident($typ:ty) using $body:expr ) => {
         #[no_mangle]
-        pub unsafe extern "system" fn $nm(
+        pub unsafe extern "C" fn $nm(
             env: JNIEnv,
             _class: JClass,
             handle: ObjectHandle,
@@ -573,11 +569,7 @@ if the provided lambda just returns Ok(something)
 macro_rules! jni_fn_get_jstring {
     ( $nm:ident($typ:ty) using $body:expr ) => {
         #[no_mangle]
-        pub unsafe extern "system" fn $nm(
-            env: JNIEnv,
-            _class: JClass,
-            handle: ObjectHandle,
-        ) -> jstring {
+        pub unsafe extern "C" fn $nm(env: JNIEnv, _class: JClass, handle: ObjectHandle) -> jstring {
             fn inner_get(t: &$typ) -> Result<String, SignalProtocolError> {
                 $body(&t)
             }
@@ -593,7 +585,7 @@ macro_rules! jni_fn_get_jstring {
 macro_rules! jni_fn_get_jbytearray {
     ( $nm:ident($typ:ty) using $body:expr ) => {
         #[no_mangle]
-        pub unsafe extern "system" fn $nm(
+        pub unsafe extern "C" fn $nm(
             env: JNIEnv,
             _class: JClass,
             handle: ObjectHandle,
@@ -610,7 +602,7 @@ macro_rules! jni_fn_get_jbytearray {
 macro_rules! jni_fn_destroy {
     ( $nm:ident destroys $typ:ty ) => {
         #[no_mangle]
-        pub unsafe extern "system" fn $nm(_env: JNIEnv, _class: JClass, handle: ObjectHandle) {
+        pub unsafe extern "C" fn $nm(_env: JNIEnv, _class: JClass, handle: ObjectHandle) {
             if handle != 0 {
                 let _boxed_value = Box::from_raw(handle as *mut $typ);
             }


### PR DESCRIPTION
Working on the sealed sender code made me realize how obnoxious it is to keep Native.java vs JNI lib.rs in sync.

This is ugly, but it works.

The changes in bridge/jni just change ABI from "system" to "C" as cbindgen doesn't recognize "system" fns for whatever reason. The ABIs should be the same for our purposes.