### PR TITLE
Java: Generate debug symbols for the native Rust library

### DIFF
--- a/java/build_jni.sh
+++ b/java/build_jni.sh
@@ -10,6 +10,7 @@ ANDROID_LIB_DIR=java/android/src/main/jniLibs
 DESKTOP_LIB_DIR=java/java/src/main/resources
 
 export RUSTFLAGS="-C link-args=-s"
+export CARGO_PROFILE_RELEASE_DEBUG=1 # enable line tables
 
 cd .. || exit
 


### PR DESCRIPTION
This means this is on for Android and iOS, but still off for Desktop, because we don't have a stripping story for Electron yet. (It doesn't matter for secrecy but it does affect download size at least a bit.)