### PR TITLE
Swift: connect Rust's 'log' to SignalCoreKit's OWSLogger

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -223,6 +223,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Check out SignalCoreKit
+        uses: actions/checkout@v2
+        with:
+          repository: signalapp/SignalCoreKit
+          path: SignalCoreKit
+
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -231,5 +237,7 @@ jobs:
 
       - name: Run pod lint
         # No import validation because it tries to build unsupported platforms (like 32-bit iOS).
-        run: pod lib lint --verbose --platforms=ios --skip-import-validation
+        run: pod lib lint --verbose --platforms=ios --include-podspecs=SignalCoreKit/SignalCoreKit.podspec --skip-import-validation
+        env:
+          XCODE_XCCONFIG_FILE: swift/PodLibLint.xcconfig
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,6 +710,7 @@ dependencies = [
  "futures",
  "libc",
  "libsignal-protocol-rust",
+ "log",
  "rand",
  "static_assertions",
 ]

--- a/SignalClient.podspec
+++ b/SignalClient.podspec
@@ -14,10 +14,11 @@ Pod::Spec.new do |s|
   s.source           = { :git => 'https://github.com/signalapp/libsignal-client.git', :tag => "v#{s.version}" }
 
   s.swift_version    = '5'
-  s.ios.deployment_target  = '8'
-  s.osx.deployment_target  = '10.9'
+  s.platform = :ios, '10'
 
-  s.source_files = 'swift/Sources/**/*.swift'
+  s.dependency 'SignalCoreKit'
+
+  s.source_files = ['swift/Sources/**/*.swift', 'swift/Sources/**/*.m']
   s.preserve_paths = [
     'bin/*',
     'Cargo.toml',
@@ -33,6 +34,7 @@ Pod::Spec.new do |s|
       'CARGO_PROFILE_RELEASE_DEBUG' => '1', # enable line tables
       'LIBSIGNAL_FFI_DIR' => '$(CARGO_BUILD_TARGET_DIR)/$(CARGO_BUILD_TARGET)/release',
 
+      'HEADER_SEARCH_PATHS' => '$(LIBSIGNAL_FFI_DIR)',
       'SWIFT_INCLUDE_PATHS' => '$(PODS_TARGET_SRCROOT)/swift/Sources/SignalFfi $(LIBSIGNAL_FFI_DIR)',
 
       # Make sure we link the static library, not a dynamic one.

--- a/rust/bridge/ffi/Cargo.toml
+++ b/rust/bridge/ffi/Cargo.toml
@@ -22,6 +22,7 @@ libc = "0.2"
 futures = "0.3.7"
 rand = "0.7.3"
 static_assertions = "1.1"
+log = "0.4.11"
 
 [build-dependencies]
 cbindgen = "0.14"

--- a/rust/bridge/ffi/src/lib.rs
+++ b/rust/bridge/ffi/src/lib.rs
@@ -15,6 +15,7 @@ use std::ffi::{c_void, CString};
 
 use aes_gcm_siv::Aes256GcmSiv;
 
+pub mod logging;
 mod util;
 
 use crate::util::*;

--- a/rust/bridge/ffi/src/logging.rs
+++ b/rust/bridge/ffi/src/logging.rs
@@ -1,0 +1,105 @@
+//
+// Copyright 2020 Signal Messenger, LLC.
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+use libc::c_char;
+use std::ffi::CString;
+
+#[repr(C)]
+pub enum LogLevel {
+    Error = 1,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl From<log::Level> for LogLevel {
+    fn from(level: log::Level) -> Self {
+        use log::Level::*;
+        match level {
+            Error => Self::Error,
+            Warn => Self::Warn,
+            Info => Self::Info,
+            Debug => Self::Debug,
+            Trace => Self::Trace,
+        }
+    }
+}
+
+impl From<LogLevel> for log::Level {
+    fn from(level: LogLevel) -> Self {
+        use LogLevel::*;
+        match level {
+            Error => Self::Error,
+            Warn => Self::Warn,
+            Info => Self::Info,
+            Debug => Self::Debug,
+            Trace => Self::Trace,
+        }
+    }
+}
+
+pub type LogCallback = extern "C" fn(
+    target: *const c_char,
+    level: LogLevel,
+    file: *const c_char,
+    line: u32,
+    message: *const c_char,
+);
+
+pub type LogEnabledCallback = extern "C" fn(target: *const c_char, level: LogLevel) -> bool;
+
+pub type LogFlushCallback = extern "C" fn();
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct FfiLogger {
+    enabled: LogEnabledCallback,
+    log: LogCallback,
+    flush: LogFlushCallback,
+}
+
+impl log::Log for FfiLogger {
+    fn enabled(&self, metadata: &log::Metadata) -> bool {
+        let target = CString::new(metadata.target()).expect("no 0 bytes in log target");
+        (self.enabled)(target.as_ptr(), metadata.level().into())
+    }
+
+    fn log(&self, record: &log::Record) {
+        let target = CString::new(record.target()).expect("no 0 bytes in log target");
+        let file = record
+            .file()
+            .map(|file| CString::new(file).expect("no 0 bytes in file"));
+        let message = CString::new(record.args().to_string()).unwrap_or_else(|_| {
+            CString::new(record.args().to_string().replace("\0", "\\0")).unwrap()
+        });
+        (self.log)(
+            target.as_ptr(),
+            record.level().into(),
+            file.as_ref()
+                .map(|file| file.as_ptr())
+                .unwrap_or(std::ptr::null()),
+            record.line().unwrap_or(0),
+            message.as_ptr(),
+        );
+    }
+
+    fn flush(&self) {
+        (self.flush)()
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn signal_init_logger(max_level: LogLevel, logger: FfiLogger) {
+    match log::set_logger(Box::leak(Box::new(logger))) {
+        Ok(_) => {
+            log::set_max_level(log::Level::from(max_level).to_level_filter());
+            log::debug!("logging initialized for libsignal-client");
+        }
+        Err(_) => {
+            log::warn!("logging already initialized for libsignal-client; ignoring later call");
+        }
+    }
+}

--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -23,6 +23,7 @@ let package = Package(
         .target(
             name: "SignalClient",
             dependencies: ["SignalFfi"],
+            exclude: ["Logging.m"],
             swiftSettings: [.unsafeFlags(["-I", rustBuildDir])]
         ),
         .testTarget(

--- a/swift/PodLibLint.xcconfig
+++ b/swift/PodLibLint.xcconfig
@@ -1,0 +1,7 @@
+// Disable arm64 simulator builds for `pod lib lint`.
+// Not only does SignalClient not support it yet,
+// but neither do some of its indirect dependencies.
+//
+// This *ought* to be limited to [sdk=iphonesimulator*],
+// but xcodebuild doesn't support that for XCODE_XCCONFIG_FILE.
+EXCLUDED_ARCHS = arm64

--- a/swift/README.md
+++ b/swift/README.md
@@ -15,7 +15,17 @@ This is a binding to the Signal client code in rust/, implemented on top of the 
 
 ## Development as a CocoaPod
 
-Instead of a git-based dependency, use a path-based dependency to treat SignalClient as a development pod.
+Instead of a git-based dependency, use a path-based dependency to treat SignalClient as a development pod. If validating SignalClient locally, use the following invocation:
+
+    XCODE_XCCONFIG_FILE=swift/PodLibLint.xcconfig pod lib lint \
+      --platforms=ios \
+      --include-podspecs=../SignalCoreKit/SignalCoreKit.podspec \
+      --skip-import-validation \
+      --verbose
+
+You will also need to have [SignalCoreKit][] checked out; the above command assumes you have checked it out as a sibling directory to libsignal-client.
+
+[SignalCoreKit]: https://github.com/signalapp/SignalCoreKit
 
 
 # Development as a Swift Package

--- a/swift/Sources/SignalClient/Logging.m
+++ b/swift/Sources/SignalClient/Logging.m
@@ -1,0 +1,76 @@
+//
+// Copyright 2020 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+#import "signal_ffi.h"
+#import <SignalCoreKit/OWSLogs.h>
+
+static bool isEnabled(const char *_Nonnull target, SignalLogLevel level)
+{
+    switch (level) {
+        case SignalLogLevel_Error:
+            return ShouldLogError();
+        case SignalLogLevel_Warn:
+            return ShouldLogWarning();
+        case SignalLogLevel_Info:
+            return ShouldLogInfo();
+        case SignalLogLevel_Debug:
+            return ShouldLogDebug();
+        case SignalLogLevel_Trace:
+            return ShouldLogVerbose();
+        default:
+            return ShouldLogError();
+    }
+}
+
+static void logMessage(const char *_Nonnull target,
+    SignalLogLevel level,
+    const char *_Nullable file,
+    uint32_t line,
+    const char *_Nonnull message)
+{
+    if (!isEnabled(target, level)) {
+        return;
+    }
+
+    // We're not using OWSLog* directly because we don't want log() to be the source of the log.
+    NSString *formattedMessage;
+    if (file) {
+        formattedMessage = [NSString stringWithFormat:@"[%s:%u] %s", file, line, message];
+    } else {
+        formattedMessage = [NSString stringWithUTF8String:message];
+    }
+
+    switch (level) {
+        case SignalLogLevel_Error:
+            [OWSLogger error:formattedMessage];
+            break;
+        case SignalLogLevel_Warn:
+            [OWSLogger warn:formattedMessage];
+            break;
+        case SignalLogLevel_Info:
+            [OWSLogger info:formattedMessage];
+            break;
+        case SignalLogLevel_Debug:
+            [OWSLogger debug:formattedMessage];
+            break;
+        case SignalLogLevel_Trace:
+            [OWSLogger verbose:formattedMessage];
+            break;
+        default:
+            [OWSLogger error:formattedMessage];
+            break;
+    }
+}
+
+static void flush()
+{
+    OWSLogFlush();
+}
+
+__attribute__((constructor)) static void initLogging()
+{
+    SignalLogLevel logLevel = ShouldLogDebug() ? SignalLogLevel_Trace : SignalLogLevel_Info;
+    signal_init_logger(logLevel, (SignalFfiLogger) { .enabled = isEnabled, .log = logMessage, .flush = flush });
+}

--- a/swift/Tests/SignalClientTests/PublicAPITests.swift
+++ b/swift/Tests/SignalClientTests/PublicAPITests.swift
@@ -6,7 +6,7 @@
 import XCTest
 import SignalClient
 
-class PublicAPITests: XCTestCase {
+class PublicAPITests: TestCaseBase {
     func testHkdfSimple() {
         let ikm: [UInt8] = [
             0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,

--- a/swift/Tests/SignalClientTests/SessionTests.swift
+++ b/swift/Tests/SignalClientTests/SessionTests.swift
@@ -6,7 +6,7 @@
 import XCTest
 import SignalClient
 
-class SessionTests: XCTestCase {
+class SessionTests: TestCaseBase {
     fileprivate func initializeSessions(alice_store: InMemorySignalProtocolStore,
                                         bob_store: InMemorySignalProtocolStore,
                                         bob_address: ProtocolAddress) {

--- a/swift/Tests/SignalClientTests/TestCaseBase.swift
+++ b/swift/Tests/SignalClientTests/TestCaseBase.swift
@@ -1,0 +1,34 @@
+//
+// Copyright 2020 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import XCTest
+import SignalFfi
+
+#if canImport(SignalCoreKit)
+import SignalCoreKit
+#endif
+
+class TestCaseBase: XCTestCase {
+    // Use a static stored property for one-time initialization.
+    static let loggingInitialized: Bool = {
+#if canImport(SignalCoreKit)
+        DDLog.add(DDOSLogger.sharedInstance)
+#else
+        signal_init_logger(SignalLogLevel_Trace, .init(
+            enabled: { _, _ in true },
+            log: { _, level, file, line, message in
+                let file = file.map { String(cString: $0) } ?? "<unknown>"
+                NSLog("(%u) [%@:%u] %s", level.rawValue, file as NSString, line, message!)
+            },
+            flush: {}
+        ))
+#endif
+        return true
+    }()
+
+    override class func setUp() {
+        precondition(loggingInitialized)
+    }
+}


### PR DESCRIPTION
We're not actually logging anything yet, but this will let us do so. The logging is initialized using a static constructor so that clients of SignalCoreKit don't have to do any additional setup. This requires an ObjC file instead of a Swift one. (When running as a Swift package, logs will just go to stderr via NSLog.)