### PR TITLE
build_helpers.sh: fix error message if Rust isn't installed

### DIFF
--- a/bin/build_helpers.sh
+++ b/bin/build_helpers.sh
@@ -6,16 +6,18 @@
 # shellcheck shell=bash
 
 check_rust() {
-  if ! which rustup > /dev/null; then
+  if ! which rustup > /dev/null && [[ -n "$SHELL" ]]; then
     # Try to find rustup using the user's default shell.
     # This will be important when running from inside Xcode,
-    # which does not run in an existing shell context.
-    RUSTUP_PATH=$("$SHELL" -c 'which rustup')
-    PATH=$(dirname "$RUSTUP_PATH"):$PATH
+    # which does not run in a login shell context.
+    RUSTUP_PATH=$("$SHELL" -c 'which rustup' || true)
+    if [[ "$RUSTUP_PATH" == /* || "$RUSTUP_PATH" == '~'/* ]]; then
+      PATH=$(dirname "$RUSTUP_PATH"):$PATH
+    fi
   fi
 
   if ! which rustup > /dev/null; then
-    echo 'error: rustup not found; get it from https://rustup.rs/' >&2
+    echo 'error: rustup not found; install Rust from https://rustup.rs/' >&2
     exit 1
   fi
 
@@ -23,7 +25,7 @@ check_rust() {
     echo "error: Rust target ${CARGO_BUILD_TARGET} not installed" >&2
     echo 'note: get it by running' >&2
     printf "\n\t%s\n\n" "rustup +${RUSTUP_TOOLCHAIN:-$(cat ./rust-toolchain)} target add ${CARGO_BUILD_TARGET}" >&2
-    exit 2
+    exit 1
   fi
 }
 


### PR DESCRIPTION
Fixes #63 and its mystifying errors.