### PR TITLE
Cleanup Java Session logic

### DIFF
--- a/java/java/src/main/java/org/signal/internal/Native.java
+++ b/java/java/src/main/java/org/signal/internal/Native.java
@@ -203,8 +203,28 @@ public final class Native {
   public static native byte[] SessionCipher_DecryptSignalMessage(long message, long protocolAddress, SessionStore sessionStore, IdentityKeyStore identityKeyStore);
   public static native CiphertextMessage SessionCipher_EncryptMessage(byte[] message, long protocolAddress, SessionStore sessionStore, IdentityKeyStore identityKeyStore);
 
+  public static native void SessionRecord_ArchiveCurrentState(long handle);
+  public static native long SessionRecord_Deserialize(byte[] data);
+  public static native void SessionRecord_Destroy(long handle);
+  public static native long SessionRecord_FromSessionState(long sessionState);
+  public static native long SessionRecord_GetSessionState(long sessionRecord);
+  public static native long SessionRecord_NewFresh();
+  public static native byte[] SessionRecord_Serialize(long handle);
+
+  public static native long SessionState_Deserialize(byte[] data);
+  public static native void SessionState_Destroy(long handle);
+  public static native byte[] SessionState_GetAliceBaseKey(long handle);
+  public static native byte[] SessionState_GetLocalIdentityKeyPublic(long handle);
+  public static native int SessionState_GetLocalRegistrationId(long handle);
+  public static native byte[] SessionState_GetReceiverChainKeyValue(long sessionRecord, long key);
+  public static native byte[] SessionState_GetRemoteIdentityKeyPublic(long handle);
+  public static native int SessionState_GetRemoteRegistrationId(long handle);
+  public static native byte[] SessionState_GetSenderChainKeyValue(long handle);
+  public static native int SessionState_GetSessionVersion(long handle);
+  public static native boolean SessionState_HasSenderChain(long handle);
   public static native byte[] SessionState_InitializeAliceSession(long identityKeyPrivate, long identityKeyPublic, long basePrivate, long basePublic, long theirIdentityKey, long theirSignedPrekey, long theirRatchetKey);
   public static native byte[] SessionState_InitializeBobSession(long identityKeyPrivate, long identityKeyPublic, long signedPrekeyPrivate, long signedPrekeyPublic, long ephPrivate, long ephPublic, long theirIdentityKey, long theirBaseKey);
+  public static native byte[] SessionState_Serialized(long handle);
 
   public static native long SignalMessage_Deserialize(byte[] data);
   public static native void SignalMessage_Destroy(long handle);

--- a/java/java/src/main/java/org/whispersystems/libsignal/SessionCipher.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/SessionCipher.java
@@ -133,7 +133,7 @@ public class SessionCipher {
   public int getRemoteRegistrationId() {
     synchronized (SESSION_LOCK) {
       SessionRecord record = sessionStore.loadSession(remoteAddress);
-      return record.getSessionState().getRemoteRegistrationId();
+      return record.getRemoteRegistrationId();
     }
   }
 
@@ -144,7 +144,7 @@ public class SessionCipher {
       }
 
       SessionRecord record = sessionStore.loadSession(remoteAddress);
-      return record.getSessionState().getSessionVersion();
+      return record.getSessionVersion();
     }
   }
 }

--- a/java/java/src/main/java/org/whispersystems/libsignal/state/SessionRecord.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/state/SessionRecord.java
@@ -54,4 +54,7 @@ public class SessionRecord {
     return Native.SessionRecord_Serialize(this.handle);
   }
 
+  long nativeHandle() {
+    return this.handle;
+  }
 }

--- a/java/java/src/main/java/org/whispersystems/libsignal/state/SessionRecord.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/state/SessionRecord.java
@@ -45,30 +45,8 @@ public class SessionRecord {
     }
   }
 
-  public boolean hasSessionState(int version, byte[] aliceBaseKey) {
-    if (sessionState.getSessionVersion() == version &&
-        Arrays.equals(aliceBaseKey, sessionState.getAliceBaseKey()))
-    {
-      return true;
-    }
-
-    for (SessionState state : previousStates) {
-      if (state.getSessionVersion() == version &&
-          Arrays.equals(aliceBaseKey, state.getAliceBaseKey()))
-      {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
   public SessionState getSessionState() {
     return sessionState;
-  }
-
-  public boolean isFresh() {
-    return fresh;
   }
 
   /**
@@ -80,17 +58,13 @@ public class SessionRecord {
     promoteState(new SessionState());
   }
 
-  public void promoteState(SessionState promotedState) {
+  private void promoteState(SessionState promotedState) {
     this.previousStates.addFirst(sessionState);
     this.sessionState = promotedState;
 
     if (previousStates.size() > ARCHIVED_STATES_MAX_LENGTH) {
       previousStates.removeLast();
     }
-  }
-
-  public void setState(SessionState sessionState) {
-    this.sessionState = sessionState;
   }
 
   /**

--- a/java/java/src/main/java/org/whispersystems/libsignal/state/SessionRecord.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/state/SessionRecord.java
@@ -6,6 +6,12 @@
 package org.whispersystems.libsignal.state;
 
 import org.signal.client.internal.Native;
+import org.whispersystems.libsignal.state.SessionState;
+import org.whispersystems.libsignal.IdentityKeyPair;
+import org.whispersystems.libsignal.IdentityKey;
+import org.whispersystems.libsignal.ecc.ECKeyPair;
+import org.whispersystems.libsignal.ecc.ECPublicKey;
+import org.whispersystems.libsignal.ecc.ECPrivateKey;
 import java.io.IOException;
 
 /**
@@ -26,16 +32,12 @@ public class SessionRecord {
     this.handle = Native.SessionRecord_NewFresh();
   }
 
-  public SessionRecord(SessionState sessionState) {
-    this.handle = Native.SessionRecord_FromSessionState(sessionState.nativeHandle());
+  public static SessionRecord fromSingleSessionState(byte[] sessionStateBytes) throws IOException {
+    return new SessionRecord(new SessionState(sessionStateBytes));
   }
 
   public SessionRecord(byte[] serialized) throws IOException {
     this.handle = Native.SessionRecord_Deserialize(serialized);
-  }
-
-  public SessionState getSessionState() {
-    return new SessionState(Native.SessionRecord_GetSessionState(this.handle));
   }
 
   /**
@@ -47,11 +49,86 @@ public class SessionRecord {
     Native.SessionRecord_ArchiveCurrentState(this.handle);
   }
 
+  public int getSessionVersion() {
+    // return Native.SessionRecord_GetSessionVersion(this.handle);
+    return getSessionState().getSessionVersion();
+  }
+
+  public int getRemoteRegistrationId() {
+    // return Native.SessionRecord_GetRemoteRegistrationId(this.handle);
+    return getSessionState().getRemoteRegistrationId();
+  }
+
+  public int getLocalRegistrationId() {
+    // return Native.SessionRecord_GetLocalRegistrationId(this.handle);
+    return getSessionState().getLocalRegistrationId();
+  }
+
+  public IdentityKey getRemoteIdentityKey() {
+    // return Native.SessionRecord_GetRemoteIdentityKey(this.handle);
+    return getSessionState().getRemoteIdentityKey();
+  }
+
+  public IdentityKey getLocalIdentityKey() {
+    // return Native.SessionRecord_GetLocalIdentityKey(this.handle);
+    return getSessionState().getLocalIdentityKey();
+  }
+
+  public boolean hasSenderChain() {
+    return getSessionState().hasSenderChain();
+  }
+
   /**
    * @return a serialized version of the current SessionRecord.
    */
   public byte[] serialize() {
     return Native.SessionRecord_Serialize(this.handle);
+  }
+
+  // Following functions are for internal or testing use and may be removed in the future:
+
+  public byte[] getReceiverChainKeyValue(ECPublicKey senderEphemeral) {
+    return getSessionState().getReceiverChainKeyValue(senderEphemeral);
+  }
+
+  public byte[] getSenderChainKeyValue() {
+    return getSessionState().getSenderChainKeyValue();
+  }
+
+  public SessionRecord(SessionState sessionState) {
+    this.handle = Native.SessionRecord_FromSessionState(sessionState.nativeHandle());
+  }
+
+  public SessionState getSessionState() {
+    return new SessionState(Native.SessionRecord_GetSessionState(this.handle));
+  }
+
+  public byte[] getAliceBaseKey() {
+    return getSessionState().getAliceBaseKey();
+  }
+
+  static public SessionRecord initializeAliceSession(IdentityKeyPair identityKey,
+                                                     ECKeyPair baseKey,
+                                                     IdentityKey theirIdentityKey,
+                                                     ECPublicKey theirSignedPreKey,
+                                                     ECPublicKey theirRatchetKey) {
+    return new SessionRecord(SessionState.initializeAliceSession(identityKey, baseKey,
+                                                                 theirIdentityKey,
+                                                                 theirSignedPreKey,
+                                                                 theirRatchetKey));
+  }
+
+  static public SessionRecord initializeBobSession(IdentityKeyPair identityKey,
+                                                   ECKeyPair signedPreKey,
+                                                   ECKeyPair ephemeralKey,
+                                                   IdentityKey theirIdentityKey,
+                                                   ECPublicKey theirBaseKey) {
+
+    return new SessionRecord(SessionState.initializeBobSession(identityKey,
+                                                               signedPreKey,
+                                                               ephemeralKey,
+                                                               theirIdentityKey,
+                                                               theirBaseKey));
   }
 
   long nativeHandle() {

--- a/java/java/src/main/java/org/whispersystems/libsignal/state/SessionState.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/state/SessionState.java
@@ -77,7 +77,7 @@ public class SessionState {
     this.handle = copy.handle;
   }
 
-  public byte[] getAliceBaseKey() {
+  byte[] getAliceBaseKey() {
     return Native.SessionState_GetAliceBaseKey(this.handle);
   }
 
@@ -85,7 +85,7 @@ public class SessionState {
     return Native.SessionState_GetSessionVersion(this.handle);
   }
 
-  public IdentityKey getRemoteIdentityKey() {
+  IdentityKey getRemoteIdentityKey() {
     byte[] keyBytes = Native.SessionState_GetRemoteIdentityKeyPublic(this.handle);
 
     if (keyBytes == null){
@@ -100,7 +100,7 @@ public class SessionState {
     }
   }
 
-  public IdentityKey getLocalIdentityKey() {
+  IdentityKey getLocalIdentityKey() {
     byte[] keyBytes = Native.SessionState_GetLocalIdentityKeyPublic(this.handle);
     try {
        return new IdentityKey(keyBytes);
@@ -114,19 +114,19 @@ public class SessionState {
     return Native.SessionState_HasSenderChain(this.handle);
   }
 
-  public byte[] getReceiverChainKeyValue(ECPublicKey senderEphemeral) {
+  byte[] getReceiverChainKeyValue(ECPublicKey senderEphemeral) {
     return Native.SessionState_GetReceiverChainKeyValue(this.handle, senderEphemeral.nativeHandle());
   }
 
-  public byte[] getSenderChainKeyValue() {
+  byte[] getSenderChainKeyValue() {
     return Native.SessionState_GetSenderChainKeyValue(this.handle);
   }
 
-  public int getRemoteRegistrationId() {
+  int getRemoteRegistrationId() {
     return Native.SessionState_GetRemoteRegistrationId(this.handle);
   }
 
-  public int getLocalRegistrationId() {
+  int getLocalRegistrationId() {
     return Native.SessionState_GetLocalRegistrationId(this.handle);
   }
 

--- a/java/java/src/main/java/org/whispersystems/libsignal/state/SessionState.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/state/SessionState.java
@@ -72,11 +72,6 @@ public class SessionState {
     this.handle = handle;
   }
 
-  // Remove this:
-  SessionState(SessionState copy) {
-    this.handle = copy.handle;
-  }
-
   byte[] getAliceBaseKey() {
     return Native.SessionState_GetAliceBaseKey(this.handle);
   }

--- a/java/java/src/main/java/org/whispersystems/libsignal/state/SessionState.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/state/SessionState.java
@@ -7,30 +7,21 @@
 package org.whispersystems.libsignal.state;
 
 import org.signal.client.internal.Native;
-
 import org.whispersystems.libsignal.IdentityKey;
 import org.whispersystems.libsignal.IdentityKeyPair;
-import org.whispersystems.libsignal.InvalidKeyException;
-import org.whispersystems.libsignal.ecc.Curve;
 import org.whispersystems.libsignal.ecc.ECKeyPair;
-import org.whispersystems.libsignal.ecc.ECPrivateKey;
 import org.whispersystems.libsignal.ecc.ECPublicKey;
-import org.whispersystems.libsignal.logging.Log;
-import org.whispersystems.libsignal.state.StorageProtos.SessionStructure.Chain;
-import org.whispersystems.libsignal.state.StorageProtos.SessionStructure.PendingKeyExchange;
-import org.whispersystems.libsignal.state.StorageProtos.SessionStructure.PendingPreKey;
-import org.whispersystems.libsignal.util.Pair;
-import org.whispersystems.libsignal.util.guava.Optional;
-
+import org.whispersystems.libsignal.InvalidKeyException;
 import java.io.IOException;
-
-import java.util.Iterator;
-import java.util.List;
-
 import static org.whispersystems.libsignal.state.StorageProtos.SessionStructure;
 
 public class SessionState {
-  private SessionStructure sessionStructure;
+  private long handle;
+
+  @Override
+  protected void finalize() {
+     Native.SessionState_Destroy(this.handle);
+  }
 
   static public SessionState initializeAliceSession(IdentityKeyPair identityKey,
                                                     ECKeyPair baseKey,
@@ -70,109 +61,80 @@ public class SessionState {
   }
 
   public SessionState(byte[] serialized) throws IOException {
-    this.sessionStructure = SessionStructure.parseFrom(serialized);
-  }
-
-  private static final int MAX_MESSAGE_KEYS = 2000;
-
-  public SessionState() {
-    this.sessionStructure = SessionStructure.newBuilder().build();
+    this.handle = Native.SessionState_Deserialize(serialized);
   }
 
   public SessionState(SessionStructure sessionStructure) {
-    this.sessionStructure = sessionStructure;
+    this.handle = Native.SessionState_Deserialize(sessionStructure.toByteArray());
   }
 
+  SessionState(long handle) {
+    this.handle = handle;
+  }
+
+  // Remove this:
   SessionState(SessionState copy) {
-    this.sessionStructure = copy.sessionStructure.toBuilder().build();
-  }
-
-  SessionStructure getStructure() {
-    return sessionStructure;
+    this.handle = copy.handle;
   }
 
   public byte[] getAliceBaseKey() {
-    return this.sessionStructure.getAliceBaseKey().toByteArray();
+    return Native.SessionState_GetAliceBaseKey(this.handle);
   }
 
   public int getSessionVersion() {
-    int sessionVersion = this.sessionStructure.getSessionVersion();
-
-    if (sessionVersion == 0) return 2;
-    else                     return sessionVersion;
+    return Native.SessionState_GetSessionVersion(this.handle);
   }
 
   public IdentityKey getRemoteIdentityKey() {
-    try {
-      if (!this.sessionStructure.hasRemoteIdentityPublic()) {
-        return null;
-      }
+    byte[] keyBytes = Native.SessionState_GetRemoteIdentityKeyPublic(this.handle);
 
-      return new IdentityKey(this.sessionStructure.getRemoteIdentityPublic().toByteArray(), 0);
-    } catch (InvalidKeyException e) {
-      Log.w("SessionRecordV2", e);
+    if (keyBytes == null){
       return null;
+    }
+
+    try {
+       return new IdentityKey(keyBytes);
+    }
+    catch(InvalidKeyException e) {
+      throw new AssertionError(e);
     }
   }
 
   public IdentityKey getLocalIdentityKey() {
+    byte[] keyBytes = Native.SessionState_GetLocalIdentityKeyPublic(this.handle);
     try {
-      return new IdentityKey(this.sessionStructure.getLocalIdentityPublic().toByteArray(), 0);
-    } catch (InvalidKeyException e) {
+       return new IdentityKey(keyBytes);
+    }
+    catch(InvalidKeyException e) {
       throw new AssertionError(e);
     }
   }
 
   public boolean hasSenderChain() {
-    return sessionStructure.hasSenderChain();
+    return Native.SessionState_HasSenderChain(this.handle);
   }
 
-  private Pair<Chain,Integer> getReceiverChain(ECPublicKey senderEphemeral) {
-    List<Chain> receiverChains = sessionStructure.getReceiverChainsList();
-    int         index          = 0;
-
-    for (Chain receiverChain : receiverChains) {
-      try {
-        ECPublicKey chainSenderRatchetKey = Curve.decodePoint(receiverChain.getSenderRatchetKey().toByteArray(), 0);
-
-        if (chainSenderRatchetKey.equals(senderEphemeral)) {
-          return new Pair<>(receiverChain,index);
-        }
-      } catch (InvalidKeyException e) {
-        Log.w("SessionRecordV2", e);
-     }
-
-     index++;
-    }
-
-   return null;
-   }
-
-   public byte[] getReceiverChainKeyValue(ECPublicKey senderEphemeral) {
-     Pair<Chain,Integer> receiverChainAndIndex = getReceiverChain(senderEphemeral);
-     Chain               receiverChain         = receiverChainAndIndex.first();
-
-     if (receiverChain == null) {
-       return null;
-     } else {
-       return receiverChain.getChainKey().getKey().toByteArray();
-     }
+  public byte[] getReceiverChainKeyValue(ECPublicKey senderEphemeral) {
+    return Native.SessionState_GetReceiverChainKeyValue(this.handle, senderEphemeral.nativeHandle());
   }
 
   public byte[] getSenderChainKeyValue() {
-    Chain.ChainKey chainKeyStructure = sessionStructure.getSenderChain().getChainKey();
-    return chainKeyStructure.getKey().toByteArray();
+    return Native.SessionState_GetSenderChainKeyValue(this.handle);
   }
 
   public int getRemoteRegistrationId() {
-    return this.sessionStructure.getRemoteRegistrationId();
+    return Native.SessionState_GetRemoteRegistrationId(this.handle);
   }
 
   public int getLocalRegistrationId() {
-    return this.sessionStructure.getLocalRegistrationId();
+    return Native.SessionState_GetLocalRegistrationId(this.handle);
   }
 
   public byte[] serialize() {
-    return sessionStructure.toByteArray();
+    return Native.SessionState_Serialized(this.handle);
+  }
+
+  long nativeHandle() {
+    return this.handle;
   }
 }

--- a/java/java/src/main/java/org/whispersystems/libsignal/state/SessionState.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/state/SessionState.java
@@ -83,11 +83,11 @@ public class SessionState {
     this.sessionStructure = sessionStructure;
   }
 
-  public SessionState(SessionState copy) {
+  SessionState(SessionState copy) {
     this.sessionStructure = copy.sessionStructure.toBuilder().build();
   }
 
-  public SessionStructure getStructure() {
+  SessionStructure getStructure() {
     return sessionStructure;
   }
 
@@ -121,27 +121,6 @@ public class SessionState {
     } catch (InvalidKeyException e) {
       throw new AssertionError(e);
     }
-  }
-
-  public int getPreviousCounter() {
-    return sessionStructure.getPreviousCounter();
-  }
-
-  public ECPublicKey getSenderRatchetKey() {
-    try {
-      return Curve.decodePoint(sessionStructure.getSenderChain().getSenderRatchetKey().toByteArray(), 0);
-    } catch (InvalidKeyException e) {
-      throw new AssertionError(e);
-    }
-  }
-
-  public ECKeyPair getSenderRatchetKeyPair() {
-    ECPublicKey  publicKey  = getSenderRatchetKey();
-    ECPrivateKey privateKey = Curve.decodePrivatePoint(sessionStructure.getSenderChain()
-                                                                       .getSenderRatchetKeyPrivate()
-                                                                       .toByteArray());
-
-    return new ECKeyPair(publicKey, privateKey);
   }
 
   public boolean hasSenderChain() {

--- a/java/tests/src/test/java/org/whispersystems/libsignal/SessionBuilderTest.java
+++ b/java/tests/src/test/java/org/whispersystems/libsignal/SessionBuilderTest.java
@@ -42,7 +42,7 @@ public class SessionBuilderTest extends TestCase {
     aliceSessionBuilder.process(bobPreKey);
 
     assertTrue(aliceStore.containsSession(BOB_ADDRESS));
-    assertTrue(aliceStore.loadSession(BOB_ADDRESS).getSessionState().getSessionVersion() == 3);
+    assertTrue(aliceStore.loadSession(BOB_ADDRESS).getSessionVersion() == 3);
 
           String            originalMessage    = "Good, fast, cheap: pick two";
           SessionCipher     aliceSessionCipher = new SessionCipher(aliceStore, BOB_ADDRESS);
@@ -58,8 +58,8 @@ public class SessionBuilderTest extends TestCase {
     byte[] plaintext = bobSessionCipher.decrypt(incomingMessage);
 
     assertTrue(bobStore.containsSession(ALICE_ADDRESS));
-    assertTrue(bobStore.loadSession(ALICE_ADDRESS).getSessionState().getSessionVersion() == 3);
-    assertTrue(bobStore.loadSession(ALICE_ADDRESS).getSessionState().getAliceBaseKey() != null);
+    assertTrue(bobStore.loadSession(ALICE_ADDRESS).getSessionVersion() == 3);
+    assertTrue(bobStore.loadSession(ALICE_ADDRESS).getAliceBaseKey() != null);
     assertTrue(originalMessage.equals(new String(plaintext)));
 
     CiphertextMessage bobOutgoingMessage = bobSessionCipher.encrypt(originalMessage.getBytes());
@@ -318,7 +318,7 @@ public class SessionBuilderTest extends TestCase {
     aliceSessionBuilder.process(bobPreKey);
 
     assertTrue(aliceStore.containsSession(BOB_ADDRESS));
-    assertTrue(aliceStore.loadSession(BOB_ADDRESS).getSessionState().getSessionVersion() == 3);
+    assertTrue(aliceStore.loadSession(BOB_ADDRESS).getSessionVersion() == 3);
 
     String            originalMessage    = "Good, fast, cheap: pick two";
     SessionCipher     aliceSessionCipher = new SessionCipher(aliceStore, BOB_ADDRESS);
@@ -335,8 +335,8 @@ public class SessionBuilderTest extends TestCase {
     byte[]        plaintext        = bobSessionCipher.decrypt(incomingMessage);
 
     assertTrue(bobStore.containsSession(ALICE_ADDRESS));
-    assertTrue(bobStore.loadSession(ALICE_ADDRESS).getSessionState().getSessionVersion() == 3);
-    assertTrue(bobStore.loadSession(ALICE_ADDRESS).getSessionState().getAliceBaseKey() != null);
+    assertTrue(bobStore.loadSession(ALICE_ADDRESS).getSessionVersion() == 3);
+    assertTrue(bobStore.loadSession(ALICE_ADDRESS).getAliceBaseKey() != null);
     assertTrue(originalMessage.equals(new String(plaintext)));
   }
 

--- a/java/tests/src/test/java/org/whispersystems/libsignal/SessionCipherTest.java
+++ b/java/tests/src/test/java/org/whispersystems/libsignal/SessionCipherTest.java
@@ -5,11 +5,11 @@ import junit.framework.TestCase;
 import org.whispersystems.libsignal.ecc.Curve;
 import org.whispersystems.libsignal.ecc.ECKeyPair;
 import org.whispersystems.libsignal.ecc.ECPublicKey;
+import org.whispersystems.libsignal.ecc.ECPrivateKey;
 import org.whispersystems.libsignal.protocol.CiphertextMessage;
 import org.whispersystems.libsignal.protocol.SignalMessage;
 import org.whispersystems.libsignal.state.SignalProtocolStore;
 import org.whispersystems.libsignal.state.SessionRecord;
-import org.whispersystems.libsignal.state.SessionState;
 import org.whispersystems.libsignal.util.guava.Optional;
 import org.whispersystems.libsignal.util.Pair;
 
@@ -158,20 +158,17 @@ public class SessionCipherTest extends TestCase {
 
     ECKeyPair       bobPreKey            = Curve.generateKeyPair();
 
-    SessionState aliceSessionState = SessionState.initializeAliceSession(aliceIdentityKey,
-                                                                         aliceBaseKey,
-                                                                         bobIdentityKey.getPublicKey(),
-                                                                         bobBaseKey.getPublicKey(),
-                                                                         bobEphemeralKey.getPublicKey());
-    SessionRecord aliceSessionRecord = new SessionRecord(aliceSessionState);
+    SessionRecord aliceSessionRecord = SessionRecord.initializeAliceSession(aliceIdentityKey,
+                                                                            aliceBaseKey,
+                                                                            bobIdentityKey.getPublicKey(),
+                                                                            bobBaseKey.getPublicKey(),
+                                                                            bobEphemeralKey.getPublicKey());
 
-    SessionState bobSessionState = SessionState.initializeBobSession(bobIdentityKey,
-                                                                     bobBaseKey,
-                                                                     bobEphemeralKey,
-                                                                     aliceIdentityKey.getPublicKey(),
-                                                                     aliceBaseKey.getPublicKey());
-
-    SessionRecord bobSessionRecord = new SessionRecord(bobSessionState);
+    SessionRecord bobSessionRecord = SessionRecord.initializeBobSession(bobIdentityKey,
+                                                                        bobBaseKey,
+                                                                        bobEphemeralKey,
+                                                                        aliceIdentityKey.getPublicKey(),
+                                                                        aliceBaseKey.getPublicKey());
 
     return new PairOfSessions(aliceSessionRecord, bobSessionRecord);
   }

--- a/java/tests/src/test/java/org/whispersystems/libsignal/SessionCipherTest.java
+++ b/java/tests/src/test/java/org/whispersystems/libsignal/SessionCipherTest.java
@@ -24,28 +24,32 @@ import java.util.Random;
 
 public class SessionCipherTest extends TestCase {
 
+  public class PairOfSessions {
+    public PairOfSessions(SessionRecord a, SessionRecord b) {
+      aliceSession = a;
+      bobSession = b;
+    }
+
+    public SessionRecord aliceSession;
+    public SessionRecord bobSession;
+  }
+
   public void testBasicSessionV3()
       throws InvalidKeyException, DuplicateMessageException,
       LegacyMessageException, InvalidMessageException, NoSuchAlgorithmException, NoSessionException, UntrustedIdentityException
   {
-    SessionRecord aliceSessionRecord = new SessionRecord();
-    SessionRecord bobSessionRecord   = new SessionRecord();
-
-    initializeSessionsV3(aliceSessionRecord, bobSessionRecord);
-    runInteraction(aliceSessionRecord, bobSessionRecord);
+    PairOfSessions sessions = initializeSessionsV3();
+    runInteraction(sessions.aliceSession, sessions.bobSession);
   }
 
   public void testMessageKeyLimits() throws Exception {
-    SessionRecord aliceSessionRecord = new SessionRecord();
-    SessionRecord bobSessionRecord   = new SessionRecord();
-
-    initializeSessionsV3(aliceSessionRecord, bobSessionRecord);
+    PairOfSessions sessions = initializeSessionsV3();
 
     SignalProtocolStore aliceStore = new TestInMemorySignalProtocolStore();
     SignalProtocolStore bobStore   = new TestInMemorySignalProtocolStore();
 
-    aliceStore.storeSession(new SignalProtocolAddress("+14159999999", 1), aliceSessionRecord);
-    bobStore.storeSession(new SignalProtocolAddress("+14158888888", 1), bobSessionRecord);
+    aliceStore.storeSession(new SignalProtocolAddress("+14159999999", 1), sessions.aliceSession);
+    bobStore.storeSession(new SignalProtocolAddress("+14158888888", 1), sessions.bobSession);
 
     SessionCipher     aliceCipher    = new SessionCipher(aliceStore, new SignalProtocolAddress("+14159999999", 1));
     SessionCipher     bobCipher      = new SessionCipher(bobStore, new SignalProtocolAddress("+14158888888", 1));
@@ -137,9 +141,7 @@ public class SessionCipherTest extends TestCase {
     }
   }
 
-  private void initializeSessionsV3(SessionRecord aliceSessionRecord, SessionRecord bobSessionRecord)
-      throws InvalidKeyException
-  {
+  private PairOfSessions initializeSessionsV3() throws InvalidKeyException {
     ECKeyPair       aliceIdentityKeyPair = Curve.generateKeyPair();
     IdentityKeyPair aliceIdentityKey     = new IdentityKeyPair(new IdentityKey(aliceIdentityKeyPair.getPublicKey()),
                                                                aliceIdentityKeyPair.getPrivateKey());
@@ -161,15 +163,17 @@ public class SessionCipherTest extends TestCase {
                                                                          bobIdentityKey.getPublicKey(),
                                                                          bobBaseKey.getPublicKey(),
                                                                          bobEphemeralKey.getPublicKey());
-
-    aliceSessionRecord.setState(aliceSessionState);
+    SessionRecord aliceSessionRecord = new SessionRecord(aliceSessionState);
 
     SessionState bobSessionState = SessionState.initializeBobSession(bobIdentityKey,
                                                                      bobBaseKey,
                                                                      bobEphemeralKey,
                                                                      aliceIdentityKey.getPublicKey(),
                                                                      aliceBaseKey.getPublicKey());
-    bobSessionRecord.setState(bobSessionState);
+
+    SessionRecord bobSessionRecord = new SessionRecord(bobSessionState);
+
+    return new PairOfSessions(aliceSessionRecord, bobSessionRecord);
   }
 
 }

--- a/java/tests/src/test/java/org/whispersystems/libsignal/SimultaneousInitiateTests.java
+++ b/java/tests/src/test/java/org/whispersystems/libsignal/SimultaneousInitiateTests.java
@@ -61,8 +61,8 @@ public class SimultaneousInitiateTests extends TestCase {
     assertTrue(new String(alicePlaintext).equals("sample message"));
     assertTrue(new String(bobPlaintext).equals("hey there"));
 
-    assertTrue(aliceStore.loadSession(BOB_ADDRESS).getSessionState().getSessionVersion() == 3);
-    assertTrue(bobStore.loadSession(ALICE_ADDRESS).getSessionState().getSessionVersion() == 3);
+    assertTrue(aliceStore.loadSession(BOB_ADDRESS).getSessionVersion() == 3);
+    assertTrue(bobStore.loadSession(ALICE_ADDRESS).getSessionVersion() == 3);
 
     assertFalse(isSessionIdEqual(aliceStore, bobStore));
 
@@ -112,7 +112,7 @@ public class SimultaneousInitiateTests extends TestCase {
     byte[] bobPlaintext   = bobSessionCipher.decrypt(new PreKeySignalMessage(messageForBob.serialize()));
 
     assertTrue(new String(bobPlaintext).equals("hey there"));
-    assertTrue(bobStore.loadSession(ALICE_ADDRESS).getSessionState().getSessionVersion() == 3);
+    assertTrue(bobStore.loadSession(ALICE_ADDRESS).getSessionVersion() == 3);
 
     CiphertextMessage aliceResponse = aliceSessionCipher.encrypt("second message".getBytes());
 
@@ -167,8 +167,8 @@ public class SimultaneousInitiateTests extends TestCase {
     assertTrue(new String(alicePlaintext).equals("sample message"));
     assertTrue(new String(bobPlaintext).equals("hey there"));
 
-    assertTrue(aliceStore.loadSession(BOB_ADDRESS).getSessionState().getSessionVersion() == 3);
-    assertTrue(bobStore.loadSession(ALICE_ADDRESS).getSessionState().getSessionVersion() == 3);
+    assertTrue(aliceStore.loadSession(BOB_ADDRESS).getSessionVersion() == 3);
+    assertTrue(bobStore.loadSession(ALICE_ADDRESS).getSessionVersion() == 3);
 
     assertFalse(isSessionIdEqual(aliceStore, bobStore));
 
@@ -226,8 +226,8 @@ public class SimultaneousInitiateTests extends TestCase {
     assertTrue(new String(alicePlaintext).equals("sample message"));
     assertTrue(new String(bobPlaintext).equals("hey there"));
 
-    assertTrue(aliceStore.loadSession(BOB_ADDRESS).getSessionState().getSessionVersion() == 3);
-    assertTrue(bobStore.loadSession(ALICE_ADDRESS).getSessionState().getSessionVersion() == 3);
+    assertTrue(aliceStore.loadSession(BOB_ADDRESS).getSessionVersion() == 3);
+    assertTrue(bobStore.loadSession(ALICE_ADDRESS).getSessionVersion() == 3);
 
     assertFalse(isSessionIdEqual(aliceStore, bobStore));
 
@@ -304,8 +304,8 @@ public class SimultaneousInitiateTests extends TestCase {
       assertTrue(new String(alicePlaintext).equals("sample message"));
       assertTrue(new String(bobPlaintext).equals("hey there"));
 
-      assertTrue(aliceStore.loadSession(BOB_ADDRESS).getSessionState().getSessionVersion() == 3);
-      assertTrue(bobStore.loadSession(ALICE_ADDRESS).getSessionState().getSessionVersion() == 3);
+      assertTrue(aliceStore.loadSession(BOB_ADDRESS).getSessionVersion() == 3);
+      assertTrue(bobStore.loadSession(ALICE_ADDRESS).getSessionVersion() == 3);
 
       assertFalse(isSessionIdEqual(aliceStore, bobStore));
     }
@@ -392,8 +392,8 @@ public class SimultaneousInitiateTests extends TestCase {
       assertTrue(new String(alicePlaintext).equals("sample message"));
       assertTrue(new String(bobPlaintext).equals("hey there"));
 
-      assertTrue(aliceStore.loadSession(BOB_ADDRESS).getSessionState().getSessionVersion() == 3);
-      assertTrue(bobStore.loadSession(ALICE_ADDRESS).getSessionState().getSessionVersion() == 3);
+      assertTrue(aliceStore.loadSession(BOB_ADDRESS).getSessionVersion() == 3);
+      assertTrue(bobStore.loadSession(ALICE_ADDRESS).getSessionVersion() == 3);
 
       assertFalse(isSessionIdEqual(aliceStore, bobStore));
     }
@@ -447,8 +447,8 @@ public class SimultaneousInitiateTests extends TestCase {
   }
 
   private boolean isSessionIdEqual(SignalProtocolStore aliceStore, SignalProtocolStore bobStore) {
-    return Arrays.equals(aliceStore.loadSession(BOB_ADDRESS).getSessionState().getAliceBaseKey(),
-                         bobStore.loadSession(ALICE_ADDRESS).getSessionState().getAliceBaseKey());
+    return Arrays.equals(aliceStore.loadSession(BOB_ADDRESS).getAliceBaseKey(),
+                         bobStore.loadSession(ALICE_ADDRESS).getAliceBaseKey());
   }
 
   private PreKeyBundle createAlicePreKeyBundle(SignalProtocolStore aliceStore) throws InvalidKeyException {

--- a/java/tests/src/test/java/org/whispersystems/libsignal/ratchet/RatchetingSessionTest.java
+++ b/java/tests/src/test/java/org/whispersystems/libsignal/ratchet/RatchetingSessionTest.java
@@ -9,7 +9,7 @@ import org.whispersystems.libsignal.ecc.Curve;
 import org.whispersystems.libsignal.ecc.ECKeyPair;
 import org.whispersystems.libsignal.ecc.ECPrivateKey;
 import org.whispersystems.libsignal.ecc.ECPublicKey;
-import org.whispersystems.libsignal.state.SessionState;
+import org.whispersystems.libsignal.state.SessionRecord;
 import org.whispersystems.libsignal.util.guava.Optional;
 
 import java.util.Arrays;
@@ -122,7 +122,7 @@ public class RatchetingSessionTest extends TestCase {
     ECPublicKey     aliceEphemeralPublicKey  = Curve.decodePoint(aliceEphemeralPublic, 0);
     IdentityKey     aliceIdentityPublicKey   = new IdentityKey(aliceIdentityPublic, 0);
 
-    SessionState session = SessionState.initializeBobSession(bobIdentityKey,
+    SessionRecord session = SessionRecord.initializeBobSession(bobIdentityKey,
                                                              bobSignedPreKey,
                                                              bobEphemeralKey,
                                                              aliceIdentityPublicKey,
@@ -236,7 +236,7 @@ public void testRatchetingSessionAsAlice() throws InvalidKeyException {
     ECPrivateKey    aliceIdentityPrivateKey  = Curve.decodePrivatePoint(aliceIdentityPrivate);
     IdentityKeyPair aliceIdentityKey         = new IdentityKeyPair(aliceIdentityPublicKey, aliceIdentityPrivateKey);
 
-    SessionState session = SessionState.initializeAliceSession(aliceIdentityKey,
+    SessionRecord session = SessionRecord.initializeAliceSession(aliceIdentityKey,
                                                                aliceBaseKey,
                                                                bobIdentityKey,
                                                                bobSignedPreKey,

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -1583,8 +1583,8 @@ jni_fn_get_jbytearray!(Java_org_signal_client_internal_Native_SessionRecord_1Ser
 pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SessionRecord_1ArchiveCurrentState(
     env: JNIEnv,
     _class: JClass,
-    handle: ObjectHandle) {
-
+    handle: ObjectHandle,
+) {
     run_ffi_safe(&env, || {
         let session_record = native_handle_cast::<SessionRecord>(handle)?;
         session_record.archive_current_state()?;
@@ -1595,7 +1595,8 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SessionRecord_1A
 #[no_mangle]
 pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SessionRecord_1NewFresh(
     env: JNIEnv,
-    _class: JClass) -> ObjectHandle {
+    _class: JClass,
+) -> ObjectHandle {
     run_ffi_safe(&env, || {
         box_object::<SessionRecord>(Ok(SessionRecord::new_fresh()))
     })
@@ -1605,7 +1606,8 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SessionRecord_1N
 pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SessionRecord_1FromSessionState(
     env: JNIEnv,
     _class: JClass,
-    session_state: ObjectHandle) -> ObjectHandle {
+    session_state: ObjectHandle,
+) -> ObjectHandle {
     run_ffi_safe(&env, || {
         let session_state = native_handle_cast::<SessionState>(session_state)?;
         box_object::<SessionRecord>(Ok(SessionRecord::new(session_state.clone())))
@@ -1616,7 +1618,8 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SessionRecord_1F
 pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SessionRecord_1GetSessionState(
     env: JNIEnv,
     _class: JClass,
-    session_record: ObjectHandle) -> ObjectHandle {
+    session_record: ObjectHandle,
+) -> ObjectHandle {
     run_ffi_safe(&env, || {
         let session_record = native_handle_cast::<SessionRecord>(session_record)?;
         box_object::<SessionState>(session_record.session_state().map(|s| s.clone()))
@@ -1644,7 +1647,8 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SessionState_1Ge
     env: JNIEnv,
     _class: JClass,
     session_state: ObjectHandle,
-    key: ObjectHandle) -> jbyteArray {
+    key: ObjectHandle,
+) -> jbyteArray {
     run_ffi_safe(&env, || {
         let session_state = native_handle_cast::<SessionState>(session_state)?;
         let sender = native_handle_cast::<PublicKey>(key)?;
@@ -1653,12 +1657,10 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SessionState_1Ge
 
         match chain_key {
             None => Ok(std::ptr::null_mut()),
-            Some(ck) => to_jbytearray(&env, Ok(ck.key()))
+            Some(ck) => to_jbytearray(&env, Ok(ck.key())),
         }
     })
 }
-
-
 
 #[no_mangle]
 pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SessionState_1InitializeAliceSession(

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -1197,18 +1197,14 @@ impl<'a> JniSessionStore<'a> {
 
         let callback_sig = "(Lorg/whispersystems/libsignal/SignalProtocolAddress;)Lorg/whispersystems/libsignal/state/SessionRecord;";
         let callback_args = [address_jobject.into()];
-        let session = get_object_with_serialization(
+        get_object_with_native_handle::<SessionRecord>(
             self.env,
             self.store,
             &callback_args,
             callback_sig,
             "loadSession",
-        )?;
-
-        match session {
-            None => Ok(None),
-            Some(s) => Ok(Some(SessionRecord::deserialize(&s)?)),
-        }
+            None,
+        )
     }
 
     fn do_store_session(

--- a/rust/bridge/jni/src/util.rs
+++ b/rust/bridge/jni/src/util.rs
@@ -698,6 +698,26 @@ macro_rules! jni_fn_get_jbytearray {
 }
 
 #[macro_export]
+macro_rules! jni_fn_get_optional_jbytearray {
+    ( $nm:ident($typ:ty) using $body:expr ) => {
+        #[no_mangle]
+        pub unsafe extern "C" fn $nm(
+            env: JNIEnv,
+            _class: JClass,
+            handle: ObjectHandle,
+        ) -> jbyteArray {
+            run_ffi_safe(&env, || {
+                let obj = native_handle_cast::<$typ>(handle)?;
+                match $body(obj)? {
+                    Some(v) => to_jbytearray(&env, Ok(v)),
+                    None => Ok(std::ptr::null_mut()),
+                }
+            })
+        }
+    };
+}
+
+#[macro_export]
 macro_rules! jni_fn_destroy {
     ( $nm:ident destroys $typ:ty ) => {
         #[no_mangle]

--- a/rust/protocol/src/state/session.rs
+++ b/rust/protocol/src/state/session.rs
@@ -87,8 +87,16 @@ impl SessionState {
         }
     }
 
+    pub fn remote_identity_key_bytes(&self) -> Result<Option<Vec<u8>>> {
+        Ok(self.remote_identity_key()?.map(|k| k.serialize().to_vec()))
+    }
+
     pub fn local_identity_key(&self) -> Result<IdentityKey> {
         IdentityKey::decode(&self.session.local_identity_public)
+    }
+
+    pub fn local_identity_key_bytes(&self) -> Result<Vec<u8>> {
+        Ok(self.local_identity_key()?.serialize().to_vec())
     }
 
     pub fn previous_counter(&self) -> Result<u32> {
@@ -232,6 +240,10 @@ impl SessionState {
 
         let hkdf = kdf::HKDF::new(self.session_version()?)?;
         ChainKey::new(hkdf, &chain_key.key, chain_key.index)
+    }
+
+    pub fn get_sender_chain_key_bytes(&self) -> Result<Vec<u8>> {
+        Ok(self.get_sender_chain_key()?.key().to_vec())
     }
 
     pub fn set_sender_chain_key(&mut self, next_chain_key: &ChainKey) -> Result<()> {


### PR DESCRIPTION
We have to leave the protobufs around, along with SessionState, as Android uses these directly for various purposes. I'm going to try to get some changes into Android to remove those as most uses are trivial and then we can remove some more of the Java API.