### PR TITLE
Bump the Java version number

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -1,5 +1,5 @@
 subprojects {
-    ext.version_number     = "0.1.5"
+    ext.version_number     = "0.2.0"
     ext.group_info         = "org.whispersystems"
 
     if (JavaVersion.current().isJava8Compatible()) {


### PR DESCRIPTION
Arbitrarily bumping the minor version to signify more notable changes than prior versions, eg

- Sealed sender now in Rust
- Removed protobufs from Java
- Partial removal of SessionState from Java
- Adding AES-GCM-SIV