### PR TITLE
Hide more of the Rust API

### DIFF
--- a/rust/protocol/src/lib.rs
+++ b/rust/protocol/src/lib.rs
@@ -56,7 +56,6 @@ pub use {
     session::*,
     session_cipher::{
         message_decrypt, message_decrypt_prekey, message_decrypt_signal, message_encrypt,
-        remote_registration_id, session_version,
     },
     state::{PreKeyBundle, PreKeyRecord, SessionRecord, SessionState, SignedPreKeyRecord},
     storage::{

--- a/rust/protocol/src/lib.rs
+++ b/rust/protocol/src/lib.rs
@@ -43,7 +43,7 @@ pub use {
     },
     ratchet::{
         initialize_alice_session_record, initialize_bob_session_record,
-        AliceSignalProtocolParameters, BobSignalProtocolParameters
+        AliceSignalProtocolParameters, BobSignalProtocolParameters,
     },
     sealed_sender::{
         sealed_sender_decrypt, sealed_sender_decrypt_to_usmc, sealed_sender_encrypt,

--- a/rust/protocol/src/lib.rs
+++ b/rust/protocol/src/lib.rs
@@ -50,9 +50,7 @@ pub use {
         SealedSenderDecryptionResult, SenderCertificate, ServerCertificate,
         UnidentifiedSenderMessage, UnidentifiedSenderMessageContent,
     },
-    sender_keys::{
-        SenderChainKey, SenderKeyName, SenderKeyRecord, SenderKeyState, SenderMessageKey,
-    },
+    sender_keys::{SenderKeyName, SenderKeyRecord},
     session::{process_prekey, process_prekey_bundle},
     session_cipher::{
         message_decrypt, message_decrypt_prekey, message_decrypt_signal, message_encrypt,

--- a/rust/protocol/src/lib.rs
+++ b/rust/protocol/src/lib.rs
@@ -42,8 +42,8 @@ pub use {
         SenderKeyDistributionMessage, SenderKeyMessage, SignalMessage,
     },
     ratchet::{
-        are_we_alice, initialize_alice_session_record, initialize_bob_session_record,
-        AliceSignalProtocolParameters, BobSignalProtocolParameters, ChainKey, MessageKeys, RootKey,
+        initialize_alice_session_record, initialize_bob_session_record,
+        AliceSignalProtocolParameters, BobSignalProtocolParameters
     },
     sealed_sender::{
         sealed_sender_decrypt, sealed_sender_decrypt_to_usmc, sealed_sender_encrypt,

--- a/rust/protocol/src/lib.rs
+++ b/rust/protocol/src/lib.rs
@@ -53,7 +53,7 @@ pub use {
     sender_keys::{
         SenderChainKey, SenderKeyName, SenderKeyRecord, SenderKeyState, SenderMessageKey,
     },
-    session::*,
+    session::{process_prekey, process_prekey_bundle},
     session_cipher::{
         message_decrypt, message_decrypt_prekey, message_decrypt_signal, message_encrypt,
     },

--- a/rust/protocol/src/ratchet.rs
+++ b/rust/protocol/src/ratchet.rs
@@ -161,7 +161,3 @@ pub fn initialize_bob_session_record(
 ) -> Result<SessionRecord> {
     Ok(SessionRecord::new(initialize_bob_session(parameters)?))
 }
-
-pub fn are_we_alice(our_key: &curve::PublicKey, their_key: &curve::PublicKey) -> bool {
-    our_key.serialize() < their_key.serialize()
-}

--- a/rust/protocol/src/session_cipher.rs
+++ b/rust/protocol/src/session_cipher.rs
@@ -333,30 +333,6 @@ fn decrypt_message_with_state<R: Rng + CryptoRng>(
     Ok(ptext)
 }
 
-pub async fn remote_registration_id(
-    remote_address: &ProtocolAddress,
-    session_store: &mut dyn SessionStore,
-    ctx: Context,
-) -> Result<u32> {
-    let session_record = session_store
-        .load_session(&remote_address, ctx)
-        .await?
-        .ok_or(SignalProtocolError::SessionNotFound)?;
-    session_record.session_state()?.remote_registration_id()
-}
-
-pub async fn session_version(
-    remote_address: &ProtocolAddress,
-    session_store: &mut dyn SessionStore,
-    ctx: Context,
-) -> Result<u32> {
-    let session_record = session_store
-        .load_session(&remote_address, ctx)
-        .await?
-        .ok_or(SignalProtocolError::SessionNotFound)?;
-    session_record.session_state()?.session_version()
-}
-
 fn get_or_create_chain_key<R: Rng + CryptoRng>(
     state: &mut SessionState,
     their_ephemeral: &curve::PublicKey,


### PR DESCRIPTION
Hide some things that were exported to be used during intermediate steps of the JNI conversion (ChainKey, etc) and also some functions which were exposed but never needed by anything.