### PR TITLE
Make most of Rust's SessionState pub(crate)

### DIFF
--- a/rust/bridge/ffi/src/lib.rs
+++ b/rust/bridge/ffi/src/lib.rs
@@ -272,7 +272,7 @@ ffi_fn_get_bytearray!(signal_session_record_serialize(SessionRecord) using
                       |s: &SessionRecord| s.serialize());
 
 ffi_fn_get_uint32!(signal_session_record_get_remote_registration_id(SessionRecord) using
-                   |s: &SessionRecord| s.session_state()?.remote_registration_id());
+                   SessionRecord::remote_registration_id);
 
 #[no_mangle]
 pub unsafe extern "C" fn signal_session_record_archive_current_state(

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -1711,10 +1711,7 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SessionRecord_1I
             *their_ratchet_key,
         );
 
-        let session = initialize_alice_session(&parameters, &mut csprng)?;
-
-        let record = SessionRecord::new(session);
-        box_object::<SessionRecord>(Ok(record))
+        box_object::<SessionRecord>(initialize_alice_session_record(&parameters, &mut csprng))
     })
 }
 
@@ -1761,10 +1758,7 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SessionRecord_1I
             *their_base_key,
         );
 
-        let session = initialize_bob_session(&parameters)?;
-
-        let record = SessionRecord::new(session);
-        box_object::<SessionRecord>(Ok(record))
+        box_object::<SessionRecord>(initialize_bob_session_record(&parameters))
     })
 }
 

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -1628,7 +1628,7 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SessionRecord_1G
 }
 
 jni_fn_get_jbytearray!(Java_org_signal_client_internal_Native_SessionRecord_1GetAliceBaseKey(SessionRecord) using
-                       |s: &SessionRecord| Ok(s.session_state()?.alice_base_key()?.to_vec()));
+                       |s: &SessionRecord| Ok(s.alice_base_key()?.to_vec()));
 
 jni_fn_get_jbytearray!(Java_org_signal_client_internal_Native_SessionRecord_1GetLocalIdentityKeyPublic(SessionRecord) using SessionRecord::local_identity_key_bytes);
 jni_fn_get_optional_jbytearray!(Java_org_signal_client_internal_Native_SessionRecord_1GetRemoteIdentityKeyPublic(SessionRecord) using SessionRecord::remote_identity_key_bytes);
@@ -1648,7 +1648,7 @@ jni_fn_get_jbytearray!(Java_org_signal_client_internal_Native_SessionState_1Seri
 
 // The following are just exposed to make it possible to retain some of the Java tests:
 
-jni_fn_get_jbytearray!(Java_org_signal_client_internal_Native_SessionRecord_1GetSenderChainKeyValue(SessionState) using SessionState::get_sender_chain_key_bytes);
+jni_fn_get_jbytearray!(Java_org_signal_client_internal_Native_SessionRecord_1GetSenderChainKeyValue(SessionRecord) using SessionRecord::get_sender_chain_key_bytes);
 
 #[no_mangle]
 pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SessionRecord_1GetReceiverChainKeyValue(
@@ -1658,10 +1658,10 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SessionRecord_1G
     key: ObjectHandle,
 ) -> jbyteArray {
     run_ffi_safe(&env, || {
-        let session_state = native_handle_cast::<SessionState>(session_state)?;
+        let session = native_handle_cast::<SessionRecord>(session_state)?;
         let sender = native_handle_cast::<PublicKey>(key)?;
 
-        let chain_key = session_state.get_receiver_chain_key(sender)?;
+        let chain_key = session.get_receiver_chain_key(sender)?;
 
         match chain_key {
             None => Ok(std::ptr::null_mut()),

--- a/rust/protocol/src/lib.rs
+++ b/rust/protocol/src/lib.rs
@@ -42,7 +42,7 @@ pub use {
         SenderKeyDistributionMessage, SenderKeyMessage, SignalMessage,
     },
     ratchet::{
-        are_we_alice, initialize_alice_session, initialize_bob_session,
+        are_we_alice, initialize_alice_session_record, initialize_bob_session_record,
         AliceSignalProtocolParameters, BobSignalProtocolParameters, ChainKey, MessageKeys, RootKey,
     },
     sealed_sender::{

--- a/rust/protocol/src/session_cipher.rs
+++ b/rust/protocol/src/session_cipher.rs
@@ -4,8 +4,8 @@
 //
 
 use crate::{
-    Context, IdentityKeyStore, PreKeyStore, ProtocolAddress, SessionRecord, SessionState,
-    SessionStore, SignalProtocolError, SignedPreKeyStore,
+    Context, IdentityKeyStore, PreKeyStore, ProtocolAddress, SessionRecord, SessionStore,
+    SignalProtocolError, SignedPreKeyStore,
 };
 
 use crate::consts::MAX_FORWARD_JUMPS;
@@ -15,6 +15,7 @@ use crate::error::Result;
 use crate::protocol::{CiphertextMessage, PreKeySignalMessage, SignalMessage};
 use crate::ratchet::{ChainKey, MessageKeys};
 use crate::session;
+use crate::state::SessionState;
 use crate::storage::Direction;
 
 use rand::{CryptoRng, Rng};

--- a/rust/protocol/tests/ratchet.rs
+++ b/rust/protocol/tests/ratchet.rs
@@ -48,29 +48,29 @@ fn test_ratcheting_session_as_bob() -> Result<(), SignalProtocolError> {
 
     let alice_base_public_key = PublicKey::deserialize(&alice_base_public)?;
 
-    let alice_identity_public = IdentityKey::decode(&alice_identity_public)?;
-
     let bob_parameters = BobSignalProtocolParameters::new(
         bob_identity_key_pair,
         bob_signed_prekey_pair,
         None, // one time pre key pair
         bob_ephemeral_pair,
-        alice_identity_public,
+        IdentityKey::decode(&alice_identity_public)?,
         alice_base_public_key,
     );
 
     let bob_session = initialize_bob_session(&bob_parameters)?;
 
+    let bob_record = SessionRecord::new(bob_session);
+
     assert_eq!(
-        bob_session.local_identity_key()?,
-        *bob_identity_key_pair.identity_key()
+        hex::encode(bob_record.local_identity_key_bytes()?),
+        hex::encode(bob_identity_public)
     );
     assert_eq!(
-        bob_session.remote_identity_key()?.unwrap(),
-        alice_identity_public
+        hex::encode(bob_record.remote_identity_key_bytes()?.unwrap()),
+        hex::encode(alice_identity_public)
     );
     assert_eq!(
-        hex::encode(bob_session.get_sender_chain_key()?.key()),
+        hex::encode(bob_record.get_sender_chain_key_bytes()?),
         expected_sender_chain
     );
 
@@ -115,14 +115,12 @@ fn test_ratcheting_session_as_alice() -> Result<(), SignalProtocolError> {
     let alice_identity_key_pair =
         IdentityKeyPair::new(alice_identity_key_public, alice_identity_key_private);
 
-    let bob_identity_public = IdentityKey::decode(&bob_identity_public)?;
-
     let alice_base_key = KeyPair::from_public_and_private(&alice_base_public, &alice_base_private)?;
 
     let alice_parameters = AliceSignalProtocolParameters::new(
         alice_identity_key_pair,
         alice_base_key,
-        bob_identity_public,
+        IdentityKey::decode(&bob_identity_public)?,
         bob_signed_prekey_public,
         None, // one-time prekey
         bob_ephemeral_public,
@@ -131,24 +129,20 @@ fn test_ratcheting_session_as_alice() -> Result<(), SignalProtocolError> {
     let mut csprng = rand::rngs::OsRng;
     let alice_session = initialize_alice_session(&alice_parameters, &mut csprng)?;
 
+    let alice_record = SessionRecord::new(alice_session);
+
     assert_eq!(
-        alice_session.local_identity_key()?,
-        *alice_identity_key_pair.identity_key()
+        hex::encode(alice_record.local_identity_key_bytes()?),
+        hex::encode(alice_identity_public),
     );
     assert_eq!(
-        alice_session.remote_identity_key()?.unwrap(),
-        bob_identity_public
+        hex::encode(alice_record.remote_identity_key_bytes()?.unwrap()),
+        hex::encode(bob_identity_public)
     );
 
     assert_eq!(
         hex::encode(
-            alice_session
-                .get_receiver_chain(&bob_ephemeral_public)?
-                .unwrap()
-                .0
-                .chain_key
-                .unwrap()
-                .key
+            alice_record.get_receiver_chain_key(&bob_ephemeral_public)?.unwrap().key()
         ),
         expected_receiver_chain
     );

--- a/rust/protocol/tests/ratchet.rs
+++ b/rust/protocol/tests/ratchet.rs
@@ -142,7 +142,10 @@ fn test_ratcheting_session_as_alice() -> Result<(), SignalProtocolError> {
 
     assert_eq!(
         hex::encode(
-            alice_record.get_receiver_chain_key(&bob_ephemeral_public)?.unwrap().key()
+            alice_record
+                .get_receiver_chain_key(&bob_ephemeral_public)?
+                .unwrap()
+                .key()
         ),
         expected_receiver_chain
     );

--- a/rust/protocol/tests/ratchet.rs
+++ b/rust/protocol/tests/ratchet.rs
@@ -57,9 +57,7 @@ fn test_ratcheting_session_as_bob() -> Result<(), SignalProtocolError> {
         alice_base_public_key,
     );
 
-    let bob_session = initialize_bob_session(&bob_parameters)?;
-
-    let bob_record = SessionRecord::new(bob_session);
+    let bob_record = initialize_bob_session_record(&bob_parameters)?;
 
     assert_eq!(
         hex::encode(bob_record.local_identity_key_bytes()?),
@@ -127,9 +125,7 @@ fn test_ratcheting_session_as_alice() -> Result<(), SignalProtocolError> {
     );
 
     let mut csprng = rand::rngs::OsRng;
-    let alice_session = initialize_alice_session(&alice_parameters, &mut csprng)?;
-
-    let alice_record = SessionRecord::new(alice_session);
+    let alice_record = initialize_alice_session_record(&alice_parameters, &mut csprng)?;
 
     assert_eq!(
         hex::encode(alice_record.local_identity_key_bytes()?),

--- a/rust/protocol/tests/session.rs
+++ b/rust/protocol/tests/session.rs
@@ -117,12 +117,7 @@ fn test_basic_prekey_v3() -> Result<(), SignalProtocolError> {
             bobs_session_with_alice.session_state()?.session_version()?,
             3
         );
-        assert_eq!(
-            bobs_session_with_alice
-                .alice_base_key()?
-                .len(),
-            32 + 1
-        );
+        assert_eq!(bobs_session_with_alice.alice_base_key()?.len(), 32 + 1);
 
         let bob_outgoing = encrypt(&mut bob_store, &alice_address, bobs_response).await?;
 

--- a/rust/protocol/tests/session.rs
+++ b/rust/protocol/tests/session.rs
@@ -65,7 +65,6 @@ fn test_basic_prekey_v3() -> Result<(), SignalProtocolError> {
                 .load_session(&bob_address, None)
                 .await?
                 .unwrap()
-                .session_state()?
                 .session_version()?,
             3
         );
@@ -120,7 +119,6 @@ fn test_basic_prekey_v3() -> Result<(), SignalProtocolError> {
         );
         assert_eq!(
             bobs_session_with_alice
-                .session_state()?
                 .alice_base_key()?
                 .len(),
             32 + 1
@@ -897,14 +895,12 @@ async fn is_session_id_equal(
         .load_session(bob_address, None)
         .await?
         .unwrap()
-        .session_state()?
         .alice_base_key()
         .clone()
         == bob_store
             .load_session(alice_address, None)
             .await?
             .unwrap()
-            .session_state()?
             .alice_base_key()
             .clone())
 }
@@ -985,7 +981,6 @@ fn basic_simultaneous_initiate() -> Result<(), SignalProtocolError> {
                 .load_session(&bob_address, None)
                 .await?
                 .unwrap()
-                .session_state()?
                 .session_version()?,
             3
         );
@@ -994,7 +989,6 @@ fn basic_simultaneous_initiate() -> Result<(), SignalProtocolError> {
                 .load_session(&alice_address, None)
                 .await?
                 .unwrap()
-                .session_state()?
                 .session_version()?,
             3
         );
@@ -1117,7 +1111,6 @@ fn simultaneous_initiate_with_lossage() -> Result<(), SignalProtocolError> {
                 .load_session(&bob_address, None)
                 .await?
                 .unwrap()
-                .session_state()?
                 .session_version()?,
             3
         );
@@ -1126,7 +1119,6 @@ fn simultaneous_initiate_with_lossage() -> Result<(), SignalProtocolError> {
                 .load_session(&alice_address, None)
                 .await?
                 .unwrap()
-                .session_state()?
                 .session_version()?,
             3
         );
@@ -1253,7 +1245,6 @@ fn simultaneous_initiate_lost_message() -> Result<(), SignalProtocolError> {
                 .load_session(&bob_address, None)
                 .await?
                 .unwrap()
-                .session_state()?
                 .session_version()?,
             3
         );
@@ -1262,7 +1253,6 @@ fn simultaneous_initiate_lost_message() -> Result<(), SignalProtocolError> {
                 .load_session(&alice_address, None)
                 .await?
                 .unwrap()
-                .session_state()?
                 .session_version()?,
             3
         );
@@ -1385,7 +1375,6 @@ fn simultaneous_initiate_repeated_messages() -> Result<(), SignalProtocolError> 
                     .load_session(&bob_address, None)
                     .await?
                     .unwrap()
-                    .session_state()?
                     .session_version()?,
                 3
             );
@@ -1394,7 +1383,6 @@ fn simultaneous_initiate_repeated_messages() -> Result<(), SignalProtocolError> 
                     .load_session(&alice_address, None)
                     .await?
                     .unwrap()
-                    .session_state()?
                     .session_version()?,
                 3
             );
@@ -1448,7 +1436,6 @@ fn simultaneous_initiate_repeated_messages() -> Result<(), SignalProtocolError> 
                     .load_session(&bob_address, None)
                     .await?
                     .unwrap()
-                    .session_state()?
                     .session_version()?,
                 3
             );
@@ -1457,7 +1444,6 @@ fn simultaneous_initiate_repeated_messages() -> Result<(), SignalProtocolError> 
                     .load_session(&alice_address, None)
                     .await?
                     .unwrap()
-                    .session_state()?
                     .session_version()?,
                 3
             );
@@ -1595,7 +1581,6 @@ fn simultaneous_initiate_lost_message_repeated_messages() -> Result<(), SignalPr
                     .load_session(&bob_address, None)
                     .await?
                     .unwrap()
-                    .session_state()?
                     .session_version()?,
                 3
             );
@@ -1604,7 +1589,6 @@ fn simultaneous_initiate_lost_message_repeated_messages() -> Result<(), SignalPr
                     .load_session(&alice_address, None)
                     .await?
                     .unwrap()
-                    .session_state()?
                     .session_version()?,
                 3
             );
@@ -1658,7 +1642,6 @@ fn simultaneous_initiate_lost_message_repeated_messages() -> Result<(), SignalPr
                     .load_session(&bob_address, None)
                     .await?
                     .unwrap()
-                    .session_state()?
                     .session_version()?,
                 3
             );
@@ -1667,7 +1650,6 @@ fn simultaneous_initiate_lost_message_repeated_messages() -> Result<(), SignalPr
                     .load_session(&alice_address, None)
                     .await?
                     .unwrap()
-                    .session_state()?
                     .session_version()?,
                 3
             );

--- a/rust/protocol/tests/session.rs
+++ b/rust/protocol/tests/session.rs
@@ -656,18 +656,14 @@ fn optional_one_time_prekey() -> Result<(), SignalProtocolError> {
 #[test]
 fn basic_session_v3() -> Result<(), SignalProtocolError> {
     let (alice_session, bob_session) = initialize_sessions_v3()?;
-    let alice_session_record = SessionRecord::new(alice_session);
-    let bob_session_record = SessionRecord::new(bob_session);
-    run_session_interaction(alice_session_record, bob_session_record)?;
+    run_session_interaction(alice_session, bob_session)?;
     Ok(())
 }
 
 #[test]
 fn message_key_limits() -> Result<(), SignalProtocolError> {
     block_on(async {
-        let (alice_session, bob_session) = initialize_sessions_v3()?;
-        let alice_session_record = SessionRecord::new(alice_session);
-        let bob_session_record = SessionRecord::new(bob_session);
+        let (alice_session_record, bob_session_record) = initialize_sessions_v3()?;
 
         let alice_address = ProtocolAddress::new("+14159999999".to_owned(), 1);
         let bob_address = ProtocolAddress::new("+14158888888".to_owned(), 1);

--- a/rust/protocol/tests/support/mod.rs
+++ b/rust/protocol/tests/support/mod.rs
@@ -107,7 +107,7 @@ pub async fn create_pre_key_bundle<R: Rng + CryptoRng>(
 }
 
 #[allow(dead_code)]
-pub fn initialize_sessions_v3() -> Result<(SessionState, SessionState), SignalProtocolError> {
+pub fn initialize_sessions_v3() -> Result<(SessionRecord, SessionRecord), SignalProtocolError> {
     let mut csprng = OsRng;
     let alice_identity = IdentityKeyPair::generate(&mut csprng);
     let bob_identity = IdentityKeyPair::generate(&mut csprng);
@@ -126,7 +126,7 @@ pub fn initialize_sessions_v3() -> Result<(SessionState, SessionState), SignalPr
         bob_ephemeral_key.public_key,
     );
 
-    let alice_session = initialize_alice_session(&alice_params, &mut csprng)?;
+    let alice_session = initialize_alice_session_record(&alice_params, &mut csprng)?;
 
     let bob_params = BobSignalProtocolParameters::new(
         bob_identity,
@@ -137,7 +137,7 @@ pub fn initialize_sessions_v3() -> Result<(SessionState, SessionState), SignalPr
         alice_base_key.public_key,
     );
 
-    let bob_session = initialize_bob_session(&bob_params)?;
+    let bob_session = initialize_bob_session_record(&bob_params)?;
 
     Ok((alice_session, bob_session))
 }


### PR DESCRIPTION
Remove some functions which were not used within the crate or the bindings.

Also fix some type errors in the JNI binding (introduced in #107) - SessionState was being used instead of SessionRecord, and this happened to work because the first element of a SessionRecord is an `Option<SessionState>`

End goal is removing `SessionState` from the crate exports entirely but we need to do a new release and update Android first.