### PR TITLE
JNI: fix exception checks

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -1,5 +1,5 @@
 subprojects {
-    ext.version_number     = "0.1.3"
+    ext.version_number     = "0.1.4"
     ext.group_info         = "org.whispersystems"
 
     if (JavaVersion.current().isJava8Compatible()) {

--- a/java/tests/src/test/java/org/whispersystems/libsignal/SessionBuilderTest.java
+++ b/java/tests/src/test/java/org/whispersystems/libsignal/SessionBuilderTest.java
@@ -257,6 +257,47 @@ public class SessionBuilderTest extends TestCase {
     assertTrue(!bobStore.containsPreKey(31337));
   }
 
+  public void testBadSignedPreKeyStore() throws InvalidKeyException, UntrustedIdentityException, InvalidVersionException, InvalidMessageException, DuplicateMessageException, LegacyMessageException {
+    SignalProtocolStore aliceStore = new TestNoSignedPreKeysStore();
+    SessionBuilder aliceSessionBuilder = new SessionBuilder(aliceStore, BOB_ADDRESS);
+
+    SignalProtocolStore bobStore = new TestNoSignedPreKeysStore();
+
+    ECKeyPair bobPreKeyPair            = Curve.generateKeyPair();
+    ECKeyPair bobSignedPreKeyPair      = Curve.generateKeyPair();
+    byte[]    bobSignedPreKeySignature = Curve.calculateSignature(bobStore.getIdentityKeyPair().getPrivateKey(),
+                                                                  bobSignedPreKeyPair.getPublicKey().serialize());
+
+    PreKeyBundle bobPreKey = new PreKeyBundle(bobStore.getLocalRegistrationId(), 1,
+                                              31337, bobPreKeyPair.getPublicKey(),
+                                              22, bobSignedPreKeyPair.getPublicKey(), bobSignedPreKeySignature,
+                                              bobStore.getIdentityKeyPair().getPublicKey());
+
+    bobStore.storePreKey(31337, new PreKeyRecord(bobPreKey.getPreKeyId(), bobPreKeyPair));
+    bobStore.storeSignedPreKey(22, new SignedPreKeyRecord(22, System.currentTimeMillis(), bobSignedPreKeyPair, bobSignedPreKeySignature));
+
+    aliceSessionBuilder.process(bobPreKey);
+
+    String            originalMessage    = "Good, fast, cheap: pick two";
+    SessionCipher     aliceSessionCipher = new SessionCipher(aliceStore, BOB_ADDRESS);
+    CiphertextMessage outgoingMessageOne = aliceSessionCipher.encrypt(originalMessage.getBytes());
+
+    assertTrue(outgoingMessageOne.getType() == CiphertextMessage.PREKEY_TYPE);
+
+    PreKeySignalMessage incomingMessage  = new PreKeySignalMessage(outgoingMessageOne.serialize());
+    SessionCipher        bobSessionCipher = new SessionCipher(bobStore, ALICE_ADDRESS);
+
+    byte[] plaintext = null;
+
+    try {
+      plaintext = bobSessionCipher.decrypt(incomingMessage);
+      throw new AssertionError("Decrypt should have failed!");
+    } catch (InvalidKeyIdException e) {
+      // Note: This is the message coming from libsignal-client, NOT from TestNoSignedPreKeysStore.
+      assertEquals("invalid signed prekey identifier", e.getMessage());
+    }
+  }
+
   public void testOptionalOneTimePreKey() throws Exception {
     SignalProtocolStore aliceStore          = new TestInMemorySignalProtocolStore();
     SessionBuilder aliceSessionBuilder = new SessionBuilder(aliceStore, BOB_ADDRESS);

--- a/java/tests/src/test/java/org/whispersystems/libsignal/TestNoSignedPreKeysStore.java
+++ b/java/tests/src/test/java/org/whispersystems/libsignal/TestNoSignedPreKeysStore.java
@@ -1,0 +1,11 @@
+package org.whispersystems.libsignal;
+
+import org.whispersystems.libsignal.InvalidKeyIdException;
+import org.whispersystems.libsignal.state.SignedPreKeyRecord;
+
+public class TestNoSignedPreKeysStore extends TestInMemorySignalProtocolStore {
+  @Override
+  public SignedPreKeyRecord loadSignedPreKey(int signedPreKeyId) throws InvalidKeyIdException {
+    throw new InvalidKeyIdException("TestNoSignedPreKeysStore rejected loading " + signedPreKeyId);
+  }
+}

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -840,11 +840,13 @@ impl<'a> JniIdentityKeyStore<'a> {
     fn do_get_local_registration_id(&self) -> Result<u32, SignalJniError> {
         let callback_sig = "()I";
 
-        let rvalue =
-            self.env
-                .call_method(self.store, "getLocalRegistrationId", callback_sig, &[])?;
-        exception_check(self.env, "getLocalRegistrationId")?;
-
+        let rvalue = call_method_checked(
+            self.env,
+            self.store,
+            "getLocalRegistrationId",
+            callback_sig,
+            &[],
+        )?;
         match rvalue {
             JValue::Int(i) => jint_to_u32(i),
             _ => Err(SignalJniError::UnexpectedJniResultType(
@@ -867,10 +869,13 @@ impl<'a> JniIdentityKeyStore<'a> {
         )?;
         let callback_sig = "(Lorg/whispersystems/libsignal/SignalProtocolAddress;Lorg/whispersystems/libsignal/IdentityKey;)Z";
         let callback_args = [address_jobject.into(), key_jobject.into()];
-        let result =
-            self.env
-                .call_method(self.store, "saveIdentity", callback_sig, &callback_args)?;
-        exception_check(self.env, "saveIdentity")?;
+        let result = call_method_checked(
+            self.env,
+            self.store,
+            "saveIdentity",
+            callback_sig,
+            &callback_args,
+        )?;
 
         match result {
             JValue::Bool(b) => Ok(b != 0),
@@ -910,13 +915,13 @@ impl<'a> JniIdentityKeyStore<'a> {
 
         let callback_sig = "(Lorg/whispersystems/libsignal/SignalProtocolAddress;Lorg/whispersystems/libsignal/IdentityKey;Lorg/whispersystems/libsignal/state/IdentityKeyStore$Direction;)Z";
         let callback_args = [address_jobject.into(), key_jobject.into(), field_value];
-        let result = self.env.call_method(
+        let result = call_method_checked(
+            self.env,
             self.store,
             "isTrustedIdentity",
             callback_sig,
             &callback_args,
         )?;
-        exception_check(self.env, "isTrustedIdentity")?;
 
         match result {
             JValue::Bool(b) => Ok(b != 0),
@@ -1039,18 +1044,26 @@ impl<'a> JniPreKeyStore<'a> {
             JValue::from(jint_from_u32(Ok(prekey_id))?),
             jobject_record.into(),
         ];
-        self.env
-            .call_method(self.store, "storePreKey", callback_sig, &callback_args)?;
-        exception_check(self.env, "storePreKey")?;
+        call_method_checked(
+            self.env,
+            self.store,
+            "storePreKey",
+            callback_sig,
+            &callback_args,
+        )?;
         Ok(())
     }
 
     fn do_remove_pre_key(&mut self, prekey_id: u32) -> Result<(), SignalJniError> {
         let callback_sig = "(I)V";
         let callback_args = [JValue::from(jint_from_u32(Ok(prekey_id))?)];
-        self.env
-            .call_method(self.store, "removePreKey", callback_sig, &callback_args)?;
-        exception_check(self.env, "removePreKey")?;
+        call_method_checked(
+            self.env,
+            self.store,
+            "removePreKey",
+            callback_sig,
+            &callback_args,
+        )?;
         Ok(())
     }
 }
@@ -1133,13 +1146,13 @@ impl<'a> JniSignedPreKeyStore<'a> {
             JValue::from(jint_from_u32(Ok(prekey_id))?),
             jobject_record.into(),
         ];
-        self.env.call_method(
+        call_method_checked(
+            self.env,
             self.store,
             "storeSignedPreKey",
             callback_sig,
             &callback_args,
         )?;
-        exception_check(self.env, "storeSignedPreKey")?;
         Ok(())
     }
 }
@@ -1217,9 +1230,13 @@ impl<'a> JniSessionStore<'a> {
 
         let callback_sig = "(Lorg/whispersystems/libsignal/SignalProtocolAddress;Lorg/whispersystems/libsignal/state/SessionRecord;)V";
         let callback_args = [address_jobject.into(), session_jobject.into()];
-        self.env
-            .call_method(self.store, "storeSession", callback_sig, &callback_args)?;
-        exception_check(self.env, "storeSession")?;
+        call_method_checked(
+            self.env,
+            self.store,
+            "storeSession",
+            callback_sig,
+            &callback_args,
+        )?;
         Ok(())
     }
 }
@@ -1417,13 +1434,13 @@ impl<'a> JniSenderKeyStore<'a> {
             sender_key_record_jobject.into(),
         ];
         let callback_sig = "(Lorg/whispersystems/libsignal/groups/SenderKeyName;Lorg/whispersystems/libsignal/groups/state/SenderKeyRecord;)V";
-        self.env.call_method(
+        call_method_checked(
+            self.env,
             self.store,
             "storeSenderKey",
             callback_sig,
             &callback_args[..],
         )?;
-        exception_check(self.env, "storeSenderKey")?;
 
         Ok(())
     }

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -1022,6 +1022,7 @@ impl<'a> JniPreKeyStore<'a> {
             &callback_args,
             callback_sig,
             "loadPreKey",
+            Some("org/whispersystems/libsignal/InvalidKeyIdException"),
         )?;
         match pk {
             Some(pk) => Ok(pk),
@@ -1122,6 +1123,7 @@ impl<'a> JniSignedPreKeyStore<'a> {
             &callback_args,
             callback_sig,
             "loadSignedPreKey",
+            Some("org/whispersystems/libsignal/InvalidKeyIdException"),
         )?;
         match spk {
             Some(spk) => Ok(spk),
@@ -1459,6 +1461,7 @@ impl<'a> JniSenderKeyStore<'a> {
             &callback_args,
             callback_sig,
             "loadSenderKey",
+            None,
         )?;
 
         Ok(skr)

--- a/rust/bridge/jni/src/util.rs
+++ b/rust/bridge/jni/src/util.rs
@@ -315,7 +315,17 @@ pub fn jlong_from_u64(value: Result<u64, SignalProtocolError>) -> Result<jlong, 
     }
 }
 
-pub fn exception_check(env: &JNIEnv, fn_name: &'static str) -> Result<(), SignalJniError> {
+pub fn call_method_checked<'a>(
+    env: &JNIEnv<'a>,
+    obj: impl Into<JObject<'a>>,
+    fn_name: &'static str,
+    sig: &'static str,
+    args: &[JValue<'_>],
+) -> Result<JValue<'a>, SignalJniError> {
+    // Note that we are *not* unwrapping the result yet!
+    // We need to check for exceptions *first*.
+    let result = env.call_method(obj, fn_name, sig, args);
+
     fn exception_class_name(env: &JNIEnv, exn: JThrowable) -> Result<String, SignalJniError> {
         let class_type = env.call_method(exn, "getClass", "()Ljava/lang/Class;", &[])?;
         if let JValue::Object(class_type) = class_type {
@@ -367,7 +377,7 @@ pub fn exception_check(env: &JNIEnv, fn_name: &'static str) -> Result<(), Signal
         ));
     }
 
-    Ok(())
+    Ok(result?)
 }
 
 pub fn check_jobject_type(
@@ -395,8 +405,7 @@ pub fn get_object_with_native_handle<T: 'static + Clone>(
     callback_sig: &'static str,
     callback_fn: &'static str,
 ) -> Result<Option<T>, SignalJniError> {
-    let rvalue = env.call_method(store_obj, callback_fn, callback_sig, &callback_args)?;
-    exception_check(env, callback_fn)?;
+    let rvalue = call_method_checked(env, store_obj, callback_fn, callback_sig, &callback_args)?;
 
     let obj = match rvalue {
         JValue::Object(o) => *o,
@@ -412,8 +421,7 @@ pub fn get_object_with_native_handle<T: 'static + Clone>(
         return Ok(None);
     }
 
-    let handle = env.call_method(obj, "nativeHandle", "()J", &[])?;
-    exception_check(env, "nativeHandle")?;
+    let handle = call_method_checked(env, obj, "nativeHandle", "()J", &[])?;
     match handle {
         JValue::Long(handle) => {
             if handle == 0 {
@@ -436,8 +444,7 @@ pub fn get_object_with_serialization(
     callback_sig: &'static str,
     callback_fn: &'static str,
 ) -> Result<Option<Vec<u8>>, SignalJniError> {
-    let rvalue = env.call_method(store_obj, callback_fn, callback_sig, &callback_args)?;
-    exception_check(env, callback_fn)?;
+    let rvalue = call_method_checked(env, store_obj, callback_fn, callback_sig, &callback_args)?;
 
     let obj = match rvalue {
         JValue::Object(o) => *o,
@@ -453,8 +460,7 @@ pub fn get_object_with_serialization(
         return Ok(None);
     }
 
-    let bytes = env.call_method(obj, "serialize", "()[B", &[])?;
-    exception_check(env, "serialize")?;
+    let bytes = call_method_checked(env, obj, "serialize", "()[B", &[])?;
 
     match bytes {
         JValue::Object(o) => Ok(Some(env.convert_byte_array(*o)?)),

--- a/rust/bridge/jni/src/util.rs
+++ b/rust/bridge/jni/src/util.rs
@@ -363,6 +363,8 @@ pub fn call_method_with_exception_as_null<'a>(
         let getmessage_sig = "()Ljava/lang/String;";
 
         let exn_type = exception_class_name(env, throwable).ok();
+        // Clear again in case we got an exception looking up the class name.
+        env.exception_clear()?;
 
         if let Ok(jmessage) = env.call_method(throwable, "getMessage", getmessage_sig, &[]) {
             if let JValue::Object(o) = jmessage {
@@ -374,6 +376,8 @@ pub fn call_method_with_exception_as_null<'a>(
                 ));
             }
         }
+        // Clear *again* in case we got an exception reading the message.
+        env.exception_clear()?;
 
         return Err(SignalJniError::Signal(
             SignalProtocolError::ApplicationCallbackThrewException(


### PR DESCRIPTION
One of the error states for `JNIEnv::call_method` is "threw an exception", so if we want to handle exceptions we have to do it before propagating the JNI error. On top of that, PreKeyStore and SignedPreKeyStore use exceptions to indicate the load of a pre-key that doesn't exist, so we need to handle that explicitly rather than treating it as a generic failure.