### PR TITLE
Change rustup fallback search to just look in ~/.cargo

### DIFF
--- a/bin/build_helpers.sh
+++ b/bin/build_helpers.sh
@@ -6,18 +6,16 @@
 # shellcheck shell=bash
 
 check_rust() {
-  if ! which rustup > /dev/null && [[ -n "$SHELL" ]]; then
-    # Try to find rustup using the user's default shell.
+  if ! which rustup > /dev/null && [[ -d ~/.cargo/bin ]]; then
+    # Try to find rustup in its default per-user install location.
     # This will be important when running from inside Xcode,
     # which does not run in a login shell context.
-    RUSTUP_PATH=$("$SHELL" -c 'which rustup' || true)
-    if [[ "$RUSTUP_PATH" == /* || "$RUSTUP_PATH" == '~'/* ]]; then
-      PATH=$(dirname "$RUSTUP_PATH"):$PATH
-    fi
+    PATH=~/.cargo/bin:$PATH
   fi
 
   if ! which rustup > /dev/null; then
-    echo 'error: rustup not found; install Rust from https://rustup.rs/' >&2
+    echo 'error: rustup not found in PATH' >&2
+    echo 'note: Rust can be installed from https://rustup.rs/' >&2
     exit 1
   fi
 


### PR DESCRIPTION
This is the default per-user install location. Trying using the user's default shell isn't good enough without it being a login shell.

Should resolve the *actual* issue people were having in #63, rather than just the poor UX.