### PR TITLE
Propagate callback exceptions/errors when they fail the whole operation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,6 +848,7 @@ dependencies = [
  "jni",
  "libc",
  "libsignal-protocol-rust",
+ "log",
  "paste",
 ]
 

--- a/java/tests/src/test/java/org/whispersystems/libsignal/SessionBuilderTest.java
+++ b/java/tests/src/test/java/org/whispersystems/libsignal/SessionBuilderTest.java
@@ -293,8 +293,7 @@ public class SessionBuilderTest extends TestCase {
       plaintext = bobSessionCipher.decrypt(incomingMessage);
       throw new AssertionError("Decrypt should have failed!");
     } catch (InvalidKeyIdException e) {
-      // Note: This is the message coming from libsignal-client, NOT from TestNoSignedPreKeysStore.
-      assertEquals("invalid signed prekey identifier", e.getMessage());
+      assertEquals("TestNoSignedPreKeysStore rejected loading 22", e.getMessage());
     }
   }
 
@@ -335,10 +334,8 @@ public class SessionBuilderTest extends TestCase {
       throw new AssertionError("Decrypt should have failed!");
     } catch (InvalidKeyIdException e) {
       throw new AssertionError("libsignal-client swallowed the exception");
-    } catch (RuntimeException e) {
-      assertEquals("exception thrown while calling 'loadSignedPreKey'", e.getMessage());
-      assertNotNull(e.getCause());
-      assertTrue(e.getCause() instanceof TestBadSignedPreKeysStore.CustomException);
+    } catch (TestBadSignedPreKeysStore.CustomException e) {
+      // success!
     }
   }
 

--- a/java/tests/src/test/java/org/whispersystems/libsignal/TestBadSignedPreKeysStore.java
+++ b/java/tests/src/test/java/org/whispersystems/libsignal/TestBadSignedPreKeysStore.java
@@ -1,0 +1,17 @@
+package org.whispersystems.libsignal;
+
+import org.whispersystems.libsignal.InvalidKeyIdException;
+import org.whispersystems.libsignal.state.SignedPreKeyRecord;
+
+public class TestBadSignedPreKeysStore extends TestInMemorySignalProtocolStore {
+  public static class CustomException extends RuntimeException {
+    CustomException(String message) {
+      super(message);
+    }
+  }
+
+  @Override
+  public SignedPreKeyRecord loadSignedPreKey(int signedPreKeyId) throws InvalidKeyIdException {
+    throw new CustomException("TestBadSignedPreKeysStore rejected loading " + signedPreKeyId);
+  }
+}

--- a/rust/bridge/ffi/src/lib.rs
+++ b/rust/bridge/ffi/src/lib.rs
@@ -12,6 +12,7 @@ use libsignal_protocol_rust::*;
 use static_assertions::const_assert_eq;
 use std::convert::TryFrom;
 use std::ffi::{c_void, CString};
+use std::fmt;
 
 use aes_gcm_siv::Aes256GcmSiv;
 
@@ -747,6 +748,26 @@ impl FfiIdentityKeyStore {
     }
 }
 
+#[derive(Debug)]
+struct CallbackError {
+    value: std::num::NonZeroI32,
+}
+
+impl CallbackError {
+    fn check(value: i32) -> Option<Self> {
+        let value = std::num::NonZeroI32::try_from(value).ok()?;
+        Some(Self { value })
+    }
+}
+
+impl fmt::Display for CallbackError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "error code {}", self.value)
+    }
+}
+
+impl std::error::Error for CallbackError {}
+
 #[async_trait(?Send)]
 impl IdentityKeyStore for FfiIdentityKeyStore {
     async fn get_identity_key_pair(
@@ -757,13 +778,11 @@ impl IdentityKeyStore for FfiIdentityKeyStore {
         let mut key = std::ptr::null_mut();
         let result = (self.store.get_identity_key_pair)(self.store.ctx, &mut key, ctx);
 
-        if result != 0 {
-            return Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError(
-                    "get_identity_key_pair",
-                    result,
-                ),
-            );
+        if let Some(error) = CallbackError::check(result) {
+            return Err(SignalProtocolError::ApplicationCallbackError(
+                "get_identity_key_pair",
+                Box::new(error),
+            ));
         }
 
         if key.is_null() {
@@ -781,13 +800,11 @@ impl IdentityKeyStore for FfiIdentityKeyStore {
         let mut id = 0;
         let result = (self.store.get_local_registration_id)(self.store.ctx, &mut id, ctx);
 
-        if result != 0 {
-            return Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError(
-                    "get_local_registration_id",
-                    result,
-                ),
-            );
+        if let Some(error) = CallbackError::check(result) {
+            return Err(SignalProtocolError::ApplicationCallbackError(
+                "get_local_registration_id",
+                Box::new(error),
+            ));
         }
 
         Ok(id)
@@ -806,9 +823,10 @@ impl IdentityKeyStore for FfiIdentityKeyStore {
         match result {
             0 => Ok(false),
             1 => Ok(true),
-            r => Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError("save_identity", r),
-            ),
+            r => Err(SignalProtocolError::ApplicationCallbackError(
+                "save_identity",
+                Box::new(CallbackError::check(r).unwrap()),
+            )),
         }
     }
 
@@ -835,12 +853,10 @@ impl IdentityKeyStore for FfiIdentityKeyStore {
         match result {
             0 => Ok(false),
             1 => Ok(true),
-            r => Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError(
-                    "is_trusted_identity",
-                    r,
-                ),
-            ),
+            r => Err(SignalProtocolError::ApplicationCallbackError(
+                "is_trusted_identity",
+                Box::new(CallbackError::check(r).unwrap()),
+            )),
         }
     }
 
@@ -853,13 +869,11 @@ impl IdentityKeyStore for FfiIdentityKeyStore {
         let mut key = std::ptr::null_mut();
         let result = (self.store.get_identity)(self.store.ctx, &mut key, &*address, ctx);
 
-        if result != 0 {
-            return Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError(
-                    "get_identity",
-                    result,
-                ),
-            );
+        if let Some(error) = CallbackError::check(result) {
+            return Err(SignalProtocolError::ApplicationCallbackError(
+                "get_identity",
+                Box::new(error),
+            ));
         }
 
         if key.is_null() {
@@ -918,13 +932,11 @@ impl PreKeyStore for FfiPreKeyStore {
         let mut record = std::ptr::null_mut();
         let result = (self.store.load_pre_key)(self.store.ctx, &mut record, prekey_id, ctx);
 
-        if result != 0 {
-            return Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError(
-                    "load_pre_key",
-                    result,
-                ),
-            );
+        if let Some(error) = CallbackError::check(result) {
+            return Err(SignalProtocolError::ApplicationCallbackError(
+                "load_pre_key",
+                Box::new(error),
+            ));
         }
 
         if record.is_null() {
@@ -944,13 +956,11 @@ impl PreKeyStore for FfiPreKeyStore {
         let ctx = ctx.unwrap_or(std::ptr::null_mut());
         let result = (self.store.store_pre_key)(self.store.ctx, prekey_id, &*record, ctx);
 
-        if result != 0 {
-            return Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError(
-                    "store_pre_key",
-                    result,
-                ),
-            );
+        if let Some(error) = CallbackError::check(result) {
+            return Err(SignalProtocolError::ApplicationCallbackError(
+                "store_pre_key",
+                Box::new(error),
+            ));
         }
 
         Ok(())
@@ -964,13 +974,11 @@ impl PreKeyStore for FfiPreKeyStore {
         let ctx = ctx.unwrap_or(std::ptr::null_mut());
         let result = (self.store.remove_pre_key)(self.store.ctx, prekey_id, ctx);
 
-        if result != 0 {
-            return Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError(
-                    "remove_pre_key",
-                    result,
-                ),
-            );
+        if let Some(error) = CallbackError::check(result) {
+            return Err(SignalProtocolError::ApplicationCallbackError(
+                "remove_pre_key",
+                Box::new(error),
+            ));
         }
 
         Ok(())
@@ -1021,13 +1029,11 @@ impl SignedPreKeyStore for FfiSignedPreKeyStore {
         let mut record = std::ptr::null_mut();
         let result = (self.store.load_signed_pre_key)(self.store.ctx, &mut record, prekey_id, ctx);
 
-        if result != 0 {
-            return Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError(
-                    "load_signed_pre_key",
-                    result,
-                ),
-            );
+        if let Some(error) = CallbackError::check(result) {
+            return Err(SignalProtocolError::ApplicationCallbackError(
+                "load_signed_pre_key",
+                Box::new(error),
+            ));
         }
 
         if record.is_null() {
@@ -1048,13 +1054,11 @@ impl SignedPreKeyStore for FfiSignedPreKeyStore {
         let ctx = ctx.unwrap_or(std::ptr::null_mut());
         let result = (self.store.store_signed_pre_key)(self.store.ctx, prekey_id, &*record, ctx);
 
-        if result != 0 {
-            return Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError(
-                    "store_signed_pre_key",
-                    result,
-                ),
-            );
+        if let Some(error) = CallbackError::check(result) {
+            return Err(SignalProtocolError::ApplicationCallbackError(
+                "store_signed_pre_key",
+                Box::new(error),
+            ));
         }
 
         Ok(())
@@ -1105,13 +1109,11 @@ impl SessionStore for FfiSessionStore {
         let mut record = std::ptr::null_mut();
         let result = (self.store.load_session)(self.store.ctx, &mut record, &*address, ctx);
 
-        if result != 0 {
-            return Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError(
-                    "load_session",
-                    result,
-                ),
-            );
+        if let Some(error) = CallbackError::check(result) {
+            return Err(SignalProtocolError::ApplicationCallbackError(
+                "load_session",
+                Box::new(error),
+            ));
         }
 
         if record.is_null() {
@@ -1132,13 +1134,11 @@ impl SessionStore for FfiSessionStore {
         let ctx = ctx.unwrap_or(std::ptr::null_mut());
         let result = (self.store.store_session)(self.store.ctx, &*address, &*record, ctx);
 
-        if result != 0 {
-            return Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError(
-                    "store_session",
-                    result,
-                ),
-            );
+        if let Some(error) = CallbackError::check(result) {
+            return Err(SignalProtocolError::ApplicationCallbackError(
+                "store_session",
+                Box::new(error),
+            ));
         }
 
         Ok(())
@@ -1365,13 +1365,11 @@ impl SenderKeyStore for FfiSenderKeyStore {
         let result =
             (self.store.store_sender_key)(self.store.ctx, &*sender_key_name, &*record, ctx);
 
-        if result != 0 {
-            return Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError(
-                    "store_sender_key",
-                    result,
-                ),
-            );
+        if let Some(error) = CallbackError::check(result) {
+            return Err(SignalProtocolError::ApplicationCallbackError(
+                "store_sender_key",
+                Box::new(error),
+            ));
         }
 
         Ok(())
@@ -1387,13 +1385,11 @@ impl SenderKeyStore for FfiSenderKeyStore {
         let result =
             (self.store.load_sender_key)(self.store.ctx, &mut record, &*sender_key_name, ctx);
 
-        if result != 0 {
-            return Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError(
-                    "load_sender_key",
-                    result,
-                ),
-            );
+        if let Some(error) = CallbackError::check(result) {
+            return Err(SignalProtocolError::ApplicationCallbackError(
+                "load_sender_key",
+                Box::new(error),
+            ));
         }
 
         if record.is_null() {

--- a/rust/bridge/ffi/src/util.rs
+++ b/rust/bridge/ffi/src/util.rs
@@ -58,7 +58,6 @@ impl From<&SignalFfiError> for SignalErrorCode {
             SignalFfiError::InvalidType => SignalErrorCode::InvalidType,
             SignalFfiError::UnexpectedPanic(_) => SignalErrorCode::InternalError,
 
-            SignalFfiError::CallbackError(_) => SignalErrorCode::CallbackError,
             SignalFfiError::InvalidUtf8String => SignalErrorCode::InvalidUtf8String,
             SignalFfiError::InsufficientOutputSize(_, _) => SignalErrorCode::InsufficientOutputSize,
 
@@ -137,6 +136,10 @@ impl From<&SignalFfiError> for SignalErrorCode {
 
             SignalFfiError::Signal(SignalProtocolError::InvalidArgument(_))
             | SignalFfiError::AesGcmSiv(_) => SignalErrorCode::InvalidArgument,
+
+            SignalFfiError::Signal(SignalProtocolError::ApplicationCallbackError(_, _)) => {
+                SignalErrorCode::CallbackError
+            }
 
             _ => SignalErrorCode::UnknownError,
         }

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -919,7 +919,7 @@ impl<'a> JniPreKeyStore<'a> {
             &callback_args,
             callback_sig,
             "loadPreKey",
-            Some("org/whispersystems/libsignal/InvalidKeyIdException"),
+            None,
         )?;
         match pk {
             Some(pk) => Ok(pk),
@@ -1020,7 +1020,7 @@ impl<'a> JniSignedPreKeyStore<'a> {
             &callback_args,
             callback_sig,
             "loadSignedPreKey",
-            Some("org/whispersystems/libsignal/InvalidKeyIdException"),
+            None,
         )?;
         match spk {
             Some(spk) => Ok(spk),

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -919,7 +919,6 @@ impl<'a> JniPreKeyStore<'a> {
             &callback_args,
             callback_sig,
             "loadPreKey",
-            None,
         )?;
         match pk {
             Some(pk) => Ok(pk),
@@ -1020,7 +1019,6 @@ impl<'a> JniSignedPreKeyStore<'a> {
             &callback_args,
             callback_sig,
             "loadSignedPreKey",
-            None,
         )?;
         match spk {
             Some(spk) => Ok(spk),
@@ -1107,7 +1105,6 @@ impl<'a> JniSessionStore<'a> {
             &callback_args,
             callback_sig,
             "loadSession",
-            None,
         )
     }
 
@@ -1354,7 +1351,6 @@ impl<'a> JniSenderKeyStore<'a> {
             &callback_args,
             callback_sig,
             "loadSenderKey",
-            None,
         )?;
 
         Ok(skr)

--- a/rust/bridge/jni/src/util.rs
+++ b/rust/bridge/jni/src/util.rs
@@ -111,16 +111,8 @@ pub fn get_object_with_native_handle<T: 'static + Clone>(
     callback_args: &[JValue],
     callback_sig: &'static str,
     callback_fn: &'static str,
-    exception_to_treat_as_none: Option<&'static str>,
 ) -> Result<Option<T>, SignalJniError> {
-    let rvalue = call_method_with_exception_as_null(
-        env,
-        store_obj,
-        callback_fn,
-        callback_sig,
-        &callback_args,
-        exception_to_treat_as_none,
-    )?;
+    let rvalue = call_method_checked(env, store_obj, callback_fn, callback_sig, &callback_args)?;
 
     let obj = match rvalue {
         JValue::Object(o) => *o,

--- a/rust/bridge/jni/src/util.rs
+++ b/rust/bridge/jni/src/util.rs
@@ -5,11 +5,10 @@
 
 use futures::pin_mut;
 use futures::task::noop_waker_ref;
-use jni::objects::{JObject, JString, JThrowable, JValue};
+use jni::objects::{JObject, JValue};
 use jni::sys::{jint, jlong, jobject};
 use jni::JNIEnv;
 use std::convert::TryFrom;
-use std::fmt;
 use std::future::Future;
 use std::task::{self, Poll};
 
@@ -86,117 +85,6 @@ pub fn jlong_from_u64(value: Result<u64, SignalProtocolError>) -> Result<jlong, 
         }
         Err(e) => Err(SignalJniError::Signal(e)),
     }
-}
-
-#[derive(Debug)]
-struct ThrownException {
-    exn_type: Option<String>,
-    message: Option<String>,
-}
-
-impl fmt::Display for ThrownException {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let exn_type = self.exn_type.as_deref().unwrap_or("<unknown>");
-        if let Some(message) = &self.message {
-            write!(f, "exception {} \"{}\"", exn_type, message)
-        } else {
-            write!(f, "exception {}", exn_type)
-        }
-    }
-}
-
-impl std::error::Error for ThrownException {}
-
-pub fn call_method_with_exception_as_null<'a>(
-    env: &JNIEnv<'a>,
-    obj: impl Into<JObject<'a>>,
-    fn_name: &'static str,
-    sig: &'static str,
-    args: &[JValue<'_>],
-    exception_to_treat_as_null: Option<&'static str>,
-) -> Result<JValue<'a>, SignalJniError> {
-    // Note that we are *not* unwrapping the result yet!
-    // We need to check for exceptions *first*.
-    let result = env.call_method(obj, fn_name, sig, args);
-
-    fn exception_class_name(env: &JNIEnv, exn: JThrowable) -> Result<String, SignalJniError> {
-        let class_type = env.call_method(exn, "getClass", "()Ljava/lang/Class;", &[])?;
-        if let JValue::Object(class_type) = class_type {
-            let class_name =
-                env.call_method(class_type, "getCanonicalName", "()Ljava/lang/String;", &[])?;
-
-            if let JValue::Object(class_name) = class_name {
-                let class_name: String = env.get_string(JString::from(class_name))?.into();
-                Ok(class_name)
-            } else {
-                Err(SignalJniError::UnexpectedJniResultType(
-                    "getCanonicalName",
-                    class_name.type_name(),
-                ))
-            }
-        } else {
-            Err(SignalJniError::UnexpectedJniResultType(
-                "getClass",
-                class_type.type_name(),
-            ))
-        }
-    }
-
-    if env.exception_check()? {
-        let throwable = env.exception_occurred()?;
-        env.exception_clear()?;
-
-        if let Some(exception_to_treat_as_null) = exception_to_treat_as_null {
-            if env.is_instance_of(throwable, exception_to_treat_as_null)? {
-                return Ok(JValue::Object(JObject::null()));
-            }
-        }
-
-        let getmessage_sig = "()Ljava/lang/String;";
-
-        let exn_type = exception_class_name(env, throwable).ok();
-        // Clear again in case we got an exception looking up the class name.
-        env.exception_clear()?;
-
-        if let Ok(jmessage) = env.call_method(throwable, "getMessage", getmessage_sig, &[]) {
-            if let JValue::Object(o) = jmessage {
-                let message: String = env.get_string(JString::from(o))?.into();
-                return Err(SignalJniError::Signal(
-                    SignalProtocolError::ApplicationCallbackError(
-                        fn_name,
-                        Box::new(ThrownException {
-                            exn_type,
-                            message: Some(message),
-                        }),
-                    ),
-                ));
-            }
-        }
-        // Clear *again* in case we got an exception reading the message.
-        env.exception_clear()?;
-
-        return Err(SignalJniError::Signal(
-            SignalProtocolError::ApplicationCallbackError(
-                fn_name,
-                Box::new(ThrownException {
-                    exn_type,
-                    message: None,
-                }),
-            ),
-        ));
-    }
-
-    Ok(result?)
-}
-
-pub fn call_method_checked<'a>(
-    env: &JNIEnv<'a>,
-    obj: impl Into<JObject<'a>>,
-    fn_name: &'static str,
-    sig: &'static str,
-    args: &[JValue<'_>],
-) -> Result<JValue<'a>, SignalJniError> {
-    call_method_with_exception_as_null(env, obj, fn_name, sig, args, None)
 }
 
 pub fn check_jobject_type(

--- a/rust/bridge/shared/Cargo.toml
+++ b/rust/bridge/shared/Cargo.toml
@@ -13,6 +13,7 @@ license = "AGPL-3.0-only"
 [dependencies]
 libsignal-protocol-rust = { path = "../../protocol" }
 aes-gcm-siv = { path = "../../aes-gcm-siv" }
+log = "0.4.11"
 paste = "1.0"
 
 libc = { version = "0.2", optional = true }

--- a/rust/bridge/shared/src/ffi/error.rs
+++ b/rust/bridge/shared/src/ffi/error.rs
@@ -16,7 +16,6 @@ pub enum SignalFfiError {
     NullPointer,
     InvalidUtf8String,
     UnexpectedPanic(std::boxed::Box<dyn std::any::Any + std::marker::Send>),
-    CallbackError(i32),
     InvalidType,
 }
 
@@ -24,9 +23,6 @@ impl fmt::Display for SignalFfiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             SignalFfiError::Signal(s) => write!(f, "{}", s),
-            SignalFfiError::CallbackError(c) => {
-                write!(f, "callback invocation returned error code {}", c)
-            }
             SignalFfiError::AesGcmSiv(c) => {
                 write!(f, "AES-GCM-SIV operation failed: {}", c)
             }

--- a/rust/bridge/shared/src/jni/error.rs
+++ b/rust/bridge/shared/src/jni/error.rs
@@ -3,10 +3,14 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+use jni::objects::{GlobalRef, JObject, JString, JThrowable, JValue};
+use jni::{JNIEnv, JavaVM};
 use std::fmt;
 
 use aes_gcm_siv::Error as AesGcmSivError;
 use libsignal_protocol_rust::*;
+
+use super::*;
 
 #[derive(Debug)]
 pub enum SignalJniError {
@@ -76,3 +80,95 @@ impl From<SignalJniError> for SignalProtocolError {
         }
     }
 }
+
+pub struct ThrownException {
+    jvm: JavaVM,
+    exception_ref: GlobalRef,
+}
+
+impl ThrownException {
+    pub fn as_obj(&self) -> JThrowable {
+        self.exception_ref.as_obj().into()
+    }
+
+    pub fn new<'a>(env: &JNIEnv<'a>, throwable: JThrowable<'a>) -> Result<Self, SignalJniError> {
+        assert!(**throwable != *JObject::null());
+        Ok(Self {
+            jvm: env.get_java_vm()?,
+            exception_ref: env.new_global_ref(throwable)?,
+        })
+    }
+
+    pub fn class_name(&self, env: &JNIEnv) -> Result<String, SignalJniError> {
+        let class_type = env.get_object_class(self.exception_ref.as_obj())?;
+        let class_name = call_method_checked(
+            env,
+            class_type,
+            "getCanonicalName",
+            "()Ljava/lang/String;",
+            &[],
+        )?;
+
+        if let JValue::Object(class_name) = class_name {
+            let class_name: String = env.get_string(JString::from(class_name))?.into();
+            Ok(class_name)
+        } else {
+            Err(SignalJniError::UnexpectedJniResultType(
+                "getCanonicalName",
+                class_name.type_name(),
+            ))
+        }
+    }
+
+    pub fn message(&self, env: &JNIEnv) -> Result<String, SignalJniError> {
+        let message = call_method_checked(
+            env,
+            self.exception_ref.as_obj(),
+            "getMessage",
+            "()Ljava/lang/String;",
+            &[],
+        )?;
+        if let JValue::Object(message) = message {
+            Ok(env.get_string(JString::from(message))?.into())
+        } else {
+            Err(SignalJniError::UnexpectedJniResultType(
+                "getMessage",
+                message.type_name(),
+            ))
+        }
+    }
+}
+
+impl fmt::Display for ThrownException {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let env = &self.jvm.attach_current_thread().map_err(|_| fmt::Error)?;
+
+        let exn_type = self.class_name(env);
+        let exn_type = exn_type.as_deref().unwrap_or("<unknown>");
+
+        if let Ok(message) = self.message(env) {
+            write!(f, "exception {} \"{}\"", exn_type, message)
+        } else {
+            write!(f, "exception {}", exn_type)
+        }
+    }
+}
+
+impl fmt::Debug for ThrownException {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let env = &self.jvm.attach_current_thread().map_err(|_| fmt::Error)?;
+
+        let exn_type = self.class_name(env);
+        let exn_type = exn_type.as_deref().unwrap_or("<unknown>");
+
+        let obj_addr = *self.exception_ref.as_obj();
+
+        if let Ok(message) = self.message(env) {
+            write!(f, "exception {} ({:p}) \"{}\"", exn_type, obj_addr, message)
+        } else {
+            write!(f, "exception {} ({:p})", exn_type, obj_addr)
+        }
+    }
+}
+
+impl std::error::Error for ThrownException {}

--- a/rust/bridge/shared/src/jni/error.rs
+++ b/rust/bridge/shared/src/jni/error.rs
@@ -22,7 +22,6 @@ pub enum SignalJniError {
     NullHandle,
     IntegerOverflow(String),
     UnexpectedPanic(std::boxed::Box<dyn std::any::Any + std::marker::Send>),
-    ExceptionDuringCallback(String),
 }
 
 impl fmt::Display for SignalJniError {
@@ -31,9 +30,6 @@ impl fmt::Display for SignalJniError {
             SignalJniError::Signal(s) => write!(f, "{}", s),
             SignalJniError::AesGcmSiv(s) => write!(f, "{}", s),
             SignalJniError::Jni(s) => write!(f, "JNI error {}", s),
-            SignalJniError::ExceptionDuringCallback(s) => {
-                write!(f, "exception recieved during callback {}", s)
-            }
             SignalJniError::NullHandle => write!(f, "null handle"),
             SignalJniError::BadJniParameter(m) => write!(f, "bad parameter type {}", m),
             SignalJniError::UnexpectedJniResultType(m, t) => {

--- a/rust/bridge/shared/src/jni/error.rs
+++ b/rust/bridge/shared/src/jni/error.rs
@@ -21,19 +21,6 @@ pub enum SignalJniError {
     ExceptionDuringCallback(String),
 }
 
-impl SignalJniError {
-    pub fn to_signal_protocol_error(&self) -> SignalProtocolError {
-        match self {
-            SignalJniError::Signal(e) => e.clone(),
-            SignalJniError::Jni(e) => SignalProtocolError::FfiBindingError(e.to_string()),
-            SignalJniError::BadJniParameter(m) => {
-                SignalProtocolError::InvalidArgument(m.to_string())
-            }
-            _ => SignalProtocolError::FfiBindingError(format!("{}", self)),
-        }
-    }
-}
-
 impl fmt::Display for SignalJniError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {

--- a/rust/bridge/shared/src/jni/mod.rs
+++ b/rust/bridge/shared/src/jni/mod.rs
@@ -47,8 +47,6 @@ fn throw_error(env: &JNIEnv, error: SignalJniError) {
         SignalJniError::UnexpectedJniResultType(_, _) => "java/lang/AssertionError",
         SignalJniError::IntegerOverflow(_) => "java/lang/RuntimeException",
 
-        SignalJniError::ExceptionDuringCallback(_) => "java/lang/RuntimeException",
-
         SignalJniError::Signal(SignalProtocolError::DuplicatedMessage(_, _)) => {
             "org/whispersystems/libsignal/DuplicateMessageException"
         }

--- a/rust/protocol/tests/groups.rs
+++ b/rust/protocol/tests/groups.rs
@@ -305,10 +305,10 @@ fn group_basic_ratchet() -> Result<(), SignalProtocolError> {
             group_decrypt(&alice_ciphertext1, &mut bob_store, &group_sender, None).await?;
         assert_eq!(String::from_utf8(bob_plaintext1).unwrap(), "swim camp");
 
-        assert_eq!(
+        assert!(matches!(
             group_decrypt(&alice_ciphertext1, &mut bob_store, &group_sender, None).await,
             Err(SignalProtocolError::DuplicatedMessage(1, 0))
-        );
+        ));
 
         let bob_plaintext3 =
             group_decrypt(&alice_ciphertext3, &mut bob_store, &group_sender, None).await?;

--- a/rust/protocol/tests/sealed_sender.rs
+++ b/rust/protocol/tests/sealed_sender.rs
@@ -23,7 +23,7 @@ fn test_server_cert() -> Result<(), SignalProtocolError> {
 
     let recovered = ServerCertificate::deserialize(&serialized)?;
 
-    assert_eq!(recovered.validate(&trust_root.public_key), Ok(true));
+    assert_eq!(recovered.validate(&trust_root.public_key)?, true);
 
     let mut cert_data = serialized.clone();
     let cert_bits = cert_data.len() * 8;
@@ -35,7 +35,7 @@ fn test_server_cert() -> Result<(), SignalProtocolError> {
 
         match cert {
             Ok(cert) => {
-                assert_eq!(cert.validate(&trust_root.public_key), Ok(false));
+                assert_eq!(cert.validate(&trust_root.public_key)?, false);
             }
             Err(e) => match e {
                 SignalProtocolError::InvalidProtobufEncoding
@@ -76,13 +76,10 @@ fn test_sender_cert() -> Result<(), SignalProtocolError> {
         &mut rng,
     )?;
 
+    assert_eq!(sender_cert.validate(&trust_root.public_key, expires)?, true);
     assert_eq!(
-        sender_cert.validate(&trust_root.public_key, expires),
-        Ok(true)
-    );
-    assert_eq!(
-        sender_cert.validate(&trust_root.public_key, expires + 1),
-        Ok(false)
+        sender_cert.validate(&trust_root.public_key, expires + 1)?,
+        false
     ); // expired
 
     let mut sender_cert_data = sender_cert.serialized()?.to_vec();
@@ -95,7 +92,7 @@ fn test_sender_cert() -> Result<(), SignalProtocolError> {
 
         match cert {
             Ok(cert) => {
-                assert_eq!(cert.validate(&trust_root.public_key, expires), Ok(false));
+                assert_eq!(cert.validate(&trust_root.public_key, expires)?, false);
             }
             Err(e) => match e {
                 SignalProtocolError::InvalidProtobufEncoding

--- a/rust/protocol/tests/session.rs
+++ b/rust/protocol/tests/session.rs
@@ -190,12 +190,12 @@ fn test_basic_prekey_v3() -> Result<(), SignalProtocolError> {
 
         let outgoing_message = encrypt(&mut alice_store, &bob_address, original_message).await?;
 
-        assert_eq!(
+        assert!(matches!(
             decrypt(&mut bob_store, &alice_address, &outgoing_message)
                 .await
                 .unwrap_err(),
-            SignalProtocolError::UntrustedIdentity(alice_address.clone())
-        );
+            SignalProtocolError::UntrustedIdentity(a) if a == alice_address
+        ));
 
         assert_eq!(
             bob_store
@@ -553,10 +553,10 @@ fn bad_message_bundle() -> Result<(), SignalProtocolError> {
         let ptext = decrypt(&mut bob_store, &alice_address, &incoming_message).await?;
 
         assert_eq!(String::from_utf8(ptext).unwrap(), original_message);
-        assert_eq!(
+        assert!(matches!(
             bob_store.get_pre_key(pre_key_id, None).await.unwrap_err(),
             SignalProtocolError::InvalidPreKeyId
-        );
+        ));
 
         Ok(())
     })
@@ -703,7 +703,10 @@ fn message_key_limits() -> Result<(), SignalProtocolError> {
         let err = decrypt(&mut bob_store, &alice_address, &inflight[5])
             .await
             .unwrap_err();
-        assert_eq!(err, SignalProtocolError::DuplicatedMessage(2300, 5));
+        assert!(matches!(
+            err,
+            SignalProtocolError::DuplicatedMessage(2300, 5)
+        ));
         Ok(())
     })
 }
@@ -880,14 +883,12 @@ async fn is_session_id_equal(
         .load_session(bob_address, None)
         .await?
         .unwrap()
-        .alice_base_key()
-        .clone()
+        .alice_base_key()?
         == bob_store
             .load_session(alice_address, None)
             .await?
             .unwrap()
-            .alice_base_key()
-            .clone())
+            .alice_base_key()?)
 }
 
 #[test]

--- a/swift/.swiftlint.yml
+++ b/swift/.swiftlint.yml
@@ -5,6 +5,7 @@ disabled_rules:
 - function_parameter_count
 - identifier_name
 - line_length
+- redundant_optional_initialization
 - trailing_comma
 - type_body_length
 opt_in_rules:

--- a/swift/Tests/SignalClientTests/TestUtils.swift
+++ b/swift/Tests/SignalClientTests/TestUtils.swift
@@ -1,0 +1,15 @@
+//
+// Copyright 2020 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+@testable import SignalClient
+
+class BadStore: InMemorySignalProtocolStore {
+    enum Error: Swift.Error {
+        case badness
+    }
+    override func loadPreKey(id: UInt32, context: StoreContext) throws -> PreKeyRecord {
+        throw Error.badness
+    }
+}


### PR DESCRIPTION
Resolves #5, as well as providing the equivalent feature for Swift.