### PR TITLE
Get local and Android device tests working correctly

### DIFF
--- a/bin/build_helpers.sh
+++ b/bin/build_helpers.sh
@@ -33,6 +33,20 @@ check_rust() {
   fi
 }
 
+# usage: copy_built_library target/release signal_node out_dir/libsignal_node.node
+#        copy_built_library target/release signal_jni out_dir/
+copy_built_library() {
+  for possible_library_name in "lib$2.dylib" "lib$2.so" "$2.dll"; do
+    possible_library_path="$1/${possible_library_name}"
+    if [ -e "${possible_library_path}" ]; then
+      out_dir=$(dirname "$3"x) # trailing x to distinguish directories from files
+      echo_then_run mkdir -p "${out_dir}"
+      echo_then_run cp "${possible_library_path}" "$3"
+      break
+    fi
+  done
+}
+
 echo_then_run() {
   echo "$@"
   "$@"

--- a/java/android/build.gradle
+++ b/java/android/build.gradle
@@ -55,6 +55,7 @@ repositories {
 }
 
 dependencies {
+    androidTestImplementation 'junit:junit:3.8.2'
     api project(':java')
 }
 

--- a/java/build_jni.sh
+++ b/java/build_jni.sh
@@ -5,6 +5,12 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 #
 
+set -euo pipefail
+
+SCRIPT_DIR=$(dirname "$0")
+cd "${SCRIPT_DIR}"/..
+. bin/build_helpers.sh
+
 # These paths are relative to the root directory
 ANDROID_LIB_DIR=java/android/src/main/jniLibs
 DESKTOP_LIB_DIR=java/java/src/main/resources
@@ -12,17 +18,16 @@ DESKTOP_LIB_DIR=java/java/src/main/resources
 export RUSTFLAGS="-C link-args=-s"
 export CARGO_PROFILE_RELEASE_DEBUG=1 # enable line tables
 
-cd .. || exit
-
 if [ "$1" = 'desktop' ];
 then
-   cargo build -Z unstable-options -p libsignal-jni --release --target x86_64-unknown-linux-gnu --out-dir=$DESKTOP_LIB_DIR
+    echo_then_run cargo build -p libsignal-jni --release
+    copy_built_library target/release signal_jni $DESKTOP_LIB_DIR/
 elif [ "$1" = 'android' ];
 then
-    cargo ndk --target armv7-linux-androideabi --platform 19 -- build -Z unstable-options -p libsignal-jni --release --out-dir=$ANDROID_LIB_DIR/armeabi-v7a
-    cargo ndk --target aarch64-linux-android --platform 21 -- build -Z unstable-options -p libsignal-jni --release --out-dir=$ANDROID_LIB_DIR/arm64-v8a
-    cargo ndk --target i686-linux-android --platform 19 -- build -Z unstable-options -p libsignal-jni --release --out-dir=$ANDROID_LIB_DIR/x86
-    cargo ndk --target x86_64-linux-android --platform 21 -- build -Z unstable-options -p libsignal-jni --release --out-dir=$ANDROID_LIB_DIR/x86_64
+    echo_then_run cargo ndk --target armv7-linux-androideabi --platform 19 -- build -Z unstable-options -p libsignal-jni --release --out-dir=$ANDROID_LIB_DIR/armeabi-v7a
+    echo_then_run cargo ndk --target aarch64-linux-android --platform 21 -- build -Z unstable-options -p libsignal-jni --release --out-dir=$ANDROID_LIB_DIR/arm64-v8a
+    echo_then_run cargo ndk --target i686-linux-android --platform 19 -- build -Z unstable-options -p libsignal-jni --release --out-dir=$ANDROID_LIB_DIR/x86
+    echo_then_run cargo ndk --target x86_64-linux-android --platform 21 -- build -Z unstable-options -p libsignal-jni --release --out-dir=$ANDROID_LIB_DIR/x86_64
 else
     echo "Unknown target (use 'desktop' or 'android')"
 fi

--- a/node/build_node_bridge.sh
+++ b/node/build_node_bridge.sh
@@ -63,11 +63,4 @@ check_rust
 
 echo_then_run cargo build -p libsignal-node ${CARGO_PROFILE_ARG}
 
-for possible_library_name in libsignal_node.dylib libsignal_node.so signal_node.dll; do
-  possible_library_path="${CARGO_BUILD_TARGET_DIR:-target}/${CARGO_BUILD_TARGET:-}/${CARGO_PROFILE_DIR}/${possible_library_name}"
-  if [ -e "${possible_library_path}" ]; then
-    echo_then_run mkdir -p "${OUT_DIR}"
-    echo_then_run cp "${possible_library_path}" "${OUT_DIR}"/libsignal_client.node
-    break
-  fi
-done
+copy_built_library "${CARGO_BUILD_TARGET_DIR:-target}/${CARGO_BUILD_TARGET:-}/${CARGO_PROFILE_DIR}" signal_node "${OUT_DIR}"/libsignal_client.node


### PR DESCRIPTION
Thanks to @alan-signal for the first part, which allows running `gradlew android:connectedDebugAndroidTest` if you have an Android emulator running. I haven't added it to CI because (a) there doesn't seem to be a standard way to run an Android emulator on GitHub Actions*, and (b) Alan pointed out that as we get higher-level APIs, we'll probably start using Android OS features that will be mocked when run locally, and we wouldn't want to run a mocked system inside the emulator.

Still wanted: skip building the desktop library if you're building for Android. (You can skip Android via `env -u ANDROID_HOME`.)

\* I did look at [android-emulator](https://github.com/marketplace/actions/android-emulator) and [android-emulator-runner](https://github.com/marketplace/actions/android-emulator-runner) but the first is currently busted and the second is an odd environment (Android-on-Mac instead of Android-on-Linux).