### PR TITLE
Rust: don't build any bridge/* crates by default

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,10 +28,10 @@ jobs:
         echo $DUPS
         test -z "$DUPS"
     - name: Rustfmt check
-      run: cargo fmt -- --check
+      run: cargo fmt --all -- --check
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --all --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --all --verbose
     - name: Clippy
-      run: cargo clippy
+      run: cargo clippy --all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,9 @@ members = [
     "rust/protocol",
     "rust/bridge/ffi",
     "rust/bridge/jni",
-    "rust/bridge/node"
+    "rust/bridge/node",
+]
+default-members = [
+    "rust/aes-gcm-siv",
+    "rust/protocol",
 ]


### PR DESCRIPTION
Some of them have external requirements that may not be installed.