### PR TITLE
Tweak error message to account for Rust without rustup

### DIFF
--- a/bin/build_helpers.sh
+++ b/bin/build_helpers.sh
@@ -14,9 +14,15 @@ check_rust() {
   fi
 
   if ! which rustup > /dev/null; then
-    echo 'error: rustup not found in PATH' >&2
-    echo 'note: Rust can be installed from https://rustup.rs/' >&2
-    exit 1
+    if ! which cargo > /dev/null; then
+      echo 'error: cargo not found in PATH; do you have Rust installed?' >&2
+      echo 'note: we recommend installing Rust via rustup from https://rustup.rs/' >&2
+      exit 1
+    fi
+
+    echo 'warning: rustup not found in PATH; using cargo at' "$(which cargo)" >&2
+    echo 'note: this project uses Rust toolchain' "'$(cat ./rust-toolchain)'" >&2
+    return
   fi
 
   if [[ -n "${CARGO_BUILD_TARGET:-}" ]] && ! (rustup target list --installed | grep -q "${CARGO_BUILD_TARGET:-}"); then


### PR DESCRIPTION
Clarify the use of a specific Rust toolchain as discussed in #81.