### PR TITLE
Have each language ignore changes to other workflow scripts

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -3,10 +3,10 @@ name: Java
 on:
   push:
     branches: [ master ]
-    paths-ignore: ['swift/**', '*.podspec', 'node/**', 'rust/bridge/ffi/**', 'rust/bridge/node/**', 'package.json', 'yarn.lock']
+    paths-ignore: ['swift/**', '*.podspec', 'node/**', 'rust/bridge/ffi/**', 'rust/bridge/node/**', 'package.json', 'yarn.lock', '.github/workflows/swift.yml', '.github/workflows/node.yml']
   pull_request:
     branches: [ master ]
-    paths-ignore: ['swift/**', '*.podspec', 'node/**', 'rust/bridge/ffi/**', 'rust/bridge/node/**', 'package.json', 'yarn.lock']
+    paths-ignore: ['swift/**', '*.podspec', 'node/**', 'rust/bridge/ffi/**', 'rust/bridge/node/**', 'package.json', 'yarn.lock', '.github/workflows/swift.yml', '.github/workflows/node.yml']
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -3,10 +3,10 @@ name: Node
 on:
   push:
     branches: [ master ]
-    paths-ignore: ['swift/**', '*.podspec', 'java/**', 'rust/bridge/jni/**', 'rust/bridge/ffi/**']
+    paths-ignore: ['swift/**', '*.podspec', 'java/**', 'rust/bridge/jni/**', 'rust/bridge/ffi/**', '.github/workflows/java.yml', '.github/workflows/swift.yml']
   pull_request:
     branches: [ master ]
-    paths-ignore: ['swift/**', '*.podspec', 'java/**', 'rust/bridge/jni/**', 'rust/bridge/ffi/**']
+    paths-ignore: ['swift/**', '*.podspec', 'java/**', 'rust/bridge/jni/**', 'rust/bridge/ffi/**', '.github/workflows/java.yml', '.github/workflows/swift.yml']
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -3,10 +3,10 @@ name: Swift
 on:
   push:
     branches: [ master ]
-    paths-ignore: ['java/**', 'node/**', 'rust/bridge/jni/**', 'rust/bridge/node/**', 'package.json', 'yarn.lock']
+    paths-ignore: ['java/**', 'node/**', 'rust/bridge/jni/**', 'rust/bridge/node/**', 'package.json', 'yarn.lock', '.github/workflows/java.yml', '.github/workflows/node.yml']
   pull_request:
     branches: [ master ]
-    paths-ignore: ['java/**', 'node/**', 'rust/bridge/jni/**', 'rust/bridge/node/**', 'package.json', 'yarn.lock']
+    paths-ignore: ['java/**', 'node/**', 'rust/bridge/jni/**', 'rust/bridge/node/**', 'package.json', 'yarn.lock', '.github/workflows/java.yml', '.github/workflows/node.yml']
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
I noticed in #55 when I added `--strict` to the options in `swift.yml` it triggered builds of Node and Java when it didn't need to.

I am not loving the combinatorial explosion going on here but don't know of a good way to get around at. At least we are fairly unlikely to add many more supported languages.