### PR TITLE
Swift: Propagate callback errors directly

### DIFF
--- a/rust/bridge/ffi/src/util.rs
+++ b/rust/bridge/ffi/src/util.rs
@@ -22,7 +22,6 @@ pub enum SignalFfiError {
     NullPointer,
     InvalidUtf8String,
     UnexpectedPanic(std::boxed::Box<dyn std::any::Any + std::marker::Send>),
-    CallbackError(i32),
     InvalidType,
 }
 
@@ -70,7 +69,6 @@ impl From<&SignalFfiError> for SignalErrorCode {
             SignalFfiError::InvalidType => SignalErrorCode::InvalidType,
             SignalFfiError::UnexpectedPanic(_) => SignalErrorCode::InternalError,
 
-            SignalFfiError::CallbackError(_) => SignalErrorCode::CallbackError,
             SignalFfiError::InvalidUtf8String => SignalErrorCode::InvalidUtf8String,
             SignalFfiError::InsufficientOutputSize(_, _) => SignalErrorCode::InsufficientOutputSize,
 
@@ -150,6 +148,10 @@ impl From<&SignalFfiError> for SignalErrorCode {
             SignalFfiError::Signal(SignalProtocolError::InvalidArgument(_))
             | SignalFfiError::AesGcmSiv(_) => SignalErrorCode::InvalidArgument,
 
+            SignalFfiError::Signal(SignalProtocolError::ApplicationCallbackError(_, _)) => {
+                SignalErrorCode::CallbackError
+            }
+
             _ => SignalErrorCode::UnknownError,
         }
     }
@@ -159,9 +161,6 @@ impl fmt::Display for SignalFfiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             SignalFfiError::Signal(s) => write!(f, "{}", s),
-            SignalFfiError::CallbackError(c) => {
-                write!(f, "callback invocation returned error code {}", c)
-            }
             SignalFfiError::AesGcmSiv(c) => {
                 write!(f, "AES-GCM-SIV operation failed: {}", c)
             }

--- a/rust/bridge/jni/src/util.rs
+++ b/rust/bridge/jni/src/util.rs
@@ -26,7 +26,6 @@ pub enum SignalJniError {
     NullHandle,
     IntegerOverflow(String),
     UnexpectedPanic(std::boxed::Box<dyn std::any::Any + std::marker::Send>),
-    ExceptionDuringCallback(String),
 }
 
 impl SignalJniError {
@@ -48,9 +47,6 @@ impl fmt::Display for SignalJniError {
             SignalJniError::Signal(s) => write!(f, "{}", s),
             SignalJniError::AesGcmSiv(s) => write!(f, "{}", s),
             SignalJniError::Jni(s) => write!(f, "JNI error {}", s),
-            SignalJniError::ExceptionDuringCallback(s) => {
-                write!(f, "exception recieved during callback {}", s)
-            }
             SignalJniError::NullHandle => write!(f, "null handle"),
             SignalJniError::BadJniParameter(m) => write!(f, "bad parameter type {}", m),
             SignalJniError::UnexpectedJniResultType(m, t) => {
@@ -105,8 +101,6 @@ pub fn throw_error(env: &JNIEnv, error: SignalJniError) {
         SignalJniError::BadJniParameter(_) => "java/lang/AssertionError",
         SignalJniError::UnexpectedJniResultType(_, _) => "java/lang/AssertionError",
         SignalJniError::IntegerOverflow(_) => "java/lang/RuntimeException",
-
-        SignalJniError::ExceptionDuringCallback(_) => "java/lang/RuntimeException",
 
         SignalJniError::Signal(SignalProtocolError::DuplicatedMessage(_, _)) => {
             "org/whispersystems/libsignal/DuplicateMessageException"

--- a/rust/bridge/jni/src/util.rs
+++ b/rust/bridge/jni/src/util.rs
@@ -337,6 +337,25 @@ pub fn jlong_from_u64(value: Result<u64, SignalProtocolError>) -> Result<jlong, 
     }
 }
 
+#[derive(Debug)]
+struct ThrownException {
+    exn_type: Option<String>,
+    message: Option<String>,
+}
+
+impl fmt::Display for ThrownException {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let exn_type = self.exn_type.as_deref().unwrap_or("<unknown>");
+        if let Some(message) = &self.message {
+            write!(f, "exception {} \"{}\"", exn_type, message)
+        } else {
+            write!(f, "exception {}", exn_type)
+        }
+    }
+}
+
+impl std::error::Error for ThrownException {}
+
 pub fn call_method_with_exception_as_null<'a>(
     env: &JNIEnv<'a>,
     obj: impl Into<JObject<'a>>,
@@ -392,8 +411,12 @@ pub fn call_method_with_exception_as_null<'a>(
             if let JValue::Object(o) = jmessage {
                 let message: String = env.get_string(JString::from(o))?.into();
                 return Err(SignalJniError::Signal(
-                    SignalProtocolError::ApplicationCallbackThrewException(
-                        fn_name, exn_type, message,
+                    SignalProtocolError::ApplicationCallbackError(
+                        fn_name,
+                        Box::new(ThrownException {
+                            exn_type,
+                            message: Some(message),
+                        }),
                     ),
                 ));
             }
@@ -402,10 +425,12 @@ pub fn call_method_with_exception_as_null<'a>(
         env.exception_clear()?;
 
         return Err(SignalJniError::Signal(
-            SignalProtocolError::ApplicationCallbackThrewException(
+            SignalProtocolError::ApplicationCallbackError(
                 fn_name,
-                exn_type,
-                "<exception did not implement getMessage>".to_string(),
+                Box::new(ThrownException {
+                    exn_type,
+                    message: None,
+                }),
             ),
         ));
     }

--- a/swift/Tests/SignalClientTests/SessionTests.swift
+++ b/swift/Tests/SignalClientTests/SessionTests.swift
@@ -110,6 +110,43 @@ class SessionTests: TestCaseBase {
         XCTAssertEqual(ptext2_a, ptext2_b)
     }
 
+    func testSessionCipherWithBadStore() {
+        let alice_address = try! ProtocolAddress(name: "+14151111111", deviceId: 1)
+        let bob_address = try! ProtocolAddress(name: "+14151111112", deviceId: 1)
+
+        let alice_store = InMemorySignalProtocolStore()
+        let bob_store = BadStore()
+
+        initializeSessions(alice_store: alice_store, bob_store: bob_store, bob_address: bob_address)
+
+        // Alice sends a message:
+        let ptext_a: [UInt8] = [8, 6, 7, 5, 3, 0, 9]
+
+        let ctext_a = try! signalEncrypt(message: ptext_a,
+                                         for: bob_address,
+                                         sessionStore: alice_store,
+                                         identityStore: alice_store,
+                                         context: NullContext())
+
+        XCTAssertEqual(ctext_a.messageType, .preKey)
+
+        let ctext_b = try! PreKeySignalMessage(bytes: ctext_a.serialize())
+
+        XCTAssertThrowsError(try signalDecryptPreKey(message: ctext_b,
+                                                     from: alice_address,
+                                                     sessionStore: bob_store,
+                                                     identityStore: bob_store,
+                                                     preKeyStore: bob_store,
+                                                     signedPreKeyStore: bob_store,
+                                                     context: NullContext()),
+                             "should fail to decrypt") { error in
+            guard case BadStore.Error.badness = error else {
+                XCTFail("wrong error thrown: \(error)")
+                return
+            }
+        }
+    }
+
     func testSealedSenderSession() throws {
         let alice_address = try! ProtocolAddress(name: "+14151111111", deviceId: 1)
         let bob_address = try! ProtocolAddress(name: "+14151111112", deviceId: 1)
@@ -157,6 +194,7 @@ class SessionTests: TestCaseBase {
     static var allTests: [(String, (SessionTests) -> () throws -> Void)] {
         return [
             ("testSessionCipher", testSessionCipher),
+            ("testSessionCipherWithBadStore", testSessionCipherWithBadStore),
             ("testSealedSenderSession", testSealedSenderSession),
         ]
     }

--- a/swift/Tests/SignalClientTests/TestUtils.swift
+++ b/swift/Tests/SignalClientTests/TestUtils.swift
@@ -1,0 +1,15 @@
+//
+// Copyright 2020 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+@testable import SignalClient
+
+class BadStore: InMemorySignalProtocolStore {
+    enum Error: Swift.Error {
+        case badness
+    }
+    override func loadPreKey(id: UInt32, context: StoreContext) throws -> PreKeyRecord {
+        throw Error.badness
+    }
+}


### PR DESCRIPTION
This turned out to be easier to do in Swift than in Java, since we *already* have a Swift-side adapter that catches callback-thrown errors. I have the solution for Java too (#5), but that one's a Rust-side change on top of #76, so I'll put it up later.