### PR TITLE
Docker: small improvements

### DIFF
--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -70,6 +70,8 @@ RUN    rustup target add armv7-linux-androideabi aarch64-linux-android i686-linu
     && cargo install --version ${CARGO_NDK_VERSION} cargo-ndk
 
 # Pre-download Gradle.
+ENV GRADLE_OPTS=-Dorg.gradle.daemon=false
+
 COPY   java/gradle gradle
 COPY   java/gradlew gradlew
 RUN    ./gradlew --version

--- a/java/Makefile
+++ b/java/Makefile
@@ -18,12 +18,12 @@ java_build: DOCKER_EXTRA=$(shell [ -L build ] && P=$$(readlink build) && echo -v
 java_build: docker_image
 	$(DOCKER) run --rm --user $$(id -u):$$(id -g) \
 	  -v `cd .. && pwd`/:/home/libsignal/src $(DOCKER_EXTRA) $(DOCKER_IMAGE) \
-		sh -c "cp rust-toolchain src/; cd src/java; ./gradlew build"
+		sh -c "cd src/java; ./gradlew build"
 
 java_test: java_build
 	$(DOCKER) run --rm --user $$(id -u):$$(id -g) \
 	  -v `cd .. && pwd`/:/home/libsignal/src $(DOCKER_EXTRA) $(DOCKER_IMAGE) \
-		sh -c "cp rust-toolchain src/; cd src/java; ./gradlew test"
+		sh -c "cd src/java; ./gradlew test"
 
 SONATYPE_USERNAME     ?=
 SONATYPE_PASSWORD     ?=
@@ -44,7 +44,7 @@ publish_java: docker_image
 		-v `cd .. && pwd`/:/home/libsignal/src $(DOCKER_EXTRA) \
 		-v $(KEYRING_VOLUME):/home/libsignal/keyring \
 		$(DOCKER_IMAGE) \
-		sh -c "cp rust-toolchain src; cd src/java; ./gradlew uploadArchives \
+		sh -c "cd src/java; ./gradlew uploadArchives \
 			-PwhisperSonatypeUsername='$(SONATYPE_USERNAME)' \
 			-PwhisperSonatypePassword='$(SONATYPE_PASSWORD)' \
 			-Psigning.secretKeyRingFile='/home/libsignal/keyring/$(KEYRING_FILE_ROOT)' \


### PR DESCRIPTION
- Remove unnecessary extra copy of rust-toolchain
- Skip Gradle's daemon when building in Docker