### PR TITLE
replace "Rust" with "Rustup" in build_helper's tips

### DIFF
--- a/bin/build_helpers.sh
+++ b/bin/build_helpers.sh
@@ -15,7 +15,7 @@ check_rust() {
 
   if ! which rustup > /dev/null; then
     echo 'error: rustup not found in PATH' >&2
-    echo 'note: Rust can be installed from https://rustup.rs/' >&2
+    echo 'note: Rustup can be installed from https://rustup.rs/' >&2
     exit 1
   fi
 


### PR DESCRIPTION
I was confused when `swift/build_ffi.sh -d` failed with

```
error: rustup not found in PATH
note: Rust can be installed from https://rustup.rs/
```

... because I do have Rust installed, and the note to me read like `rustup.rs` would install rust itself. (I mean, the tool _does_, but that's not what it says :))

I'm not experienced with using Rust, so if anyone can add a hint why we rely on rustup rather than on e.g. the locally installed rust version, I'd happily add that to the printed note.