### PR TITLE
Fix some Swift lint warnings

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -33,7 +33,7 @@ jobs:
       working-directory: swift
 
     - name: Run lint
-      run: swiftlint lint --reporter github-actions-logging
+      run: swiftlint lint --strict --reporter github-actions-logging
       working-directory: swift
 
     - name: Generate coverage report

--- a/swift/Tests/SignalClientTests/PublicAPITests.swift
+++ b/swift/Tests/SignalClientTests/PublicAPITests.swift
@@ -64,12 +64,12 @@ class PublicAPITests: XCTestCase {
 
         let pk = try! sk.publicKey()
         let pk_bytes = try! pk.serialize()
-        XCTAssertEqual(pk_bytes[0], 0x05); // DJB
-        XCTAssertEqual(pk_bytes.count, 33);
+        XCTAssertEqual(pk_bytes[0], 0x05) // DJB
+        XCTAssertEqual(pk_bytes.count, 33)
 
-        let pk_raw = try! pk.keyBytes();
-        XCTAssertEqual(pk_raw.count, 32);
-        XCTAssertEqual(pk_raw[0...31], pk_bytes[1...32]);
+        let pk_raw = try! pk.keyBytes()
+        XCTAssertEqual(pk_raw.count, 32)
+        XCTAssertEqual(pk_raw[0...31], pk_bytes[1...32])
 
         let sk_reloaded = try! PrivateKey(sk_bytes)
         let pk_reloaded = try! sk_reloaded.publicKey()


### PR DESCRIPTION
Can we configure the Swift linter to fail on all warnings?