### PR TITLE
Swift: expose SessionRecord.archiveCurrentState()

### DIFF
--- a/rust/bridge/ffi/src/lib.rs
+++ b/rust/bridge/ffi/src/lib.rs
@@ -271,6 +271,17 @@ ffi_fn_get_bytearray!(signal_session_record_serialize(SessionRecord) using
 ffi_fn_get_uint32!(signal_session_record_get_remote_registration_id(SessionRecord) using
                    |s: &SessionRecord| s.session_state()?.remote_registration_id());
 
+#[no_mangle]
+pub unsafe extern "C" fn signal_session_record_archive_current_state(
+    session_record: *mut SessionRecord,
+) -> *mut SignalFfiError {
+    run_ffi_safe(|| {
+        let session_record = native_handle_cast_mut::<SessionRecord>(session_record)?;
+        session_record.archive_current_state()?;
+        Ok(())
+    })
+}
+
 ffi_fn_destroy!(signal_session_record_destroy destroys SessionRecord);
 
 ffi_fn_clone!(signal_session_record_clone clones SessionRecord);

--- a/rust/bridge/ffi/src/util.rs
+++ b/rust/bridge/ffi/src/util.rs
@@ -291,6 +291,14 @@ pub unsafe fn native_handle_cast<T>(handle: *const T) -> Result<&'static T, Sign
     Ok(&*(handle))
 }
 
+pub unsafe fn native_handle_cast_mut<T>(handle: *mut T) -> Result<&'static mut T, SignalFfiError> {
+    if handle.is_null() {
+        return Err(SignalFfiError::NullPointer);
+    }
+
+    Ok(&mut *handle)
+}
+
 pub unsafe fn get_optional_uint32(p: *const c_uint) -> Option<u32> {
     if p.is_null() {
         return None;

--- a/swift/Sources/SignalClient/state/SessionRecord.swift
+++ b/swift/Sources/SignalClient/state/SessionRecord.swift
@@ -39,4 +39,8 @@ public class SessionRecord: ClonableHandleOwner {
             signal_session_record_get_remote_registration_id(nativeHandle, $0)
         }
     }
+
+    public func archiveCurrentState() throws {
+        return try checkError(signal_session_record_archive_current_state(nativeHandle))
+    }
 }


### PR DESCRIPTION
This is necessary for the "reset session" user-level operation. I believe it's also our first mutating operation!