### PR TITLE
Swift: Use a marker protocol for store "context" parameters

### DIFF
--- a/swift/Sources/SignalClient/DataStoreInMemory.swift
+++ b/swift/Sources/SignalClient/DataStoreInMemory.swift
@@ -3,6 +3,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+/// A dummy StoreContext usable with InMemorySignalProtocolStore.
+public struct NullContext: StoreContext {
+    public init() {}
+}
+
 public class InMemorySignalProtocolStore: IdentityKeyStore, PreKeyStore, SignedPreKeyStore, SessionStore, SenderKeyStore {
     private var publicKeys: [ProtocolAddress: IdentityKey] = [:]
     private var privateKey: IdentityKeyPair
@@ -22,15 +27,15 @@ public class InMemorySignalProtocolStore: IdentityKeyStore, PreKeyStore, SignedP
         self.deviceId = deviceId
     }
 
-    public func identityKeyPair(context: UnsafeMutableRawPointer?) throws -> IdentityKeyPair {
+    public func identityKeyPair(context: StoreContext) throws -> IdentityKeyPair {
         return privateKey
     }
 
-    public func localRegistrationId(context: UnsafeMutableRawPointer?) throws -> UInt32 {
+    public func localRegistrationId(context: StoreContext) throws -> UInt32 {
         return deviceId
     }
 
-    public func saveIdentity(_ identity: IdentityKey, for address: ProtocolAddress, context: UnsafeMutableRawPointer?) throws -> Bool {
+    public func saveIdentity(_ identity: IdentityKey, for address: ProtocolAddress, context: StoreContext) throws -> Bool {
         if publicKeys.updateValue(identity, forKey: address) == nil {
             return false; // newly created
         } else {
@@ -38,7 +43,7 @@ public class InMemorySignalProtocolStore: IdentityKeyStore, PreKeyStore, SignedP
         }
     }
 
-    public func isTrustedIdentity(_ identity: IdentityKey, for address: ProtocolAddress, direction: Direction, context: UnsafeMutableRawPointer?) throws -> Bool {
+    public func isTrustedIdentity(_ identity: IdentityKey, for address: ProtocolAddress, direction: Direction, context: StoreContext) throws -> Bool {
         if let pk = publicKeys[address] {
             return pk == identity
         } else {
@@ -46,11 +51,11 @@ public class InMemorySignalProtocolStore: IdentityKeyStore, PreKeyStore, SignedP
         }
     }
 
-    public func identity(for address: ProtocolAddress, context: UnsafeMutableRawPointer?) throws -> IdentityKey? {
+    public func identity(for address: ProtocolAddress, context: StoreContext) throws -> IdentityKey? {
         return publicKeys[address]
     }
 
-    public func loadPreKey(id: UInt32, context: UnsafeMutableRawPointer?) throws -> PreKeyRecord {
+    public func loadPreKey(id: UInt32, context: StoreContext) throws -> PreKeyRecord {
         if let record = prekeyMap[id] {
             return record
         } else {
@@ -58,15 +63,15 @@ public class InMemorySignalProtocolStore: IdentityKeyStore, PreKeyStore, SignedP
         }
     }
 
-    public func storePreKey(_ record: PreKeyRecord, id: UInt32, context: UnsafeMutableRawPointer?) throws {
+    public func storePreKey(_ record: PreKeyRecord, id: UInt32, context: StoreContext) throws {
         prekeyMap[id] = record
     }
 
-    public func removePreKey(id: UInt32, context: UnsafeMutableRawPointer?) throws {
+    public func removePreKey(id: UInt32, context: StoreContext) throws {
         prekeyMap.removeValue(forKey: id)
     }
 
-    public func loadSignedPreKey(id: UInt32, context: UnsafeMutableRawPointer?) throws -> SignedPreKeyRecord {
+    public func loadSignedPreKey(id: UInt32, context: StoreContext) throws -> SignedPreKeyRecord {
         if let record = signedPrekeyMap[id] {
             return record
         } else {
@@ -74,23 +79,23 @@ public class InMemorySignalProtocolStore: IdentityKeyStore, PreKeyStore, SignedP
         }
     }
 
-    public func storeSignedPreKey(_ record: SignedPreKeyRecord, id: UInt32, context: UnsafeMutableRawPointer?) throws {
+    public func storeSignedPreKey(_ record: SignedPreKeyRecord, id: UInt32, context: StoreContext) throws {
         signedPrekeyMap[id] = record
     }
 
-    public func loadSession(for address: ProtocolAddress, context: UnsafeMutableRawPointer?) throws -> SessionRecord? {
+    public func loadSession(for address: ProtocolAddress, context: StoreContext) throws -> SessionRecord? {
         return sessionMap[address]
     }
 
-    public func storeSession(_ record: SessionRecord, for address: ProtocolAddress, context: UnsafeMutableRawPointer?) throws {
+    public func storeSession(_ record: SessionRecord, for address: ProtocolAddress, context: StoreContext) throws {
         sessionMap[address] = record
     }
 
-    public func storeSenderKey(name: SenderKeyName, record: SenderKeyRecord, context: UnsafeMutableRawPointer?) throws {
+    public func storeSenderKey(name: SenderKeyName, record: SenderKeyRecord, context: StoreContext) throws {
         senderKeyMap[name] = record
     }
 
-    public func loadSenderKey(name: SenderKeyName, context: UnsafeMutableRawPointer?) throws -> SenderKeyRecord? {
+    public func loadSenderKey(name: SenderKeyName, context: StoreContext) throws -> SenderKeyRecord? {
         return senderKeyMap[name]
     }
 }

--- a/swift/Sources/SignalClient/DataStoreProtocols.swift
+++ b/swift/Sources/SignalClient/DataStoreProtocols.swift
@@ -10,31 +10,36 @@ public enum Direction {
     case receiving
 }
 
+/// A marker protocol, which must be downcast to use in any particular store.
+///
+/// Essentially `Any`, but still able to catch typos when calling something that uses stores.
+public protocol StoreContext {}
+
 public protocol IdentityKeyStore: AnyObject {
-    func identityKeyPair(context: UnsafeMutableRawPointer?) throws -> IdentityKeyPair
-    func localRegistrationId(context: UnsafeMutableRawPointer?) throws -> UInt32
-    func saveIdentity(_ identity: IdentityKey, for address: ProtocolAddress, context: UnsafeMutableRawPointer?) throws -> Bool
-    func isTrustedIdentity(_ identity: IdentityKey, for address: ProtocolAddress, direction: Direction, context: UnsafeMutableRawPointer?) throws -> Bool
-    func identity(for address: ProtocolAddress, context: UnsafeMutableRawPointer?) throws -> IdentityKey?
+    func identityKeyPair(context: StoreContext) throws -> IdentityKeyPair
+    func localRegistrationId(context: StoreContext) throws -> UInt32
+    func saveIdentity(_ identity: IdentityKey, for address: ProtocolAddress, context: StoreContext) throws -> Bool
+    func isTrustedIdentity(_ identity: IdentityKey, for address: ProtocolAddress, direction: Direction, context: StoreContext) throws -> Bool
+    func identity(for address: ProtocolAddress, context: StoreContext) throws -> IdentityKey?
 }
 
 public protocol PreKeyStore: AnyObject {
-    func loadPreKey(id: UInt32, context: UnsafeMutableRawPointer?) throws -> PreKeyRecord
-    func storePreKey(_ record: PreKeyRecord, id: UInt32, context: UnsafeMutableRawPointer?) throws
-    func removePreKey(id: UInt32, context: UnsafeMutableRawPointer?) throws
+    func loadPreKey(id: UInt32, context: StoreContext) throws -> PreKeyRecord
+    func storePreKey(_ record: PreKeyRecord, id: UInt32, context: StoreContext) throws
+    func removePreKey(id: UInt32, context: StoreContext) throws
 }
 
 public protocol SignedPreKeyStore: AnyObject {
-    func loadSignedPreKey(id: UInt32, context: UnsafeMutableRawPointer?) throws -> SignedPreKeyRecord
-    func storeSignedPreKey(_ record: SignedPreKeyRecord, id: UInt32, context: UnsafeMutableRawPointer?) throws
+    func loadSignedPreKey(id: UInt32, context: StoreContext) throws -> SignedPreKeyRecord
+    func storeSignedPreKey(_ record: SignedPreKeyRecord, id: UInt32, context: StoreContext) throws
 }
 
 public protocol SessionStore: AnyObject {
-    func loadSession(for address: ProtocolAddress, context: UnsafeMutableRawPointer?) throws -> SessionRecord?
-    func storeSession(_ record: SessionRecord, for address: ProtocolAddress, context: UnsafeMutableRawPointer?) throws
+    func loadSession(for address: ProtocolAddress, context: StoreContext) throws -> SessionRecord?
+    func storeSession(_ record: SessionRecord, for address: ProtocolAddress, context: StoreContext) throws
 }
 
 public protocol SenderKeyStore: AnyObject {
-    func storeSenderKey(name: SenderKeyName, record: SenderKeyRecord, context: UnsafeMutableRawPointer?) throws
-    func loadSenderKey(name: SenderKeyName, context: UnsafeMutableRawPointer?) throws -> SenderKeyRecord?
+    func storeSenderKey(name: SenderKeyName, record: SenderKeyRecord, context: StoreContext) throws
+    func loadSenderKey(name: SenderKeyName, context: StoreContext) throws -> SenderKeyRecord?
 }

--- a/swift/Sources/SignalClient/Protocol.swift
+++ b/swift/Sources/SignalClient/Protocol.swift
@@ -46,12 +46,14 @@ public func signalEncrypt<Bytes: ContiguousBytes>(message: Bytes,
                                                   for address: ProtocolAddress,
                                                   sessionStore: SessionStore,
                                                   identityStore: IdentityKeyStore,
-                                                  context: UnsafeMutableRawPointer?) throws -> CiphertextMessage {
+                                                  context: StoreContext) throws -> CiphertextMessage {
     return try message.withUnsafeBytes { messageBytes in
-        try withSessionStore(sessionStore) { ffiSessionStore in
-            try withIdentityKeyStore(identityStore) { ffiIdentityStore in
-                try invokeFnReturningCiphertextMessage {
-                    signal_encrypt_message($0, messageBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), messageBytes.count, address.nativeHandle, ffiSessionStore, ffiIdentityStore, context)
+        try context.withOpaquePointer { context in
+            try withSessionStore(sessionStore) { ffiSessionStore in
+                try withIdentityKeyStore(identityStore) { ffiIdentityStore in
+                    try invokeFnReturningCiphertextMessage {
+                        signal_encrypt_message($0, messageBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), messageBytes.count, address.nativeHandle, ffiSessionStore, ffiIdentityStore, context)
+                    }
                 }
             }
         }
@@ -62,11 +64,13 @@ public func signalDecrypt(message: SignalMessage,
                           from address: ProtocolAddress,
                           sessionStore: SessionStore,
                           identityStore: IdentityKeyStore,
-                          context: UnsafeMutableRawPointer?) throws -> [UInt8] {
-    return try withSessionStore(sessionStore) { ffiSessionStore in
-        try withIdentityKeyStore(identityStore) { ffiIdentityStore in
-            try invokeFnReturningArray {
-                signal_decrypt_message($0, $1, message.nativeHandle, address.nativeHandle, ffiSessionStore, ffiIdentityStore, context)
+                          context: StoreContext) throws -> [UInt8] {
+    return try context.withOpaquePointer { context in
+        try withSessionStore(sessionStore) { ffiSessionStore in
+            try withIdentityKeyStore(identityStore) { ffiIdentityStore in
+                try invokeFnReturningArray {
+                    signal_decrypt_message($0, $1, message.nativeHandle, address.nativeHandle, ffiSessionStore, ffiIdentityStore, context)
+                }
             }
         }
     }
@@ -78,13 +82,15 @@ public func signalDecryptPreKey(message: PreKeySignalMessage,
                                 identityStore: IdentityKeyStore,
                                 preKeyStore: PreKeyStore,
                                 signedPreKeyStore: SignedPreKeyStore,
-                                context: UnsafeMutableRawPointer?) throws -> [UInt8] {
-    return try withSessionStore(sessionStore) { ffiSessionStore in
-        try withIdentityKeyStore(identityStore) { ffiIdentityStore in
-            try withPreKeyStore(preKeyStore) { ffiPreKeyStore in
-                try withSignedPreKeyStore(signedPreKeyStore) { ffiSignedPreKeyStore in
-                    try invokeFnReturningArray {
-                        signal_decrypt_pre_key_message($0, $1, message.nativeHandle, from.nativeHandle, ffiSessionStore, ffiIdentityStore, ffiPreKeyStore, ffiSignedPreKeyStore, context)
+                                context: StoreContext) throws -> [UInt8] {
+    return try context.withOpaquePointer { context in
+        try withSessionStore(sessionStore) { ffiSessionStore in
+            try withIdentityKeyStore(identityStore) { ffiIdentityStore in
+                try withPreKeyStore(preKeyStore) { ffiPreKeyStore in
+                    try withSignedPreKeyStore(signedPreKeyStore) { ffiSignedPreKeyStore in
+                        try invokeFnReturningArray {
+                            signal_decrypt_pre_key_message($0, $1, message.nativeHandle, from.nativeHandle, ffiSessionStore, ffiIdentityStore, ffiPreKeyStore, ffiSignedPreKeyStore, context)
+                        }
                     }
                 }
             }
@@ -96,10 +102,12 @@ public func processPreKeyBundle(_ bundle: PreKeyBundle,
                                 for address: ProtocolAddress,
                                 sessionStore: SessionStore,
                                 identityStore: IdentityKeyStore,
-                                context: UnsafeMutableRawPointer?) throws {
-    return try withSessionStore(sessionStore) { ffiSessionStore in
-        try withIdentityKeyStore(identityStore) { ffiIdentityStore in
-            try checkError(signal_process_prekey_bundle(bundle.nativeHandle, address.nativeHandle, ffiSessionStore, ffiIdentityStore, context))
+                                context: StoreContext) throws {
+    return try context.withOpaquePointer { context in
+        try withSessionStore(sessionStore) { ffiSessionStore in
+            try withIdentityKeyStore(identityStore) { ffiIdentityStore in
+                try checkError(signal_process_prekey_bundle(bundle.nativeHandle, address.nativeHandle, ffiSessionStore, ffiIdentityStore, context))
+            }
         }
     }
 }
@@ -107,11 +115,13 @@ public func processPreKeyBundle(_ bundle: PreKeyBundle,
 public func groupEncrypt<Bytes: ContiguousBytes>(groupId: SenderKeyName,
                                                  message: Bytes,
                                                  store: SenderKeyStore,
-                                                 context: UnsafeMutableRawPointer?) throws -> [UInt8] {
-    return try message.withUnsafeBytes { messageBytes in
-        return try withSenderKeyStore(store) { ffiStore in
-            return try invokeFnReturningArray {
-                signal_group_encrypt_message($0, $1, groupId.nativeHandle, messageBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), messageBytes.count, ffiStore, context)
+                                                 context: StoreContext) throws -> [UInt8] {
+    return try context.withOpaquePointer { context in
+        try message.withUnsafeBytes { messageBytes in
+            try withSenderKeyStore(store) { ffiStore in
+                try invokeFnReturningArray {
+                    signal_group_encrypt_message($0, $1, groupId.nativeHandle, messageBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), messageBytes.count, ffiStore, context)
+                }
             }
         }
     }
@@ -120,11 +130,13 @@ public func groupEncrypt<Bytes: ContiguousBytes>(groupId: SenderKeyName,
 public func groupDecrypt<Bytes: ContiguousBytes>(groupId: SenderKeyName,
                                                  message: Bytes,
                                                  store: SenderKeyStore,
-                                                 context: UnsafeMutableRawPointer?) throws -> [UInt8] {
-    return try message.withUnsafeBytes { messageBytes in
-        return try withSenderKeyStore(store) { ffiStore in
-            return try invokeFnReturningArray {
-                signal_group_decrypt_message($0, $1, groupId.nativeHandle, messageBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), messageBytes.count, ffiStore, context)
+                                                 context: StoreContext) throws -> [UInt8] {
+    return try context.withOpaquePointer { context in
+        try message.withUnsafeBytes { messageBytes in
+            try withSenderKeyStore(store) { ffiStore in
+                try invokeFnReturningArray {
+                    signal_group_decrypt_message($0, $1, groupId.nativeHandle, messageBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), messageBytes.count, ffiStore, context)
+                }
             }
         }
     }
@@ -133,10 +145,12 @@ public func groupDecrypt<Bytes: ContiguousBytes>(groupId: SenderKeyName,
 public func processSenderKeyDistributionMessage(sender: SenderKeyName,
                                                 message: SenderKeyDistributionMessage,
                                                 store: SenderKeyStore,
-                                                context: UnsafeMutableRawPointer?) throws {
-    try withSenderKeyStore(store) {
-        try checkError(signal_process_sender_key_distribution_message(sender.nativeHandle,
-                                                                      message.nativeHandle,
-                                                                      $0, context))
+                                                context: StoreContext) throws {
+    return try context.withOpaquePointer { context in
+        try withSenderKeyStore(store) {
+            try checkError(signal_process_sender_key_distribution_message(sender.nativeHandle,
+                                                                          message.nativeHandle,
+                                                                          $0, context))
+        }
     }
 }

--- a/swift/Sources/SignalClient/messages/SenderKeyDistributionMessage.swift
+++ b/swift/Sources/SignalClient/messages/SenderKeyDistributionMessage.swift
@@ -17,10 +17,12 @@ public class SenderKeyDistributionMessage {
         return handle
     }
 
-    public init(name: SenderKeyName, store: SenderKeyStore, context: UnsafeMutableRawPointer?) throws {
-        try withSenderKeyStore(store) {
-            try checkError(signal_create_sender_key_distribution_message(&handle, name.nativeHandle,
-                                                                         $0, context))
+    public init(name: SenderKeyName, store: SenderKeyStore, context: StoreContext) throws {
+        try context.withOpaquePointer { context in
+            try withSenderKeyStore(store) {
+                try checkError(signal_create_sender_key_distribution_message(&handle, name.nativeHandle,
+                                                                             $0, context))
+            }
         }
     }
 

--- a/swift/Tests/SignalClientTests/PublicAPITests.swift
+++ b/swift/Tests/SignalClientTests/PublicAPITests.swift
@@ -236,20 +236,20 @@ class PublicAPITests: TestCaseBase {
 
         let a_store = InMemorySignalProtocolStore()
 
-        let skdm = try! SenderKeyDistributionMessage(name: group_id, store: a_store, context: nil)
+        let skdm = try! SenderKeyDistributionMessage(name: group_id, store: a_store, context: NullContext())
 
         let skdm_bits = skdm.serialize()
 
         let skdm_r = try! SenderKeyDistributionMessage(bytes: skdm_bits)
 
-        let a_ctext = try! groupEncrypt(groupId: group_id, message: [1, 2, 3], store: a_store, context: nil)
+        let a_ctext = try! groupEncrypt(groupId: group_id, message: [1, 2, 3], store: a_store, context: NullContext())
 
         let b_store = InMemorySignalProtocolStore()
         try! processSenderKeyDistributionMessage(sender: group_id,
                                                  message: skdm_r,
                                                  store: b_store,
-                                                 context: nil)
-        let b_ptext = try! groupDecrypt(groupId: group_id, message: a_ctext, store: b_store, context: nil)
+                                                 context: NullContext())
+        let b_ptext = try! groupDecrypt(groupId: group_id, message: a_ctext, store: b_store, context: NullContext())
 
         XCTAssertEqual(b_ptext, [1, 2, 3])
     }

--- a/swift/Tests/SignalClientTests/SessionTests.swift
+++ b/swift/Tests/SignalClientTests/SessionTests.swift
@@ -15,13 +15,13 @@ class SessionTests: TestCaseBase {
 
         let bob_signed_pre_key_public = bob_signed_pre_key.publicKey.serialize()
 
-        let bob_identity_key = try! bob_store.identityKeyPair(context: nil).identityKey
-        let bob_signed_pre_key_signature = try! bob_store.identityKeyPair(context: nil).privateKey.generateSignature(message: bob_signed_pre_key_public)
+        let bob_identity_key = try! bob_store.identityKeyPair(context: NullContext()).identityKey
+        let bob_signed_pre_key_signature = try! bob_store.identityKeyPair(context: NullContext()).privateKey.generateSignature(message: bob_signed_pre_key_public)
 
         let prekey_id: UInt32 = 4570
         let signed_prekey_id: UInt32 = 3006
 
-        let bob_bundle = try! PreKeyBundle(registrationId: bob_store.localRegistrationId(context: nil),
+        let bob_bundle = try! PreKeyBundle(registrationId: bob_store.localRegistrationId(context: NullContext()),
                                            deviceId: 9,
                                            prekeyId: prekey_id,
                                            prekey: bob_pre_key.publicKey,
@@ -35,15 +35,15 @@ class SessionTests: TestCaseBase {
                                  for: bob_address,
                                  sessionStore: alice_store,
                                  identityStore: alice_store,
-                                 context: nil)
+                                 context: NullContext())
 
-        XCTAssertEqual(try! alice_store.loadSession(for: bob_address, context: nil)?.remoteRegistrationId(),
-                       try! bob_store.localRegistrationId(context: nil))
+        XCTAssertEqual(try! alice_store.loadSession(for: bob_address, context: NullContext())?.remoteRegistrationId(),
+                       try! bob_store.localRegistrationId(context: NullContext()))
 
         // Bob does the same:
         try! bob_store.storePreKey(PreKeyRecord(id: prekey_id, privateKey: bob_pre_key),
                                    id: prekey_id,
-                                   context: nil)
+                                   context: NullContext())
 
         try! bob_store.storeSignedPreKey(
             SignedPreKeyRecord(
@@ -53,7 +53,7 @@ class SessionTests: TestCaseBase {
                 signature: bob_signed_pre_key_signature
             ),
             id: signed_prekey_id,
-            context: nil)
+            context: NullContext())
     }
 
     func testSessionCipher() {
@@ -72,7 +72,7 @@ class SessionTests: TestCaseBase {
                                          for: bob_address,
                                          sessionStore: alice_store,
                                          identityStore: alice_store,
-                                         context: nil)
+                                         context: NullContext())
 
         XCTAssertEqual(ctext_a.messageType, .preKey)
 
@@ -84,7 +84,7 @@ class SessionTests: TestCaseBase {
                                                identityStore: bob_store,
                                                preKeyStore: bob_store,
                                                signedPreKeyStore: bob_store,
-                                               context: nil)
+                                               context: NullContext())
 
         XCTAssertEqual(ptext_a, ptext_b)
 
@@ -95,7 +95,7 @@ class SessionTests: TestCaseBase {
                                           for: alice_address,
                                           sessionStore: bob_store,
                                           identityStore: bob_store,
-                                          context: nil)
+                                          context: NullContext())
 
         XCTAssertEqual(ctext2_b.messageType, .whisper)
 
@@ -105,7 +105,7 @@ class SessionTests: TestCaseBase {
                                           from: bob_address,
                                           sessionStore: alice_store,
                                           identityStore: alice_store,
-                                          context: nil)
+                                          context: NullContext())
 
         XCTAssertEqual(ptext2_a, ptext2_b)
     }
@@ -126,7 +126,7 @@ class SessionTests: TestCaseBase {
                                                    uuidString: "9d0652a3-dcc3-4d11-975f-74d61598733f",
                                                    deviceId: 1)
         let sender_cert = try! SenderCertificate(sender: sender_addr,
-                                                 publicKey: alice_store.identityKeyPair(context: nil).publicKey,
+                                                 publicKey: alice_store.identityKeyPair(context: NullContext()).publicKey,
                                                  expiration: 31337,
                                                  signerCertificate: server_cert,
                                                  signerKey: server_keys.privateKey)
@@ -137,7 +137,7 @@ class SessionTests: TestCaseBase {
                                                  from: sender_cert,
                                                  sessionStore: alice_store,
                                                  identityStore: alice_store,
-                                                 context: nil)
+                                                 context: NullContext())
 
         let recipient_addr = try! SealedSenderAddress(e164: bob_address.name, uuidString: nil, deviceId: 1)
         let plaintext = try sealedSenderDecrypt(message: ciphertext,
@@ -148,7 +148,7 @@ class SessionTests: TestCaseBase {
                                                 identityStore: bob_store,
                                                 preKeyStore: bob_store,
                                                 signedPreKeyStore: bob_store,
-                                                context: nil)
+                                                context: NullContext())
 
         XCTAssertEqual(plaintext.message, message)
         XCTAssertEqual(plaintext.sender, sender_addr)


### PR DESCRIPTION
...instead of a bare UnsafeMutableRawPointer.

The "most correct" thing to do would be to have the context be an associated type of each store, and then clients would set them to the correct type, and they'd all have to be compatible when using multiple stores in an operation. However, this falls down in practice because Swift doesn't allow values to have protocol type for protocols with associated type, and the iOS framework SignalMetadataKit (and plenty of tests) do in fact want to reference the store types without having to use concrete types. Additionally, preserving that type through the C function shims used in each with*Store function would require a lot of extra work, since Swift generics are not monomorphized (resolved down to concrete types at compile time).

Instead, use a marker protocol, which is easier to work with than a pointer and less error-prone than Any.