### PR TITLE
Support generic bridge functions for FFI/JNI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,6 +845,7 @@ name = "libsignal-bridge"
 version = "0.1.0"
 dependencies = [
  "aes-gcm-siv",
+ "futures",
  "jni",
  "libc",
  "libsignal-protocol-rust",
@@ -858,7 +859,6 @@ version = "0.1.0"
 dependencies = [
  "aes-gcm-siv",
  "async-trait",
- "futures",
  "libc",
  "libsignal-bridge",
  "libsignal-protocol-rust",
@@ -873,7 +873,6 @@ version = "0.1.0"
 dependencies = [
  "aes-gcm-siv",
  "async-trait",
- "futures",
  "jni",
  "libsignal-bridge",
  "libsignal-protocol-rust",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,6 +858,7 @@ dependencies = [
 name = "libsignal-bridge-macros"
 version = "0.1.0"
 dependencies = [
+ "heck",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,6 +862,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+ "syn-mid",
  "unzip3",
 ]
 
@@ -1631,6 +1632,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "syn-mid"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baa8e7560a164edb1621a55d18a0c59abf49d360f47aa7b821061dd7eea7fac9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,9 +848,20 @@ dependencies = [
  "futures",
  "jni",
  "libc",
+ "libsignal-bridge-macros",
  "libsignal-protocol-rust",
  "log",
  "paste",
+]
+
+[[package]]
+name = "libsignal-bridge-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unzip3",
 ]
 
 [[package]]
@@ -1750,6 +1761,12 @@ dependencies = [
  "generic-array",
  "subtle",
 ]
+
+[[package]]
+name = "unzip3"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99c0ec316ab08201476c032feb2f94a5c8ece5b209765c1fbc4430dd6e931ad6"
 
 [[package]]
 name = "ureq"

--- a/java/java/src/main/java/org/signal/internal/Native.java
+++ b/java/java/src/main/java/org/signal/internal/Native.java
@@ -86,7 +86,7 @@ public final class Native {
   public static native void ECPublicKey_Destroy(long handle);
   public static native byte[] ECPublicKey_GetPublicKeyBytes(long handle);
   public static native byte[] ECPublicKey_Serialize(long handle);
-  public static native boolean ECPublicKey_Verify(long handle, byte[] message, byte[] signature);
+  public static native boolean ECPublicKey_Verify(long key, byte[] message, byte[] signature);
 
   public static native byte[] GroupCipher_DecryptMessage(long senderKeyName, byte[] message, SenderKeyStore store);
   public static native byte[] GroupCipher_EncryptMessage(long senderKeyName, byte[] message, SenderKeyStore store);

--- a/java/java/src/main/java/org/signal/internal/Native.java
+++ b/java/java/src/main/java/org/signal/internal/Native.java
@@ -133,7 +133,7 @@ public final class Native {
   public static native byte[] PreKeySignalMessage_GetSignalMessage(long handle);
   public static native int PreKeySignalMessage_GetSignedPreKeyId(long handle);
   public static native int PreKeySignalMessage_GetVersion(long handle);
-  public static native long PreKeySignalMessage_New(int messageVersion, int registrationId, int preKeyId, int signedPreKeyId, long baseKeyHandle, long identityKeyHandle, long signalMessageHandle);
+  public static native long PreKeySignalMessage_New(int messageVersion, int registrationId, int preKeyId, int signedPreKeyId, long baseKey, long identityKey, long signalMessage);
 
   public static native void ProtocolAddress_Destroy(long handle);
   public static native int ProtocolAddress_DeviceId(long handle);
@@ -230,7 +230,7 @@ public final class Native {
   public static native byte[] SignalMessage_GetSenderRatchetKey(long handle);
   public static native byte[] SignalMessage_GetSerialized(long handle);
   public static native long SignalMessage_New(int messageVersion, byte[] macKey, long senderRatchetKey, int counter, int previousCounter, byte[] ciphertext, long senderIdentityKey, long receiverIdentityKey);
-  public static native boolean SignalMessage_VerifyMac(long handle, long senderIdentityKey, long receiverIdentityKey, byte[] macKey);
+  public static native boolean SignalMessage_VerifyMac(long msg, long senderIdentityKey, long receiverIdentityKey, byte[] macKey);
 
   public static native long SignedPreKeyRecord_Deserialize(byte[] data);
   public static native void SignedPreKeyRecord_Destroy(long handle);

--- a/rust/bridge/ffi/Cargo.toml
+++ b/rust/bridge/ffi/Cargo.toml
@@ -20,7 +20,6 @@ aes-gcm-siv = { path = "../../aes-gcm-siv" }
 libsignal-bridge = { path = "../shared", features = ["ffi"] }
 async-trait = "0.1.41"
 libc = "0.2"
-futures = "0.3.7"
 rand = "0.7.3"
 static_assertions = "1.1"
 log = "0.4.11"

--- a/rust/bridge/ffi/src/lib.rs
+++ b/rust/bridge/ffi/src/lib.rs
@@ -117,25 +117,6 @@ ffi_fn_get_uint32!(signal_address_get_device_id(ProtocolAddress) using
 ffi_fn_clone!(signal_address_clone clones ProtocolAddress);
 
 #[no_mangle]
-pub unsafe extern "C" fn signal_publickey_compare(
-    result: *mut i32,
-    key1: *const PublicKey,
-    key2: *const PublicKey,
-) -> *mut SignalFfiError {
-    run_ffi_safe(|| {
-        let key1 = native_handle_cast::<PublicKey>(key1)?;
-        let key2 = native_handle_cast::<PublicKey>(key2)?;
-
-        *result = match key1.cmp(&key2) {
-            std::cmp::Ordering::Less => -1,
-            std::cmp::Ordering::Equal => 0,
-            std::cmp::Ordering::Greater => 1,
-        };
-        Ok(())
-    })
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn signal_publickey_verify(
     key: *const PublicKey,
     result: *mut bool,

--- a/rust/bridge/ffi/src/lib.rs
+++ b/rust/bridge/ffi/src/lib.rs
@@ -116,26 +116,6 @@ ffi_fn_get_uint32!(signal_address_get_device_id(ProtocolAddress) using
 
 ffi_fn_clone!(signal_address_clone clones ProtocolAddress);
 
-#[no_mangle]
-pub unsafe extern "C" fn signal_publickey_verify(
-    key: *const PublicKey,
-    result: *mut bool,
-    message: *const c_uchar,
-    message_len: size_t,
-    signature: *const c_uchar,
-    signature_len: size_t,
-) -> *mut SignalFfiError {
-    run_ffi_safe(|| {
-        *result = false; // pre-set to invalid state
-        let key = native_handle_cast::<PublicKey>(key)?;
-        let message = as_slice(message, message_len)?;
-        let signature = as_slice(signature, signature_len)?;
-
-        *result = key.verify_signature(&message, &signature)?;
-        Ok(())
-    })
-}
-
 ffi_fn_clone!(signal_publickey_clone clones PublicKey);
 
 #[no_mangle]

--- a/rust/bridge/ffi/src/lib.rs
+++ b/rust/bridge/ffi/src/lib.rs
@@ -111,18 +111,6 @@ pub unsafe extern "C" fn signal_hkdf_derive(
     })
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn signal_address_new(
-    address: *mut *mut ProtocolAddress,
-    name: *const c_char,
-    device_id: c_uint,
-) -> *mut SignalFfiError {
-    run_ffi_safe(|| {
-        let name = read_c_string(name)?;
-        box_object(address, Ok(ProtocolAddress::new(name, device_id)))
-    })
-}
-
 ffi_fn_get_uint32!(signal_address_get_device_id(ProtocolAddress) using
                    |obj: &ProtocolAddress| { Ok(obj.device_id()) });
 

--- a/rust/bridge/ffi/src/lib.rs
+++ b/rust/bridge/ffi/src/lib.rs
@@ -213,22 +213,6 @@ pub unsafe extern "C" fn signal_session_record_archive_current_state(
 ffi_fn_clone!(signal_session_record_clone clones SessionRecord);
 
 #[no_mangle]
-pub unsafe extern "C" fn signal_fingerprint_format(
-    fprint: *mut *const c_char,
-    local: *const c_uchar,
-    local_len: size_t,
-    remote: *const c_uchar,
-    remote_len: size_t,
-) -> *mut SignalFfiError {
-    run_ffi_safe(|| {
-        let local = as_slice(local, local_len)?;
-        let remote = as_slice(remote, remote_len)?;
-        let fingerprint = DisplayableFingerprint::new(&local, &remote).map(|f| format!("{}", f));
-        write_cstr_to(fprint, fingerprint)
-    })
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn signal_fingerprint_new(
     obj: *mut *mut Fingerprint,
     iterations: c_uint,
@@ -261,27 +245,6 @@ pub unsafe extern "C" fn signal_fingerprint_new(
 }
 
 ffi_fn_clone!(signal_fingerprint_clone clones Fingerprint);
-
-#[no_mangle]
-pub unsafe extern "C" fn signal_fingerprint_compare(
-    result: *mut bool,
-    fprint1: *const c_uchar,
-    fprint1_len: size_t,
-    fprint2: *const c_uchar,
-    fprint2_len: size_t,
-) -> *mut SignalFfiError {
-    run_ffi_safe(|| {
-        if fprint1.is_null() || fprint2.is_null() || result.is_null() {
-            return Err(SignalFfiError::NullPointer);
-        }
-        let fprint1 = as_slice(fprint1, fprint1_len)?;
-        let fprint2 = as_slice(fprint2, fprint2_len)?;
-
-        let fprint1 = ScannableFingerprint::deserialize(&fprint1)?;
-        *result = fprint1.compare(&fprint2)?;
-        Ok(())
-    })
-}
 
 #[no_mangle]
 pub unsafe extern "C" fn signal_message_new(

--- a/rust/bridge/ffi/src/util.rs
+++ b/rust/bridge/ffi/src/util.rs
@@ -3,14 +3,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use futures::pin_mut;
-use futures::task::noop_waker_ref;
 use libc::{c_char, c_uchar, c_uint, c_ulonglong, size_t};
 use libsignal_bridge::ffi::*;
 use libsignal_protocol_rust::*;
 use std::ffi::CStr;
-use std::future::Future;
-use std::task::{self, Poll};
 
 use aes_gcm_siv::Error as AesGcmSivError;
 
@@ -143,15 +139,6 @@ impl From<&SignalFfiError> for SignalErrorCode {
 
             _ => SignalErrorCode::UnknownError,
         }
-    }
-}
-
-#[track_caller]
-pub fn expect_ready<F: Future>(future: F) -> F::Output {
-    pin_mut!(future);
-    match future.poll(&mut task::Context::from_waker(noop_waker_ref())) {
-        Poll::Ready(result) => result,
-        Poll::Pending => panic!("future was not ready"),
     }
 }
 

--- a/rust/bridge/jni/Cargo.toml
+++ b/rust/bridge/jni/Cargo.toml
@@ -21,6 +21,5 @@ libsignal-protocol-rust = { path = "../../protocol" }
 aes-gcm-siv = { path = "../../aes-gcm-siv" }
 libsignal-bridge = { path = "../shared", features = ["jni"] }
 async-trait = "0.1.41"
-futures = "0.3.7"
 jni = "0.17"
 rand = "0.7.3"

--- a/rust/bridge/jni/bin/gen_java_decl.py
+++ b/rust/bridge/jni/bin/gen_java_decl.py
@@ -35,7 +35,11 @@ cbindgen = subprocess.Popen(['cbindgen'], cwd=os.path.join(our_abs_dir, '..'), s
 stdout = str(stdout.decode('utf8'))
 stderr = str(stderr.decode('utf8'))
 
-ignore_this_warning = re.compile(r"WARN: Can't find .*\. This usually means that this type was incompatible or not found\.")
+ignore_this_warning = re.compile(
+    "("
+    r"WARN: Can't find .*\. This usually means that this type was incompatible or not found\.|"
+    r"WARN: Missing `\[defines\]` entry for `feature = \"jni\"` in cbindgen config\."
+    ")")
 
 unknown_warning = False
 

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -201,113 +201,11 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_HKDF_1DeriveSecr
     })
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SignalMessage_1New(
-    env: JNIEnv,
-    _class: JClass,
-    message_version: jint,
-    mac_key: jbyteArray,
-    sender_ratchet_key: ObjectHandle,
-    counter: jint,
-    previous_counter: jint,
-    ciphertext: jbyteArray,
-    sender_identity_key: ObjectHandle,
-    receiver_identity_key: ObjectHandle,
-) -> ObjectHandle {
-    run_ffi_safe(&env, || {
-        let message_version = jint_to_u8(message_version)?;
-        let mac_key = env.convert_byte_array(mac_key)?;
-        let sender_ratchet_key = native_handle_cast::<PublicKey>(sender_ratchet_key)?;
-        let counter = jint_to_u32(counter)?;
-        let previous_counter = jint_to_u32(previous_counter)?;
-        let ciphertext = env.convert_byte_array(ciphertext)?;
-
-        let sender_identity_key = native_handle_cast::<PublicKey>(sender_identity_key)?;
-        let receiver_identity_key = native_handle_cast::<PublicKey>(receiver_identity_key)?;
-
-        let msg = SignalMessage::new(
-            message_version,
-            &mac_key,
-            *sender_ratchet_key,
-            counter,
-            previous_counter,
-            &ciphertext,
-            &IdentityKey::new(*sender_identity_key),
-            &IdentityKey::new(*receiver_identity_key),
-        )?;
-
-        box_object::<SignalMessage>(Ok(msg))
-    })
-}
-
 jni_fn_get_jint!(Java_org_signal_client_internal_Native_SignalMessage_1GetMessageVersion(SignalMessage) using
                  |msg: &SignalMessage| { Ok(msg.message_version() as u32) });
 
 jni_fn_get_jint!(Java_org_signal_client_internal_Native_SignalMessage_1GetCounter(SignalMessage) using
                  |msg: &SignalMessage| { Ok(msg.counter()) });
-
-#[no_mangle]
-pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SignalMessage_1VerifyMac(
-    env: JNIEnv,
-    _class: JClass,
-    handle: ObjectHandle,
-    sender_identity_key: ObjectHandle,
-    receiver_identity_key: ObjectHandle,
-    mac_key: jbyteArray,
-) -> jboolean {
-    run_ffi_safe(&env, || {
-        let msg = native_handle_cast::<SignalMessage>(handle)?;
-        let sender_identity_key = native_handle_cast::<PublicKey>(sender_identity_key)?;
-        let receiver_identity_key = native_handle_cast::<PublicKey>(receiver_identity_key)?;
-        let mac_key = env.convert_byte_array(mac_key)?;
-
-        let valid = msg.verify_mac(
-            &IdentityKey::new(*sender_identity_key),
-            &IdentityKey::new(*receiver_identity_key),
-            &mac_key,
-        )?;
-
-        Ok(valid as jboolean)
-    })
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn Java_org_signal_client_internal_Native_PreKeySignalMessage_1New(
-    env: JNIEnv,
-    _class: JClass,
-    message_version: jint,
-    registration_id: jint,
-    pre_key_id: jint,
-    signed_pre_key_id: jint,
-    base_key_handle: ObjectHandle,
-    identity_key_handle: ObjectHandle,
-    signal_message_handle: ObjectHandle,
-) -> ObjectHandle {
-    run_ffi_safe(&env, || {
-        let message_version = message_version as u8;
-        let registration_id = jint_to_u32(registration_id)?;
-        let pre_key_id = if pre_key_id < 0 {
-            None
-        } else {
-            Some(jint_to_u32(pre_key_id)?)
-        };
-        let signed_pre_key_id = jint_to_u32(signed_pre_key_id)?;
-        let base_key = native_handle_cast::<PublicKey>(base_key_handle)?;
-        let identity_key = native_handle_cast::<PublicKey>(identity_key_handle)?;
-        let signal_message = native_handle_cast::<SignalMessage>(signal_message_handle)?;
-
-        let msg = PreKeySignalMessage::new(
-            message_version,
-            registration_id,
-            pre_key_id,
-            signed_pre_key_id,
-            *base_key,
-            IdentityKey::new(*identity_key),
-            signal_message.clone(),
-        );
-        box_object::<PreKeySignalMessage>(msg)
-    })
-}
 
 jni_fn_get_jint!(Java_org_signal_client_internal_Native_PreKeySignalMessage_1GetVersion(PreKeySignalMessage) using
                  |m: &PreKeySignalMessage| Ok(m.message_version() as u32));

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -26,21 +26,6 @@ type JavaSignedPreKeyStore = jobject;
 type JavaCiphertextMessage = jobject;
 type JavaSenderKeyStore = jobject;
 
-#[no_mangle]
-pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ProtocolAddress_1New(
-    env: JNIEnv,
-    _class: JClass,
-    name: JString,
-    device_id: jint,
-) -> ObjectHandle {
-    run_ffi_safe(&env, || {
-        let name: String = env.get_string(name)?.into();
-        let device_id = jint_to_u32(device_id)?;
-        let address = ProtocolAddress::new(name, device_id);
-        box_object::<ProtocolAddress>(Ok(address))
-    })
-}
-
 jni_fn_get_jint!(Java_org_signal_client_internal_Native_ProtocolAddress_1DeviceId(ProtocolAddress) using
                  |obj: &ProtocolAddress| { Ok(obj.device_id()) });
 

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -45,25 +45,6 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ECPublicKey_1Des
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ECPublicKey_1Compare(
-    env: JNIEnv,
-    _class: JClass,
-    key1: ObjectHandle,
-    key2: ObjectHandle,
-) -> jint {
-    run_ffi_safe(&env, || {
-        let key1 = native_handle_cast::<PublicKey>(key1)?;
-        let key2 = native_handle_cast::<PublicKey>(key2)?;
-
-        match key1.cmp(&key2) {
-            std::cmp::Ordering::Less => Ok(-1),
-            std::cmp::Ordering::Equal => Ok(0),
-            std::cmp::Ordering::Greater => Ok(1),
-        }
-    })
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ECPublicKey_1Verify(
     env: JNIEnv,
     _class: JClass,

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -7,7 +7,7 @@
 
 use async_trait::async_trait;
 use jni::objects::{JClass, JObject, JString, JValue};
-use jni::sys::{jboolean, jbyteArray, jint, jlong, jlongArray, jobject, jstring};
+use jni::sys::{jboolean, jbyteArray, jint, jlong, jlongArray, jobject};
 use jni::JNIEnv;
 use std::convert::TryFrom;
 
@@ -127,22 +127,6 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_IdentityKeyPair_
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Java_org_signal_client_internal_Native_DisplayableFingerprint_1Format(
-    env: JNIEnv,
-    _class: JClass,
-    local: jbyteArray,
-    remote: jbyteArray,
-) -> jstring {
-    run_ffi_safe(&env, || {
-        let local = env.convert_byte_array(local)?;
-        let remote = env.convert_byte_array(remote)?;
-        let fingerprint = DisplayableFingerprint::new(&local, &remote)?;
-        let result = env.new_string(format!("{}", fingerprint))?;
-        Ok(result.into_inner())
-    })
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn Java_org_signal_client_internal_Native_NumericFingerprintGenerator_1New(
     env: JNIEnv,
     _class: JClass,
@@ -175,22 +159,6 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_NumericFingerpri
         )?;
 
         box_object::<Fingerprint>(Ok(fprint))
-    })
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ScannableFingerprint_1Compare(
-    env: JNIEnv,
-    _class: JClass,
-    fprint1: jbyteArray,
-    fprint2: jbyteArray,
-) -> jboolean {
-    run_ffi_safe(&env, || {
-        let fprint1 = env.convert_byte_array(fprint1)?;
-        let fprint2 = env.convert_byte_array(fprint2)?;
-
-        let fprint1 = ScannableFingerprint::deserialize(&fprint1)?;
-        Ok(fprint1.compare(&fprint2)? as jboolean)
     })
 }
 

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -45,22 +45,6 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ECPublicKey_1Des
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ECPublicKey_1Verify(
-    env: JNIEnv,
-    _class: JClass,
-    handle: ObjectHandle,
-    message: jbyteArray,
-    signature: jbyteArray,
-) -> jboolean {
-    run_ffi_safe(&env, || {
-        let key = native_handle_cast::<PublicKey>(handle)?;
-        let message = env.convert_byte_array(message)?;
-        let signature = env.convert_byte_array(signature)?;
-        Ok(key.verify_signature(&message, &signature)? as jboolean)
-    })
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ECPrivateKey_1Generate(
     env: JNIEnv,
     _class: JClass,

--- a/rust/bridge/jni/src/util.rs
+++ b/rust/bridge/jni/src/util.rs
@@ -21,13 +21,6 @@ pub unsafe fn native_handle_cast_optional<T>(
     Ok(Some(&mut *(handle as *mut T)))
 }
 
-pub fn jint_to_u32(v: jint) -> Result<u32, SignalJniError> {
-    if v < 0 {
-        return Err(SignalJniError::IntegerOverflow(format!("{} to u32", v)));
-    }
-    Ok(v as u32)
-}
-
 pub fn jlong_to_u64(v: jlong) -> Result<u64, SignalJniError> {
     if v < 0 {
         return Err(SignalJniError::IntegerOverflow(format!("{} to u64", v)));

--- a/rust/bridge/jni/src/util.rs
+++ b/rust/bridge/jni/src/util.rs
@@ -6,7 +6,6 @@
 use jni::objects::{JObject, JValue};
 use jni::sys::{jint, jlong, jobject};
 use jni::JNIEnv;
-use std::convert::TryFrom;
 
 use libsignal_bridge::jni::*;
 use libsignal_protocol_rust::SignalProtocolError;
@@ -26,13 +25,6 @@ pub fn jlong_to_u64(v: jlong) -> Result<u64, SignalJniError> {
         return Err(SignalJniError::IntegerOverflow(format!("{} to u64", v)));
     }
     Ok(v as u64)
-}
-
-pub fn jint_to_u8(v: jint) -> Result<u8, SignalJniError> {
-    match u8::try_from(v) {
-        Err(_) => Err(SignalJniError::IntegerOverflow(format!("{} to u8", v))),
-        Ok(v) => Ok(v),
-    }
 }
 
 pub fn jint_from_u32(value: Result<u32, SignalProtocolError>) -> Result<jint, SignalJniError> {

--- a/rust/bridge/jni/src/util.rs
+++ b/rust/bridge/jni/src/util.rs
@@ -3,14 +3,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use futures::pin_mut;
-use futures::task::noop_waker_ref;
 use jni::objects::{JObject, JValue};
 use jni::sys::{jint, jlong, jobject};
 use jni::JNIEnv;
 use std::convert::TryFrom;
-use std::future::Future;
-use std::task::{self, Poll};
 
 use libsignal_bridge::jni::*;
 use libsignal_protocol_rust::SignalProtocolError;
@@ -23,15 +19,6 @@ pub unsafe fn native_handle_cast_optional<T>(
     }
 
     Ok(Some(&mut *(handle as *mut T)))
-}
-
-#[track_caller]
-pub fn expect_ready<F: Future>(future: F) -> F::Output {
-    pin_mut!(future);
-    match future.poll(&mut task::Context::from_waker(noop_waker_ref())) {
-        Poll::Ready(result) => result,
-        Poll::Pending => panic!("future was not ready"),
-    }
 }
 
 pub fn jint_to_u32(v: jint) -> Result<u32, SignalJniError> {

--- a/rust/bridge/shared/Cargo.toml
+++ b/rust/bridge/shared/Cargo.toml
@@ -13,6 +13,7 @@ license = "AGPL-3.0-only"
 [dependencies]
 libsignal-protocol-rust = { path = "../../protocol" }
 aes-gcm-siv = { path = "../../aes-gcm-siv" }
+libsignal-bridge-macros = { path = "macros" }
 futures = "0.3.7"
 log = "0.4.11"
 paste = "1.0"

--- a/rust/bridge/shared/Cargo.toml
+++ b/rust/bridge/shared/Cargo.toml
@@ -13,6 +13,7 @@ license = "AGPL-3.0-only"
 [dependencies]
 libsignal-protocol-rust = { path = "../../protocol" }
 aes-gcm-siv = { path = "../../aes-gcm-siv" }
+futures = "0.3.7"
 log = "0.4.11"
 paste = "1.0"
 

--- a/rust/bridge/shared/macros/Cargo.toml
+++ b/rust/bridge/shared/macros/Cargo.toml
@@ -14,7 +14,8 @@ license = "AGPL-3.0-only"
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0", features = ["full"] }
+heck = "0.3.1"
 proc-macro2 = "1.0"
 quote = "1.0"
+syn = { version = "1.0", features = ["full"] }
 unzip3 = "1.0.0"

--- a/rust/bridge/shared/macros/Cargo.toml
+++ b/rust/bridge/shared/macros/Cargo.toml
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2020 Signal Messenger, LLC.
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+
+[package]
+name = "libsignal-bridge-macros"
+version = "0.1.0"
+authors = ["Jack Lloyd <jack@signal.org>", "Jordan Rose <jrose@signal.org>"]
+edition = "2018"
+license = "AGPL-3.0-only"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "1.0", features = ["full"] }
+proc-macro2 = "1.0"
+quote = "1.0"
+unzip3 = "1.0.0"

--- a/rust/bridge/shared/macros/Cargo.toml
+++ b/rust/bridge/shared/macros/Cargo.toml
@@ -17,5 +17,6 @@ proc-macro = true
 heck = "0.3.1"
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["full"] }
+syn = { version = "1.0" }
+syn-mid = "0.5"
 unzip3 = "1.0.0"

--- a/rust/bridge/shared/macros/src/lib.rs
+++ b/rust/bridge/shared/macros/src/lib.rs
@@ -9,9 +9,9 @@ use heck::SnakeCase;
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::*;
-use syn::*;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
+use syn::*;
 use unzip3::Unzip3;
 
 fn ffi_bridge_fn(name: String, sig: &Signature) -> TokenStream2 {
@@ -21,35 +21,65 @@ fn ffi_bridge_fn(name: String, sig: &Signature) -> TokenStream2 {
         ReturnType::Default => (quote!(), quote!()),
         ReturnType::Type(_, ref ty) => (
             quote!(out: *mut ffi_result_type!(#ty),), // note the trailing comma
-            quote!(<#ty as ffi::ResultTypeInfo>::write_to(out, __result)?)
-        )
+            quote!(<#ty as ffi::ResultTypeInfo>::write_to(out, __result)?),
+        ),
     };
 
-    let (input_names, input_args, input_processing): (Vec<Ident>, Vec<TokenStream2>, Vec<TokenStream2>) = sig.inputs.iter().map(|arg| match arg {
-        FnArg::Receiver(tokens) => (
-            Ident::new("self", tokens.self_token.span),
-            Error::new(tokens.self_token.span, "cannot have 'self' parameter").to_compile_error(),
-            quote!()
-        ),
-        FnArg::Typed(PatType { attrs, pat: box Pat::Ident(name), colon_token, ty: ty @ box Type::Reference(TypeReference { elem: box Type::Slice(_), .. }) }) => {
-            let size_arg = format_ident!("{}_len", name.ident);
-            (
+    let (input_names, input_args, input_processing): (
+        Vec<Ident>,
+        Vec<TokenStream2>,
+        Vec<TokenStream2>,
+    ) = sig
+        .inputs
+        .iter()
+        .map(|arg| match arg {
+            FnArg::Receiver(tokens) => (
+                Ident::new("self", tokens.self_token.span),
+                Error::new(tokens.self_token.span, "cannot have 'self' parameter")
+                    .to_compile_error(),
+                quote!(),
+            ),
+            FnArg::Typed(PatType {
+                attrs,
+                pat: box Pat::Ident(name),
+                colon_token,
+                ty:
+                    ty
+                    @
+                    box Type::Reference(TypeReference {
+                        elem: box Type::Slice(_),
+                        ..
+                    }),
+            }) => {
+                let size_arg = format_ident!("{}_len", name.ident);
+                (
+                    name.ident.clone(),
+                    quote!(
+                        #(#attrs)* #name #colon_token ffi_arg_type!(#ty),
+                        #size_arg: libc::size_t
+                    ),
+                    quote!(
+                        let #name = <#ty as ffi::SizedArgTypeInfo>::convert_from(#name, #size_arg)?
+                    ),
+                )
+            }
+            FnArg::Typed(PatType {
+                attrs,
+                pat: box Pat::Ident(name),
+                colon_token,
+                ty,
+            }) => (
                 name.ident.clone(),
-                quote!(#(#attrs)* #name #colon_token ffi_arg_type!(#ty), #size_arg: libc::size_t),
-                quote!(let #name = <#ty as ffi::SizedArgTypeInfo>::convert_from(#name, #size_arg)?),
-            )
-        }
-        FnArg::Typed(PatType { attrs, pat: box Pat::Ident(name), colon_token, ty }) => (
-            name.ident.clone(),
-            quote!(#(#attrs)* #name #colon_token ffi_arg_type!(#ty)),
-            quote!(let #name = <#ty as ffi::ArgTypeInfo>::convert_from(#name)?),
-        ),
-        FnArg::Typed(PatType { pat, .. }) => (
-            Ident::new("unexpected", pat.span()),
-            Error::new(pat.span(), "cannot use patterns in paramater").to_compile_error(),
-            quote!()
-        )
-    }).unzip3();
+                quote!(#(#attrs)* #name #colon_token ffi_arg_type!(#ty)),
+                quote!(let #name = <#ty as ffi::ArgTypeInfo>::convert_from(#name)?),
+            ),
+            FnArg::Typed(PatType { pat, .. }) => (
+                Ident::new("unexpected", pat.span()),
+                Error::new(pat.span(), "cannot use patterns in paramater").to_compile_error(),
+                quote!(),
+            ),
+        })
+        .unzip3();
 
     let orig_name = sig.ident.clone();
 
@@ -82,28 +112,50 @@ fn jni_bridge_fn(name: String, sig: &Signature) -> TokenStream2 {
         ReturnType::Type(_, ref ty) => quote!(-> jni_result_type!(#ty)),
     };
 
-    let (input_names, input_args, input_processing): (Vec<Ident>, Vec<TokenStream2>, Vec<TokenStream2>) = sig.inputs.iter().map(|arg| match arg {
-        FnArg::Receiver(tokens) => (
-            Ident::new("self", tokens.self_token.span),
-            Error::new(tokens.self_token.span, "cannot have 'self' parameter").to_compile_error(),
-            quote!()
-        ),
-        FnArg::Typed(PatType { attrs, pat: box Pat::Ident(name), colon_token, ty: ty @ box Type::Reference(_) }) => (
-            name.ident.clone(),
-            quote!(#(#attrs)* #name #colon_token jni_arg_type!(#ty)),
-            quote!(let #name = <#ty as jni::RefArgTypeInfo>::convert_from(&env, #name)?; let #name = std::borrow::Borrow::borrow(&#name)),
-        ),
-        FnArg::Typed(PatType { attrs, pat: box Pat::Ident(name), colon_token, ty }) => (
-            name.ident.clone(),
-            quote!(#(#attrs)* #name #colon_token jni_arg_type!(#ty)),
-            quote!(let #name = <#ty as jni::ArgTypeInfo>::convert_from(&env, #name)?),
-        ),
-        FnArg::Typed(PatType { pat, .. }) => (
-            Ident::new("unexpected", pat.span()),
-            Error::new(pat.span(), "cannot use patterns in paramater").to_compile_error(),
-            quote!()
-        )
-    }).unzip3();
+    let (input_names, input_args, input_processing): (
+        Vec<Ident>,
+        Vec<TokenStream2>,
+        Vec<TokenStream2>,
+    ) = sig
+        .inputs
+        .iter()
+        .map(|arg| match arg {
+            FnArg::Receiver(tokens) => (
+                Ident::new("self", tokens.self_token.span),
+                Error::new(tokens.self_token.span, "cannot have 'self' parameter")
+                    .to_compile_error(),
+                quote!(),
+            ),
+            FnArg::Typed(PatType {
+                attrs,
+                pat: box Pat::Ident(name),
+                colon_token,
+                ty: ty @ box Type::Reference(_),
+            }) => (
+                name.ident.clone(),
+                quote!(#(#attrs)* #name #colon_token jni_arg_type!(#ty)),
+                quote!(
+                    let #name = <#ty as jni::RefArgTypeInfo>::convert_from(&env, #name)?;
+                    let #name = std::borrow::Borrow::borrow(&#name)
+                ),
+            ),
+            FnArg::Typed(PatType {
+                attrs,
+                pat: box Pat::Ident(name),
+                colon_token,
+                ty,
+            }) => (
+                name.ident.clone(),
+                quote!(#(#attrs)* #name #colon_token jni_arg_type!(#ty)),
+                quote!(let #name = <#ty as jni::ArgTypeInfo>::convert_from(&env, #name)?),
+            ),
+            FnArg::Typed(PatType { pat, .. }) => (
+                Ident::new("unexpected", pat.span()),
+                Error::new(pat.span(), "cannot use patterns in paramater").to_compile_error(),
+                quote!(),
+            ),
+        })
+        .unzip3();
 
     let orig_name = sig.ident.clone();
 
@@ -131,15 +183,36 @@ fn jni_name_from_ident(ident: &Ident) -> String {
 pub fn bridge_fn(attr: TokenStream, item: TokenStream) -> TokenStream {
     let function = parse_macro_input!(item as ItemFn);
 
-    let item_names = parse_macro_input!(attr with Punctuated<MetaNameValue, Token![,]>::parse_terminated);
-    let ffi_name = match item_names.iter().find(|meta| meta.path.get_ident().map_or(false, |ident| ident == "ffi")) {
-        Some(MetaNameValue { lit: Lit::Str(name_str), .. }) => name_str.value(),
-        Some(meta) => return Error::new(meta.lit.span(), "ffi name must be a string literal").to_compile_error().into(),
-        None => ffi_name_from_ident(&function.sig.ident)
+    let item_names =
+        parse_macro_input!(attr with Punctuated<MetaNameValue, Token![,]>::parse_terminated);
+    let ffi_name = match item_names
+        .iter()
+        .find(|meta| meta.path.get_ident().map_or(false, |ident| ident == "ffi"))
+    {
+        Some(MetaNameValue {
+            lit: Lit::Str(name_str),
+            ..
+        }) => name_str.value(),
+        Some(meta) => {
+            return Error::new(meta.lit.span(), "ffi name must be a string literal")
+                .to_compile_error()
+                .into()
+        }
+        None => ffi_name_from_ident(&function.sig.ident),
     };
-    let jni_name = match item_names.iter().find(|meta| meta.path.get_ident().map_or(false, |ident| ident == "jni")) {
-        Some(MetaNameValue { lit: Lit::Str(name_str), .. }) => name_str.value(),
-        Some(meta) => return Error::new(meta.lit.span(), "jni name must be a string literal").to_compile_error().into(),
+    let jni_name = match item_names
+        .iter()
+        .find(|meta| meta.path.get_ident().map_or(false, |ident| ident == "jni"))
+    {
+        Some(MetaNameValue {
+            lit: Lit::Str(name_str),
+            ..
+        }) => name_str.value(),
+        Some(meta) => {
+            return Error::new(meta.lit.span(), "jni name must be a string literal")
+                .to_compile_error()
+                .into()
+        }
         None => jni_name_from_ident(&function.sig.ident),
     };
 
@@ -153,5 +226,6 @@ pub fn bridge_fn(attr: TokenStream, item: TokenStream) -> TokenStream {
         #ffi_fn
 
         #jni_fn
-    ).into()
+    )
+    .into()
 }

--- a/rust/bridge/shared/macros/src/lib.rs
+++ b/rust/bridge/shared/macros/src/lib.rs
@@ -1,0 +1,139 @@
+//
+// Copyright 2020 Signal Messenger, LLC.
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+#![feature(box_patterns)]
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::*;
+use syn::*;
+use syn::punctuated::Punctuated;
+use syn::spanned::Spanned;
+use unzip3::Unzip3;
+
+fn ffi_bridge_fn(name: String, sig: &Signature) -> TokenStream2 {
+    let name = format_ident!("signal_{}", name);
+
+    let (output_args, output_processing) = match sig.output {
+        ReturnType::Default => (quote!(), quote!()),
+        ReturnType::Type(_, ref ty) => (
+            quote!(out: *mut ffi_result_type!(#ty),), // note the trailing comma
+            quote!(<#ty as ffi::ResultTypeInfo>::write_to(out, __result)?)
+        )
+    };
+
+    let (input_names, input_args, input_processing): (Vec<Ident>, Vec<TokenStream2>, Vec<TokenStream2>) = sig.inputs.iter().map(|arg| match arg {
+        FnArg::Receiver(tokens) => (
+            Ident::new("self", tokens.self_token.span),
+            Error::new(tokens.self_token.span, "cannot have 'self' parameter").to_compile_error(),
+            quote!()
+        ),
+        FnArg::Typed(PatType { attrs, pat: box Pat::Ident(name), colon_token, ty: ty @ box Type::Reference(TypeReference { elem: box Type::Array(_), .. }) }) => {
+            let size_arg = format_ident!("{}_size", name.ident);
+            (
+                name.ident.clone(),
+                quote!(#(#attrs)* #name #colon_token ffi_arg_type!(#ty), #size_arg: usize),
+                quote!(let #name = <#ty as ffi::SizedArgTypeInfo>::convert_from(#name, #size_arg)?),
+            )
+        }
+        FnArg::Typed(PatType { attrs, pat: box Pat::Ident(name), colon_token, ty }) => (
+            name.ident.clone(),
+            quote!(#(#attrs)* #name #colon_token ffi_arg_type!(#ty)),
+            quote!(let #name = <#ty as ffi::ArgTypeInfo>::convert_from(#name)?),
+        ),
+        FnArg::Typed(PatType { pat, .. }) => (
+            Ident::new("unexpected", pat.span()),
+            Error::new(pat.span(), "cannot use patterns in paramater").to_compile_error(),
+            quote!()
+        )
+    }).unzip3();
+
+    let orig_name = sig.ident.clone();
+
+    quote! {
+        #[cfg(feature = "ffi")]
+        #[no_mangle]
+        pub unsafe extern "C" fn #name(
+            #output_args
+            #(#input_args),*
+        ) -> *mut ffi::SignalFfiError {
+            ffi::run_ffi_safe(|| {
+                #(#input_processing);*;
+                let __result = #orig_name(#(#input_names),*);
+                #output_processing;
+                Ok(())
+            })
+        }
+    }
+}
+
+fn jni_bridge_fn(name: String, sig: &Signature) -> TokenStream2 {
+    let name = format_ident!("Java_org_signal_client_internal_Native_{}", name);
+
+    let output = match sig.output {
+        ReturnType::Default => quote!(),
+        ReturnType::Type(_, ref ty) => quote!(-> jni_result_type!(#ty)),
+    };
+
+    let (input_names, input_args, input_processing): (Vec<Ident>, Vec<TokenStream2>, Vec<TokenStream2>) = sig.inputs.iter().map(|arg| match arg {
+        FnArg::Receiver(tokens) => (
+            Ident::new("self", tokens.self_token.span),
+            Error::new(tokens.self_token.span, "cannot have 'self' parameter").to_compile_error(),
+            quote!()
+        ),
+        FnArg::Typed(PatType { attrs, pat: box Pat::Ident(name), colon_token, ty }) => (
+            name.ident.clone(),
+            quote!(#(#attrs)* #name #colon_token jni_arg_type!(#ty)),
+            quote!(let #name = <#ty as jni::ArgTypeInfo>::convert_from(&env, #name)?),
+        ),
+        FnArg::Typed(PatType { pat, .. }) => (
+            Ident::new("unexpected", pat.span()),
+            Error::new(pat.span(), "cannot use patterns in paramater").to_compile_error(),
+            quote!()
+        )
+    }).unzip3();
+
+    let orig_name = sig.ident.clone();
+
+    quote! {
+        #[cfg(feature = "jni")]
+        #[no_mangle]
+        pub unsafe extern "C" fn #name(
+            env: jni::JNIEnv,
+            _class: jni::JClass,
+            #(#input_args),*
+        ) #output {
+            jni::run_ffi_safe(&env, || {
+                #(#input_processing);*;
+                jni::ResultTypeInfo::convert_into(#orig_name(#(#input_names),*), &env)
+            })
+        }
+    }
+}
+
+#[proc_macro_attribute]
+pub fn bridge_fn(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let function = parse_macro_input!(item as ItemFn);
+
+    let item_names = parse_macro_input!(attr with Punctuated<MetaNameValue, Token![,]>::parse_terminated);
+    let ffi_name = match item_names.iter().find(|meta| meta.path.get_ident().map_or(false, |ident| ident == "ffi")) {
+        Some(MetaNameValue { lit: Lit::Str(name_str), .. }) => name_str.value(),
+        Some(meta) => return Error::new(meta.lit.span(), "ffi name must be a string literal").to_compile_error().into(),
+        None => function.sig.ident.to_string(),
+    };
+    let jni_name = match item_names.iter().find(|meta| meta.path.get_ident().map_or(false, |ident| ident == "jni")) {
+        Some(MetaNameValue { lit: Lit::Str(name_str), .. }) => name_str.value(),
+        Some(meta) => return Error::new(meta.lit.span(), "jni name must be a string literal").to_compile_error().into(),
+        None => function.sig.ident.to_string(),
+    };
+
+    let ffi_fn = ffi_bridge_fn(ffi_name, &function.sig);
+    let jni_fn = jni_bridge_fn(jni_name, &function.sig);
+
+    let mut result = function.into_token_stream();
+    result.extend(ffi_fn);
+    result.extend(jni_fn);
+    result.into()
+}

--- a/rust/bridge/shared/macros/src/lib.rs
+++ b/rust/bridge/shared/macros/src/lib.rs
@@ -30,11 +30,11 @@ fn ffi_bridge_fn(name: String, sig: &Signature) -> TokenStream2 {
             Error::new(tokens.self_token.span, "cannot have 'self' parameter").to_compile_error(),
             quote!()
         ),
-        FnArg::Typed(PatType { attrs, pat: box Pat::Ident(name), colon_token, ty: ty @ box Type::Reference(TypeReference { elem: box Type::Array(_), .. }) }) => {
-            let size_arg = format_ident!("{}_size", name.ident);
+        FnArg::Typed(PatType { attrs, pat: box Pat::Ident(name), colon_token, ty: ty @ box Type::Reference(TypeReference { elem: box Type::Slice(_), .. }) }) => {
+            let size_arg = format_ident!("{}_len", name.ident);
             (
                 name.ident.clone(),
-                quote!(#(#attrs)* #name #colon_token ffi_arg_type!(#ty), #size_arg: usize),
+                quote!(#(#attrs)* #name #colon_token ffi_arg_type!(#ty), #size_arg: libc::size_t),
                 quote!(let #name = <#ty as ffi::SizedArgTypeInfo>::convert_from(#name, #size_arg)?),
             )
         }
@@ -82,6 +82,11 @@ fn jni_bridge_fn(name: String, sig: &Signature) -> TokenStream2 {
             Ident::new("self", tokens.self_token.span),
             Error::new(tokens.self_token.span, "cannot have 'self' parameter").to_compile_error(),
             quote!()
+        ),
+        FnArg::Typed(PatType { attrs, pat: box Pat::Ident(name), colon_token, ty: ty @ box Type::Reference(_) }) => (
+            name.ident.clone(),
+            quote!(#(#attrs)* #name #colon_token jni_arg_type!(#ty)),
+            quote!(let #name = <#ty as jni::RefArgTypeInfo>::convert_from(&env, #name)?; let #name = std::borrow::Borrow::borrow(&#name)),
         ),
         FnArg::Typed(PatType { attrs, pat: box Pat::Ident(name), colon_token, ty }) => (
             name.ident.clone(),

--- a/rust/bridge/shared/macros/src/lib.rs
+++ b/rust/bridge/shared/macros/src/lib.rs
@@ -12,6 +12,7 @@ use quote::*;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::*;
+use syn_mid::{FnArg, ItemFn, Pat, PatType, Signature};
 use unzip3::Unzip3;
 
 fn value_for_meta_key<'a>(

--- a/rust/bridge/shared/src/ffi/convert.rs
+++ b/rust/bridge/shared/src/ffi/convert.rs
@@ -76,6 +76,15 @@ impl<T: ResultTypeInfo> ResultTypeInfo for Result<T, SignalProtocolError> {
     }
 }
 
+impl ResultTypeInfo for String {
+    type ResultType = *const libc::c_char;
+    fn convert_into(self) -> Result<Self::ResultType, SignalFfiError> {
+        let cstr =
+            CString::new(self).expect("No NULL characters in string being returned to C");
+        Ok(cstr.into_raw())
+    }
+}
+
 impl ResultTypeInfo for ProtocolAddress {
     type ResultType = *mut ProtocolAddress;
     fn convert_into(self) -> Result<Self::ResultType, SignalFfiError> {
@@ -113,5 +122,6 @@ macro_rules! ffi_result_type {
     (Result<$typ:tt, $_:tt>) => (ffi_result_type!($typ));
     (i32) => (i32);
     (bool) => (bool);
+    (String) => (*const libc::c_char);
     ( $typ:ty ) => (*mut $typ);
 }

--- a/rust/bridge/shared/src/ffi/convert.rs
+++ b/rust/bridge/shared/src/ffi/convert.rs
@@ -69,6 +69,13 @@ impl<T> ArgTypeInfo for &'static T {
     }
 }
 
+impl<T: ResultTypeInfo> ResultTypeInfo for Result<T, SignalProtocolError> {
+    type ResultType = T::ResultType;
+    fn convert_into(self) -> Result<Self::ResultType, SignalFfiError> {
+        T::convert_into(self?)
+    }
+}
+
 impl ResultTypeInfo for ProtocolAddress {
     type ResultType = *mut ProtocolAddress;
     fn convert_into(self) -> Result<Self::ResultType, SignalFfiError> {
@@ -92,6 +99,7 @@ macro_rules! trivial {
 trivial!(i32);
 trivial!(u32);
 trivial!(usize);
+trivial!(bool);
 
 macro_rules! ffi_arg_type {
     (u32) => (u32);
@@ -102,6 +110,8 @@ macro_rules! ffi_arg_type {
 }
 
 macro_rules! ffi_result_type {
+    (Result<$typ:tt, $_:tt>) => (ffi_result_type!($typ));
     (i32) => (i32);
+    (bool) => (bool);
     ( $typ:ty ) => (*mut $typ);
 }

--- a/rust/bridge/shared/src/ffi/convert.rs
+++ b/rust/bridge/shared/src/ffi/convert.rs
@@ -1,0 +1,95 @@
+//
+// Copyright 2020 Signal Messenger, LLC.
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+use libc::{c_char, c_uchar};
+use libsignal_protocol_rust::*;
+use std::ffi::CStr;
+
+use crate::ffi::error::*;
+
+pub(crate) trait ArgTypeInfo: Sized {
+    type ArgType;
+    fn convert_from(foreign: Self::ArgType) -> Result<Self, SignalFfiError>;
+}
+
+pub(crate) trait SizedArgTypeInfo: Sized {
+    type ArgType;
+    fn convert_from(foreign: Self::ArgType, size: usize) -> Result<Self, SignalFfiError>;
+}
+
+pub(crate) trait ResultTypeInfo: Sized {
+    type ResultType;
+    fn convert_into(self) -> Result<Self::ResultType, SignalFfiError>;
+    fn write_to(ptr: *mut Self::ResultType, value: Self) -> Result<(), SignalFfiError> {
+        if ptr.is_null() {
+            return Err(SignalFfiError::NullPointer);
+        }
+        unsafe { *ptr = value.convert_into()? };
+        Ok(())
+    }
+}
+
+pub(crate) trait TrivialTypeInfo {}
+
+impl<T: TrivialTypeInfo> ArgTypeInfo for T {
+    type ArgType = Self;
+    fn convert_from(foreign: Self) -> Result<Self, SignalFfiError> { Ok(foreign) }
+}
+
+impl<T: TrivialTypeInfo> ResultTypeInfo for T {
+    type ResultType = Self;
+    fn convert_into(self) -> Result<Self, SignalFfiError> { Ok(self) }
+}
+
+impl SizedArgTypeInfo for &[u8] {
+    type ArgType = *const c_uchar;
+    fn convert_from(input: Self::ArgType, input_len: usize) -> Result<Self, SignalFfiError> {
+        if input.is_null() {
+            if input_len != 0 {
+                return Err(SignalFfiError::NullPointer);
+            }
+            // We can't just fall through because slice::from_raw_parts still expects a non-null pointer. Reference a dummy buffer instead.
+            return Ok(&[]);
+        }
+
+        unsafe { Ok(std::slice::from_raw_parts(input, input_len)) }
+    }
+}
+
+impl ArgTypeInfo for String {
+    type ArgType = *const c_char;
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    fn convert_from(foreign: *const c_char) -> Result<Self, SignalFfiError> {
+        if foreign.is_null() {
+            return Err(SignalFfiError::NullPointer);
+        }
+
+        match unsafe { CStr::from_ptr(foreign).to_str() } {
+            Ok(s) => Ok(s.to_owned()),
+            Err(_) => Err(SignalFfiError::InvalidUtf8String),
+        }
+    }
+}
+
+impl TrivialTypeInfo for u32 {}
+impl TrivialTypeInfo for usize {}
+
+impl ResultTypeInfo for ProtocolAddress {
+    type ResultType = *mut ProtocolAddress;
+    fn convert_into(self) -> Result<Self::ResultType, SignalFfiError> {
+        Ok(Box::into_raw(Box::new(self)))
+    }
+}
+
+macro_rules! ffi_arg_type {
+    (u32) => (u32);
+    (usize) => (libc::size_t);
+    (&[u8]) => (*const libc::c_uchar);
+    (String) => (*const libc::c_char);
+}
+
+macro_rules! ffi_result_type {
+    ( $typ:ty ) => (*mut $typ);
+}

--- a/rust/bridge/shared/src/ffi/convert.rs
+++ b/rust/bridge/shared/src/ffi/convert.rs
@@ -82,8 +82,7 @@ impl<T: ResultTypeInfo> ResultTypeInfo for Result<T, SignalProtocolError> {
 impl ResultTypeInfo for String {
     type ResultType = *const libc::c_char;
     fn convert_into(self) -> Result<Self::ResultType, SignalFfiError> {
-        let cstr =
-            CString::new(self).expect("No NULL characters in string being returned to C");
+        let cstr = CString::new(self).expect("No NULL characters in string being returned to C");
         Ok(cstr.into_raw())
     }
 }
@@ -103,7 +102,7 @@ macro_rules! native_handle {
                 Ok(Box::into_raw(Box::new(self)))
             }
         }
-    }
+    };
 }
 
 native_handle!(ProtocolAddress);
@@ -115,13 +114,17 @@ macro_rules! trivial {
     ($typ:ty) => {
         impl ArgTypeInfo for $typ {
             type ArgType = Self;
-            fn convert_from(foreign: Self) -> Result<Self, SignalFfiError> { Ok(foreign) }
+            fn convert_from(foreign: Self) -> Result<Self, SignalFfiError> {
+                Ok(foreign)
+            }
         }
         impl ResultTypeInfo for $typ {
             type ResultType = Self;
-            fn convert_into(self) -> Result<Self, SignalFfiError> { Ok(self) }
+            fn convert_into(self) -> Result<Self, SignalFfiError> {
+                Ok(self)
+            }
         }
-    }
+    };
 }
 
 trivial!(i32);

--- a/rust/bridge/shared/src/ffi/convert.rs
+++ b/rust/bridge/shared/src/ffi/convert.rs
@@ -87,28 +87,23 @@ impl ResultTypeInfo for String {
     }
 }
 
-macro_rules! native_handle {
+macro_rules! ffi_bridge_handle {
     ($typ:ty) => {
-        impl ArgTypeInfo for &'static $typ {
+        impl ffi::ArgTypeInfo for &'static $typ {
             type ArgType = *const $typ;
             #[allow(clippy::not_unsafe_ptr_arg_deref)]
-            fn convert_from(foreign: *const $typ) -> Result<Self, SignalFfiError> {
-                unsafe { native_handle_cast(foreign) }
+            fn convert_from(foreign: *const $typ) -> Result<Self, ffi::SignalFfiError> {
+                unsafe { ffi::native_handle_cast(foreign) }
             }
         }
-        impl ResultTypeInfo for $typ {
+        impl ffi::ResultTypeInfo for $typ {
             type ResultType = *mut $typ;
-            fn convert_into(self) -> Result<Self::ResultType, SignalFfiError> {
+            fn convert_into(self) -> Result<Self::ResultType, ffi::SignalFfiError> {
                 Ok(Box::into_raw(Box::new(self)))
             }
         }
     };
 }
-
-native_handle!(ProtocolAddress);
-native_handle!(PublicKey);
-native_handle!(SignalMessage);
-native_handle!(PreKeySignalMessage);
 
 macro_rules! trivial {
     ($typ:ty) => {

--- a/rust/bridge/shared/src/ffi/mod.rs
+++ b/rust/bridge/shared/src/ffi/mod.rs
@@ -10,6 +10,8 @@ use std::ffi::CString;
 mod error;
 pub use error::*;
 
+pub use crate::support::expect_ready;
+
 pub fn run_ffi_safe<F: FnOnce() -> Result<(), SignalFfiError> + std::panic::UnwindSafe>(
     f: F,
 ) -> *mut SignalFfiError {

--- a/rust/bridge/shared/src/ffi/mod.rs
+++ b/rust/bridge/shared/src/ffi/mod.rs
@@ -7,6 +7,10 @@ use libc::{c_char, c_uchar, size_t};
 use libsignal_protocol_rust::*;
 use std::ffi::CString;
 
+#[macro_use]
+mod convert;
+pub(crate) use convert::*;
+
 mod error;
 pub use error::*;
 

--- a/rust/bridge/shared/src/jni/convert.rs
+++ b/rust/bridge/shared/src/jni/convert.rs
@@ -5,13 +5,22 @@
 
 use jni::JNIEnv;
 use jni::objects::JString;
+use jni::sys::{JNI_FALSE, JNI_TRUE};
 use libsignal_protocol_rust::*;
+use std::borrow::Borrow;
+use std::ops::Deref;
 
 use crate::jni::*;
 
 pub(crate) trait ArgTypeInfo<'a>: Sized {
     type ArgType;
     fn convert_from(env: &JNIEnv<'a>, foreign: Self::ArgType) -> Result<Self, SignalJniError>;
+}
+
+pub(crate) trait RefArgTypeInfo<'a>: Deref {
+    type ArgType;
+    type StoredType: Borrow<Self::Target> + 'a;
+    fn convert_from(env: &JNIEnv<'a>, foreign: Self::ArgType) -> Result<Self::StoredType, SignalJniError>;
 }
 
 pub(crate) trait ResultTypeInfo<'a>: Sized {
@@ -33,19 +42,48 @@ impl<'a> ArgTypeInfo<'a> for String {
     }
 }
 
-impl<'a, T> ArgTypeInfo<'a> for &'static T {
-    type ArgType = ObjectHandle;
-    fn convert_from(_env: &JNIEnv<'a>, foreign: Self::ArgType) -> Result<Self, SignalJniError> {
-        Ok(unsafe { native_handle_cast(foreign) }?)
+impl<'a> RefArgTypeInfo<'a> for &'_ [u8] {
+    type ArgType = jbyteArray;
+    type StoredType = Vec<u8>;
+    fn convert_from(env: &JNIEnv<'a>, foreign: Self::ArgType) -> Result<Vec<u8>, SignalJniError> {
+        Ok(env.convert_byte_array(foreign)?)
     }
 }
 
-impl<'a> ResultTypeInfo<'a> for ProtocolAddress {
-    type ResultType = ObjectHandle;
+impl<'a> ResultTypeInfo<'a> for bool {
+    type ResultType = jboolean;
     fn convert_into(self, _env: &JNIEnv<'a>) -> Result<Self::ResultType, SignalJniError> {
-        box_object(Ok(self))
+        Ok(if self { JNI_TRUE } else { JNI_FALSE })
     }
 }
+
+impl<'a, T: ResultTypeInfo<'a>> ResultTypeInfo<'a> for Result<T, SignalProtocolError> {
+    type ResultType = T::ResultType;
+    fn convert_into(self, env: &JNIEnv<'a>) -> Result<Self::ResultType, SignalJniError> {
+        T::convert_into(self?, env)
+    }
+}
+
+macro_rules! native_handle {
+    ($typ:ty) => {
+        impl<'a> RefArgTypeInfo<'a> for &$typ {
+            type ArgType = ObjectHandle;
+            type StoredType = &'static $typ;
+            fn convert_from(_env: &JNIEnv<'a>, foreign: Self::ArgType) -> Result<Self::StoredType, SignalJniError> {
+                Ok(unsafe { native_handle_cast(foreign) }?)
+            }
+        }
+        impl<'a> ResultTypeInfo<'a> for $typ {
+            type ResultType = ObjectHandle;
+            fn convert_into(self, _env: &JNIEnv<'a>) -> Result<Self::ResultType, SignalJniError> {
+                box_object(Ok(self))
+            }
+        }
+    }
+}
+
+native_handle!(PublicKey);
+native_handle!(ProtocolAddress);
 
 macro_rules! trivial {
     ($typ:ty) => {
@@ -65,10 +103,13 @@ trivial!(i32);
 macro_rules! jni_arg_type {
     (u32) => (jni::jint);
     (String) => (jni::JString);
+    (&[u8]) => (jni::jbyteArray);
     (& $typ:ty) => (jni::ObjectHandle);
 }
 
 macro_rules! jni_result_type {
+    (Result<$typ:tt, $_:tt>) => (jni_result_type!($typ));
+    (bool) => (jni::jboolean);
     (i32) => (jni::jint);
     ( $typ:ty ) => (jni::ObjectHandle);
 }

--- a/rust/bridge/shared/src/jni/convert.rs
+++ b/rust/bridge/shared/src/jni/convert.rs
@@ -35,6 +35,24 @@ impl<'a> ArgTypeInfo<'a> for u32 {
     }
 }
 
+impl<'a> ArgTypeInfo<'a> for Option<u32> {
+    type ArgType = jint;
+    fn convert_from(env: &JNIEnv<'a>, foreign: jint) -> Result<Self, SignalJniError> {
+        if foreign < 0 {
+            Ok(None)
+        } else {
+            u32::convert_from(env, foreign).map(Some)
+        }
+    }
+}
+
+impl<'a> ArgTypeInfo<'a> for u8 {
+    type ArgType = jint;
+    fn convert_from(_env: &JNIEnv<'a>, foreign: jint) -> Result<Self, SignalJniError> {
+        jint_to_u8(foreign)
+    }
+}
+
 impl<'a> ArgTypeInfo<'a> for String {
     type ArgType = JString<'a>;
     fn convert_from(env: &JNIEnv<'a>, foreign: JString<'a>) -> Result<Self, SignalJniError> {
@@ -91,6 +109,8 @@ macro_rules! native_handle {
 
 native_handle!(PublicKey);
 native_handle!(ProtocolAddress);
+native_handle!(SignalMessage);
+native_handle!(PreKeySignalMessage);
 
 macro_rules! trivial {
     ($typ:ty) => {
@@ -108,7 +128,9 @@ macro_rules! trivial {
 trivial!(i32);
 
 macro_rules! jni_arg_type {
+    (u8) => (jni::jint);
     (u32) => (jni::jint);
+    (Option<u32>) => (jni::jint);
     (String) => (jni::JString);
     (&[u8]) => (jni::jbyteArray);
     (& $typ:ty) => (jni::ObjectHandle);

--- a/rust/bridge/shared/src/jni/convert.rs
+++ b/rust/bridge/shared/src/jni/convert.rs
@@ -1,0 +1,62 @@
+//
+// Copyright 2020 Signal Messenger, LLC.
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+use jni::JNIEnv;
+use jni::objects::JString;
+use libsignal_protocol_rust::*;
+
+use crate::jni::*;
+
+pub(crate) trait ArgTypeInfo<'a>: Sized {
+    type ArgType;
+    fn convert_from(env: &JNIEnv<'a>, foreign: Self::ArgType) -> Result<Self, SignalJniError>;
+}
+
+pub(crate) trait ResultTypeInfo<'a>: Sized {
+    type ResultType;
+    fn convert_into(self, env: &JNIEnv<'a>) -> Result<Self::ResultType, SignalJniError>;
+}
+
+pub(crate) trait TrivialTypeInfo {}
+
+impl<'a, T: TrivialTypeInfo> ArgTypeInfo<'a> for T {
+    type ArgType = Self;
+    fn convert_from(_env: &JNIEnv<'a>, foreign: Self) -> Result<Self, SignalJniError> { Ok(foreign) }
+}
+
+impl<'a, T: TrivialTypeInfo> ResultTypeInfo<'a> for T {
+    type ResultType = Self;
+    fn convert_into(self, _env: &JNIEnv<'a>) -> Result<Self, SignalJniError> { Ok(self) }
+}
+
+impl<'a> ArgTypeInfo<'a> for u32 {
+    type ArgType = jint;
+    fn convert_from(_env: &JNIEnv<'a>, foreign: jint) -> Result<Self, SignalJniError> {
+        jint_to_u32(foreign)
+    }
+}
+
+impl<'a> ArgTypeInfo<'a> for String {
+    type ArgType = JString<'a>;
+    fn convert_from(env: &JNIEnv<'a>, foreign: JString<'a>) -> Result<Self, SignalJniError> {
+        Ok(env.get_string(foreign)?.into())
+    }
+}
+
+impl<'a> ResultTypeInfo<'a> for ProtocolAddress {
+    type ResultType = ObjectHandle;
+    fn convert_into(self, _env: &JNIEnv<'a>) -> Result<Self::ResultType, SignalJniError> {
+        box_object(Ok(self))
+    }
+}
+
+macro_rules! jni_arg_type {
+    (u32) => (jni::jint);
+    (String) => (jni::JString);
+}
+
+macro_rules! jni_result_type {
+    ( $typ:ty ) => (jni::ObjectHandle);
+}

--- a/rust/bridge/shared/src/jni/convert.rs
+++ b/rust/bridge/shared/src/jni/convert.rs
@@ -57,6 +57,13 @@ impl<'a> ResultTypeInfo<'a> for bool {
     }
 }
 
+impl<'a> ResultTypeInfo<'a> for String {
+    type ResultType = jstring;
+    fn convert_into(self, env: &JNIEnv<'a>) -> Result<Self::ResultType, SignalJniError> {
+        Ok(env.new_string(self)?.into_inner())
+    }
+}
+
 impl<'a, T: ResultTypeInfo<'a>> ResultTypeInfo<'a> for Result<T, SignalProtocolError> {
     type ResultType = T::ResultType;
     fn convert_into(self, env: &JNIEnv<'a>) -> Result<Self::ResultType, SignalJniError> {
@@ -111,5 +118,6 @@ macro_rules! jni_result_type {
     (Result<$typ:tt, $_:tt>) => (jni_result_type!($typ));
     (bool) => (jni::jboolean);
     (i32) => (jni::jint);
+    (String) => (jni::jstring);
     ( $typ:ty ) => (jni::ObjectHandle);
 }

--- a/rust/bridge/shared/src/jni/convert.rs
+++ b/rust/bridge/shared/src/jni/convert.rs
@@ -111,31 +111,29 @@ impl<T: ResultTypeInfo> ResultTypeInfo for Result<T, SignalProtocolError> {
     }
 }
 
-macro_rules! native_handle {
+macro_rules! jni_bridge_handle {
     ($typ:ty) => {
-        impl<'a> RefArgTypeInfo<'a> for &$typ {
-            type ArgType = ObjectHandle;
+        impl<'a> jni::RefArgTypeInfo<'a> for &$typ {
+            type ArgType = jni::ObjectHandle;
             type StoredType = &'static $typ;
             fn convert_from(
-                _env: &'a JNIEnv,
+                _env: &'a jni::JNIEnv,
                 foreign: Self::ArgType,
-            ) -> Result<Self::StoredType, SignalJniError> {
-                Ok(unsafe { native_handle_cast(foreign) }?)
+            ) -> Result<Self::StoredType, jni::SignalJniError> {
+                Ok(unsafe { jni::native_handle_cast(foreign) }?)
             }
         }
-        impl ResultTypeInfo for $typ {
-            type ResultType = ObjectHandle;
-            fn convert_into(self, _env: &JNIEnv) -> Result<Self::ResultType, SignalJniError> {
-                box_object(Ok(self))
+        impl jni::ResultTypeInfo for $typ {
+            type ResultType = jni::ObjectHandle;
+            fn convert_into(
+                self,
+                _env: &jni::JNIEnv,
+            ) -> Result<Self::ResultType, jni::SignalJniError> {
+                jni::box_object(Ok(self))
             }
         }
     };
 }
-
-native_handle!(PublicKey);
-native_handle!(ProtocolAddress);
-native_handle!(SignalMessage);
-native_handle!(PreKeySignalMessage);
 
 macro_rules! trivial {
     ($typ:ty) => {

--- a/rust/bridge/shared/src/jni/mod.rs
+++ b/rust/bridge/shared/src/jni/mod.rs
@@ -17,6 +17,8 @@ pub(crate) use jni::JNIEnv;
 mod error;
 pub use error::*;
 
+pub use crate::support::expect_ready;
+
 pub type ObjectHandle = jlong;
 
 fn throw_error(env: &JNIEnv, error: SignalJniError) {

--- a/rust/bridge/shared/src/jni/mod.rs
+++ b/rust/bridge/shared/src/jni/mod.rs
@@ -4,15 +4,19 @@
 //
 
 use jni::objects::{JObject, JValue};
-use jni::sys::{_jobject, jboolean, jint, jlong};
+use jni::sys::{_jobject, jboolean, jlong};
 
 use aes_gcm_siv::Error as AesGcmSivError;
 use libsignal_protocol_rust::*;
 
-pub(crate) use jni::objects::JClass;
+pub(crate) use jni::objects::{JClass, JString};
 pub(crate) use jni::strings::JNIString;
-pub(crate) use jni::sys::{jbyteArray, jstring};
+pub(crate) use jni::sys::{jbyteArray, jint, jstring};
 pub(crate) use jni::JNIEnv;
+
+#[macro_use]
+mod convert;
+pub(crate) use convert::*;
 
 mod error;
 pub use error::*;
@@ -198,6 +202,13 @@ pub unsafe fn native_handle_cast<T>(
     }
 
     Ok(&mut *(handle as *mut T))
+}
+
+pub fn jint_to_u32(v: jint) -> Result<u32, SignalJniError> {
+    if v < 0 {
+        return Err(SignalJniError::IntegerOverflow(format!("{} to u32", v)));
+    }
+    Ok(v as u32)
 }
 
 pub fn to_jbytearray<T: AsRef<[u8]>>(

--- a/rust/bridge/shared/src/jni/mod.rs
+++ b/rust/bridge/shared/src/jni/mod.rs
@@ -8,6 +8,7 @@ use jni::sys::{_jobject, jlong};
 
 use aes_gcm_siv::Error as AesGcmSivError;
 use libsignal_protocol_rust::*;
+use std::convert::TryFrom;
 
 pub(crate) use jni::objects::{JClass, JString};
 pub(crate) use jni::strings::JNIString;
@@ -209,6 +210,13 @@ pub fn jint_to_u32(v: jint) -> Result<u32, SignalJniError> {
         return Err(SignalJniError::IntegerOverflow(format!("{} to u32", v)));
     }
     Ok(v as u32)
+}
+
+pub fn jint_to_u8(v: jint) -> Result<u8, SignalJniError> {
+    match u8::try_from(v) {
+        Err(_) => Err(SignalJniError::IntegerOverflow(format!("{} to u8", v))),
+        Ok(v) => Ok(v),
+    }
 }
 
 pub fn to_jbytearray<T: AsRef<[u8]>>(

--- a/rust/bridge/shared/src/jni/mod.rs
+++ b/rust/bridge/shared/src/jni/mod.rs
@@ -4,14 +4,14 @@
 //
 
 use jni::objects::{JObject, JValue};
-use jni::sys::{_jobject, jboolean, jlong};
+use jni::sys::{_jobject, jlong};
 
 use aes_gcm_siv::Error as AesGcmSivError;
 use libsignal_protocol_rust::*;
 
 pub(crate) use jni::objects::{JClass, JString};
 pub(crate) use jni::strings::JNIString;
-pub(crate) use jni::sys::{jbyteArray, jint, jstring};
+pub(crate) use jni::sys::{jboolean, jbyteArray, jint, jstring};
 pub(crate) use jni::JNIEnv;
 
 #[macro_use]

--- a/rust/bridge/shared/src/lib.rs
+++ b/rust/bridge/shared/src/lib.rs
@@ -47,10 +47,7 @@ bridge_get_bytearray!(
 );
 
 #[bridge_fn(ffi = "publickey_compare")]
-fn ECPublicKey_Compare(
-    key1: &PublicKey,
-    key2: &PublicKey,
-) -> i32 {
+fn ECPublicKey_Compare(key1: &PublicKey, key2: &PublicKey) -> i32 {
     match key1.cmp(&key2) {
         std::cmp::Ordering::Less => -1,
         std::cmp::Ordering::Equal => 0,
@@ -66,7 +63,6 @@ fn ECPublicKey_Verify(
 ) -> Result<bool, SignalProtocolError> {
     key.verify_signature(&message, &signature)
 }
-
 
 bridge_destroy!(PrivateKey, ffi = privatekey, jni = ECPrivateKey);
 bridge_deserialize!(
@@ -91,14 +87,19 @@ bridge_get_string!(display_string(Fingerprint), jni = NumericFingerprintGenerato
     Fingerprint::display_string
 );
 #[bridge_fn(ffi = "fingerprint_format")]
-fn DisplayableFingerprint_Format(local: &[u8], remote: &[u8]) -> Result<String, SignalProtocolError> {
+fn DisplayableFingerprint_Format(
+    local: &[u8],
+    remote: &[u8],
+) -> Result<String, SignalProtocolError> {
     DisplayableFingerprint::new(&local, &remote).map(|f| f.to_string())
 }
 #[bridge_fn(ffi = "fingerprint_compare")]
-fn ScannableFingerprint_Compare(fprint1: &[u8], fprint2: &[u8]) -> Result<bool, SignalProtocolError> {
+fn ScannableFingerprint_Compare(
+    fprint1: &[u8],
+    fprint2: &[u8],
+) -> Result<bool, SignalProtocolError> {
     ScannableFingerprint::deserialize(&fprint1)?.compare(fprint2)
 }
-
 
 bridge_destroy!(SignalMessage, ffi = message);
 bridge_deserialize!(SignalMessage::try_from, ffi = message);
@@ -169,7 +170,6 @@ fn PreKeySignalMessage_New(
         signal_message.clone(),
     )
 }
-
 
 bridge_destroy!(PreKeySignalMessage);
 bridge_deserialize!(PreKeySignalMessage::try_from);

--- a/rust/bridge/shared/src/lib.rs
+++ b/rust/bridge/shared/src/lib.rs
@@ -58,6 +58,15 @@ fn publickey_compare(
     }
 }
 
+#[bridge_fn(jni = "ECPublicKey_1Verify")]
+fn publickey_verify(
+    key: &PublicKey,
+    message: &[u8],
+    signature: &[u8],
+) -> Result<bool, SignalProtocolError> {
+    key.verify_signature(&message, &signature)
+}
+
 
 bridge_destroy!(PrivateKey, ffi = privatekey, jni = ECPrivateKey);
 bridge_deserialize!(

--- a/rust/bridge/shared/src/lib.rs
+++ b/rust/bridge/shared/src/lib.rs
@@ -30,8 +30,8 @@ bridge_get_string!(name(ProtocolAddress), ffi = address_get_name =>
     |p| Ok(p.name())
 );
 
-#[bridge_fn(jni = "ProtocolAddress_1New")]
-fn address_new(name: String, device_id: u32) -> ProtocolAddress {
+#[bridge_fn(ffi = "address_new")]
+fn ProtocolAddress_New(name: String, device_id: u32) -> ProtocolAddress {
     ProtocolAddress::new(name, device_id)
 }
 
@@ -46,8 +46,8 @@ bridge_get_bytearray!(
     PublicKey::public_key_bytes
 );
 
-#[bridge_fn(jni = "ECPublicKey_1Compare")]
-fn publickey_compare(
+#[bridge_fn(ffi = "publickey_compare")]
+fn ECPublicKey_Compare(
     key1: &PublicKey,
     key2: &PublicKey,
 ) -> i32 {
@@ -58,8 +58,8 @@ fn publickey_compare(
     }
 }
 
-#[bridge_fn(jni = "ECPublicKey_1Verify")]
-fn publickey_verify(
+#[bridge_fn(ffi = "publickey_verify")]
+fn ECPublicKey_Verify(
     key: &PublicKey,
     message: &[u8],
     signature: &[u8],
@@ -90,12 +90,12 @@ bridge_get_bytearray!(
 bridge_get_string!(display_string(Fingerprint), jni = NumericFingerprintGenerator_1GetDisplayString =>
     Fingerprint::display_string
 );
-#[bridge_fn(jni = "DisplayableFingerprint_1Format")]
-fn fingerprint_format(local: &[u8], remote: &[u8]) -> Result<String, SignalProtocolError> {
-    DisplayableFingerprint::new(&local, &remote).map(|f| format!("{}", f))
+#[bridge_fn(ffi = "fingerprint_format")]
+fn DisplayableFingerprint_Format(local: &[u8], remote: &[u8]) -> Result<String, SignalProtocolError> {
+    DisplayableFingerprint::new(&local, &remote).map(|f| f.to_string())
 }
-#[bridge_fn(jni = "ScannableFingerprint_1Compare")]
-fn fingerprint_compare(fprint1: &[u8], fprint2: &[u8]) -> Result<bool, SignalProtocolError> {
+#[bridge_fn(ffi = "fingerprint_compare")]
+fn ScannableFingerprint_Compare(fprint1: &[u8], fprint2: &[u8]) -> Result<bool, SignalProtocolError> {
     ScannableFingerprint::deserialize(&fprint1)?.compare(fprint2)
 }
 
@@ -112,8 +112,8 @@ bridge_get_bytearray!(get_serialized(SignalMessage), ffi = message_get_serialize
     |m| Ok(m.serialized())
 );
 
-#[bridge_fn(jni = "SignalMessage_1New")]
-fn message_new(
+#[bridge_fn(ffi = "message_new")]
+fn SignalMessage_New(
     message_version: u8,
     mac_key: &[u8],
     sender_ratchet_key: &PublicKey,
@@ -135,8 +135,8 @@ fn message_new(
     )
 }
 
-#[bridge_fn(jni = "SignalMessage_1VerifyMac")]
-fn message_verify_mac(
+#[bridge_fn(ffi = "message_verify_mac")]
+fn SignalMessage_VerifyMac(
     msg: &SignalMessage,
     sender_identity_key: &PublicKey,
     receiver_identity_key: &PublicKey,
@@ -149,8 +149,8 @@ fn message_verify_mac(
     )
 }
 
-#[bridge_fn(jni = "PreKeySignalMessage_1New")]
-fn pre_key_signal_message_new(
+#[bridge_fn]
+fn PreKeySignalMessage_New(
     message_version: u8,
     registration_id: u32,
     pre_key_id: Option<u32>,

--- a/rust/bridge/shared/src/lib.rs
+++ b/rust/bridge/shared/src/lib.rs
@@ -112,6 +112,65 @@ bridge_get_bytearray!(get_serialized(SignalMessage), ffi = message_get_serialize
     |m| Ok(m.serialized())
 );
 
+#[bridge_fn(jni = "SignalMessage_1New")]
+fn message_new(
+    message_version: u8,
+    mac_key: &[u8],
+    sender_ratchet_key: &PublicKey,
+    counter: u32,
+    previous_counter: u32,
+    ciphertext: &[u8],
+    sender_identity_key: &PublicKey,
+    receiver_identity_key: &PublicKey,
+) -> Result<SignalMessage, SignalProtocolError> {
+    SignalMessage::new(
+        message_version,
+        mac_key,
+        *sender_ratchet_key,
+        counter,
+        previous_counter,
+        ciphertext,
+        &IdentityKey::new(*sender_identity_key),
+        &IdentityKey::new(*receiver_identity_key),
+    )
+}
+
+#[bridge_fn(jni = "SignalMessage_1VerifyMac")]
+fn message_verify_mac(
+    msg: &SignalMessage,
+    sender_identity_key: &PublicKey,
+    receiver_identity_key: &PublicKey,
+    mac_key: &[u8],
+) -> Result<bool, SignalProtocolError> {
+    msg.verify_mac(
+        &IdentityKey::new(*sender_identity_key),
+        &IdentityKey::new(*receiver_identity_key),
+        &mac_key,
+    )
+}
+
+#[bridge_fn(jni = "PreKeySignalMessage_1New")]
+fn pre_key_signal_message_new(
+    message_version: u8,
+    registration_id: u32,
+    pre_key_id: Option<u32>,
+    signed_pre_key_id: u32,
+    base_key: &PublicKey,
+    identity_key: &PublicKey,
+    signal_message: &SignalMessage,
+) -> Result<PreKeySignalMessage, SignalProtocolError> {
+    PreKeySignalMessage::new(
+        message_version,
+        registration_id,
+        pre_key_id,
+        signed_pre_key_id,
+        *base_key,
+        IdentityKey::new(*identity_key),
+        signal_message.clone(),
+    )
+}
+
+
 bridge_destroy!(PreKeySignalMessage);
 bridge_deserialize!(PreKeySignalMessage::try_from);
 bridge_get_bytearray!(serialize(PreKeySignalMessage), jni = PreKeySignalMessage_1GetSerialized =>

--- a/rust/bridge/shared/src/lib.rs
+++ b/rust/bridge/shared/src/lib.rs
@@ -90,6 +90,15 @@ bridge_get_bytearray!(
 bridge_get_string!(display_string(Fingerprint), jni = NumericFingerprintGenerator_1GetDisplayString =>
     Fingerprint::display_string
 );
+#[bridge_fn(jni = "DisplayableFingerprint_1Format")]
+fn fingerprint_format(local: &[u8], remote: &[u8]) -> Result<String, SignalProtocolError> {
+    DisplayableFingerprint::new(&local, &remote).map(|f| format!("{}", f))
+}
+#[bridge_fn(jni = "ScannableFingerprint_1Compare")]
+fn fingerprint_compare(fprint1: &[u8], fprint2: &[u8]) -> Result<bool, SignalProtocolError> {
+    ScannableFingerprint::deserialize(&fprint1)?.compare(fprint2)
+}
+
 
 bridge_destroy!(SignalMessage, ffi = message);
 bridge_deserialize!(SignalMessage::try_from, ffi = message);

--- a/rust/bridge/shared/src/lib.rs
+++ b/rust/bridge/shared/src/lib.rs
@@ -46,6 +46,19 @@ bridge_get_bytearray!(
     PublicKey::public_key_bytes
 );
 
+#[bridge_fn(jni = "ECPublicKey_1Compare")]
+fn publickey_compare(
+    key1: &PublicKey,
+    key2: &PublicKey,
+) -> i32 {
+    match key1.cmp(&key2) {
+        std::cmp::Ordering::Less => -1,
+        std::cmp::Ordering::Equal => 0,
+        std::cmp::Ordering::Greater => 1,
+    }
+}
+
+
 bridge_destroy!(PrivateKey, ffi = privatekey, jni = ECPrivateKey);
 bridge_deserialize!(
     PrivateKey::deserialize,

--- a/rust/bridge/shared/src/lib.rs
+++ b/rust/bridge/shared/src/lib.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::missing_safety_doc)]
 
 use aes_gcm_siv::Aes256GcmSiv;
+use libsignal_bridge_macros::*;
 use libsignal_protocol_rust::*;
 use std::convert::TryFrom;
 
@@ -28,6 +29,11 @@ bridge_destroy!(ProtocolAddress, ffi = address);
 bridge_get_string!(name(ProtocolAddress), ffi = address_get_name =>
     |p| Ok(p.name())
 );
+
+#[bridge_fn(jni = "ProtocolAddress_1New")]
+fn address_new(name: String, device_id: u32) -> ProtocolAddress {
+    ProtocolAddress::new(name, device_id)
+}
 
 bridge_destroy!(PublicKey, ffi = publickey, jni = ECPublicKey);
 bridge_deserialize!(PublicKey::deserialize, ffi = publickey, jni = None);

--- a/rust/bridge/shared/src/lib.rs
+++ b/rust/bridge/shared/src/lib.rs
@@ -25,6 +25,11 @@ pub mod jni;
 mod support;
 use support::*;
 
+bridge_handle!(ProtocolAddress);
+bridge_handle!(PublicKey);
+bridge_handle!(SignalMessage);
+bridge_handle!(PreKeySignalMessage);
+
 bridge_destroy!(ProtocolAddress, ffi = address);
 bridge_get_string!(name(ProtocolAddress), ffi = address_get_name =>
     |p| Ok(p.name())

--- a/rust/bridge/shared/src/support.rs
+++ b/rust/bridge/shared/src/support.rs
@@ -3,7 +3,21 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-pub use paste::paste;
+use futures::pin_mut;
+use futures::task::noop_waker_ref;
+use std::future::Future;
+use std::task::{self, Poll};
+
+pub(crate) use paste::paste;
+
+#[track_caller]
+pub fn expect_ready<F: Future>(future: F) -> F::Output {
+    pin_mut!(future);
+    match future.poll(&mut task::Context::from_waker(noop_waker_ref())) {
+        Poll::Ready(result) => result,
+        Poll::Pending => panic!("future was not ready"),
+    }
+}
 
 /// Wraps an expression in a function with a given name and type...
 /// except that if the expression is a closure with a single typeless argument,

--- a/rust/bridge/shared/src/support.rs
+++ b/rust/bridge/shared/src/support.rs
@@ -33,6 +33,15 @@ macro_rules! expr_as_fn {
     };
 }
 
+// macro_rules! bridge_fn {
+//     (ffi = $ffi_name:ident, jni = $jni_name:ident, $($body:tt)+) => {
+//         #[cfg(feature = "ffi")]
+//         ffi_bridge_fn!($ffi_name $($body)+);
+//         // #[cfg(feature = "jni")]
+//         // jni_bridge_get_string!($name($typ) $(as $jni_name)? => $body);
+//     }
+// }
+
 macro_rules! bridge_destroy {
     ($typ:ty $(, ffi = $ffi_name:ident)? $(, jni = $jni_name:ident)? ) => {
         #[cfg(feature = "ffi")]

--- a/rust/bridge/shared/src/support.rs
+++ b/rust/bridge/shared/src/support.rs
@@ -33,14 +33,14 @@ macro_rules! expr_as_fn {
     };
 }
 
-// macro_rules! bridge_fn {
-//     (ffi = $ffi_name:ident, jni = $jni_name:ident, $($body:tt)+) => {
-//         #[cfg(feature = "ffi")]
-//         ffi_bridge_fn!($ffi_name $($body)+);
-//         // #[cfg(feature = "jni")]
-//         // jni_bridge_get_string!($name($typ) $(as $jni_name)? => $body);
-//     }
-// }
+macro_rules! bridge_handle {
+    ($typ:ty) => {
+        #[cfg(feature = "ffi")]
+        ffi_bridge_handle!($typ);
+        #[cfg(feature = "jni")]
+        jni_bridge_handle!($typ);
+    };
+}
 
 macro_rules! bridge_destroy {
     ($typ:ty $(, ffi = $ffi_name:ident)? $(, jni = $jni_name:ident)? ) => {

--- a/swift/Sources/SignalClient/PublicKey.swift
+++ b/swift/Sources/SignalClient/PublicKey.swift
@@ -53,7 +53,7 @@ public class PublicKey: ClonableHandleOwner {
         var result: Bool = false
         try message.withUnsafeBytes { messageBytes in
             try signature.withUnsafeBytes { signatureBytes in
-                try checkError(signal_publickey_verify(nativeHandle, &result, messageBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), messageBytes.count, signatureBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), signatureBytes.count))
+                try checkError(signal_publickey_verify(&result, nativeHandle, messageBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), messageBytes.count, signatureBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), signatureBytes.count))
             }
         }
         return result

--- a/swift/Sources/SignalClient/messages/PreKeySignalMessage.swift
+++ b/swift/Sources/SignalClient/messages/PreKeySignalMessage.swift
@@ -29,12 +29,10 @@ public class PreKeySignalMessage {
                 identityKey: PublicKey,
                 message: SignalMessage) throws {
 
-        var preKeyId = preKeyId ?? 0xFFFFFFFF
-
         try checkError(signal_pre_key_signal_message_new(&handle,
                                                          version,
                                                          registrationId,
-                                                         &preKeyId,
+                                                         preKeyId ?? .max,
                                                          signedPreKeyId,
                                                          baseKey.nativeHandle,
                                                          identityKey.nativeHandle,

--- a/swift/Sources/SignalFfi/signal_ffi.h
+++ b/swift/Sources/SignalFfi/signal_ffi.h
@@ -196,25 +196,10 @@ SignalFfiError *signal_hkdf_derive(unsigned char *output,
                                    const unsigned char *info,
                                    size_t info_len);
 
-SignalFfiError *signal_address_new(SignalProtocolAddress **address,
-                                   const char *name,
-                                   unsigned int device_id);
-
 SignalFfiError *signal_address_get_device_id(const SignalProtocolAddress *obj, unsigned int *out);
 
 SignalFfiError *signal_address_clone(SignalProtocolAddress **new_obj,
                                      const SignalProtocolAddress *obj);
-
-SignalFfiError *signal_publickey_compare(int32_t *result,
-                                         const SignalPublicKey *key1,
-                                         const SignalPublicKey *key2);
-
-SignalFfiError *signal_publickey_verify(const SignalPublicKey *key,
-                                        bool *result,
-                                        const unsigned char *message,
-                                        size_t message_len,
-                                        const unsigned char *signature,
-                                        size_t signature_len);
 
 SignalFfiError *signal_publickey_clone(SignalPublicKey **new_obj, const SignalPublicKey *obj);
 
@@ -254,12 +239,6 @@ SignalFfiError *signal_session_record_archive_current_state(SignalSessionRecord 
 SignalFfiError *signal_session_record_clone(SignalSessionRecord **new_obj,
                                             const SignalSessionRecord *obj);
 
-SignalFfiError *signal_fingerprint_format(const char **fprint,
-                                          const unsigned char *local,
-                                          size_t local_len,
-                                          const unsigned char *remote,
-                                          size_t remote_len);
-
 SignalFfiError *signal_fingerprint_new(SignalFingerprint **obj,
                                        unsigned int iterations,
                                        unsigned int version,
@@ -272,24 +251,6 @@ SignalFfiError *signal_fingerprint_new(SignalFingerprint **obj,
 
 SignalFfiError *signal_fingerprint_clone(SignalFingerprint **new_obj, const SignalFingerprint *obj);
 
-SignalFfiError *signal_fingerprint_compare(bool *result,
-                                           const unsigned char *fprint1,
-                                           size_t fprint1_len,
-                                           const unsigned char *fprint2,
-                                           size_t fprint2_len);
-
-SignalFfiError *signal_message_new(SignalMessage **obj,
-                                   unsigned char message_version,
-                                   const unsigned char *mac_key,
-                                   size_t mac_key_len,
-                                   const SignalPublicKey *sender_ratchet_key,
-                                   unsigned int counter,
-                                   unsigned int previous_counter,
-                                   const unsigned char *ciphertext,
-                                   size_t ciphertext_len,
-                                   const SignalPublicKey *sender_identity_key,
-                                   const SignalPublicKey *receiver_identity_key);
-
 SignalFfiError *signal_message_clone(SignalMessage **new_obj, const SignalMessage *obj);
 
 SignalFfiError *signal_message_get_sender_ratchet_key(SignalPublicKey **new_obj,
@@ -298,22 +259,6 @@ SignalFfiError *signal_message_get_sender_ratchet_key(SignalPublicKey **new_obj,
 SignalFfiError *signal_message_get_message_version(const SignalMessage *obj, unsigned int *out);
 
 SignalFfiError *signal_message_get_counter(const SignalMessage *obj, unsigned int *out);
-
-SignalFfiError *signal_message_verify_mac(bool *result,
-                                          const SignalMessage *handle,
-                                          const SignalPublicKey *sender_identity_key,
-                                          const SignalPublicKey *receiver_identity_key,
-                                          const unsigned char *mac_key,
-                                          size_t mac_key_len);
-
-SignalFfiError *signal_pre_key_signal_message_new(SignalPreKeySignalMessage **obj,
-                                                  unsigned char message_version,
-                                                  unsigned int registration_id,
-                                                  const unsigned int *pre_key_id,
-                                                  unsigned int signed_pre_key_id,
-                                                  const SignalPublicKey *base_key,
-                                                  const SignalPublicKey *identity_key,
-                                                  const SignalMessage *signal_message);
 
 SignalFfiError *signal_pre_key_signal_message_clone(SignalPreKeySignalMessage **new_obj,
                                                     const SignalPreKeySignalMessage *obj);
@@ -639,6 +584,10 @@ SignalFfiError *signal_address_destroy(SignalProtocolAddress *p);
 
 SignalFfiError *signal_address_get_name(const SignalProtocolAddress *obj, const char **out);
 
+SignalFfiError *signal_address_new(SignalProtocolAddress **out,
+                                   const char *name,
+                                   uint32_t device_id);
+
 SignalFfiError *signal_publickey_destroy(SignalPublicKey *p);
 
 SignalFfiError *signal_publickey_deserialize(SignalPublicKey **p,
@@ -652,6 +601,17 @@ SignalFfiError *signal_publickey_serialize(const SignalPublicKey *obj,
 SignalFfiError *signal_publickey_get_public_key_bytes(const SignalPublicKey *obj,
                                                       const unsigned char **out,
                                                       size_t *out_len);
+
+SignalFfiError *signal_publickey_compare(int32_t *out,
+                                         const SignalPublicKey *key1,
+                                         const SignalPublicKey *key2);
+
+SignalFfiError *signal_publickey_verify(bool *out,
+                                        const SignalPublicKey *key,
+                                        const unsigned char *message,
+                                        size_t message_len,
+                                        const unsigned char *signature,
+                                        size_t signature_len);
 
 SignalFfiError *signal_privatekey_destroy(SignalPrivateKey *p);
 
@@ -671,6 +631,18 @@ SignalFfiError *signal_fingerprint_scannable_encoding(const SignalFingerprint *o
 
 SignalFfiError *signal_fingerprint_display_string(const SignalFingerprint *obj, const char **out);
 
+SignalFfiError *signal_fingerprint_format(const char **out,
+                                          const unsigned char *local,
+                                          size_t local_len,
+                                          const unsigned char *remote,
+                                          size_t remote_len);
+
+SignalFfiError *signal_fingerprint_compare(bool *out,
+                                           const unsigned char *fprint1,
+                                           size_t fprint1_len,
+                                           const unsigned char *fprint2,
+                                           size_t fprint2_len);
+
 SignalFfiError *signal_message_destroy(SignalMessage *p);
 
 SignalFfiError *signal_message_deserialize(SignalMessage **p,
@@ -684,6 +656,34 @@ SignalFfiError *signal_message_get_body(const SignalMessage *obj,
 SignalFfiError *signal_message_get_serialized(const SignalMessage *obj,
                                               const unsigned char **out,
                                               size_t *out_len);
+
+SignalFfiError *signal_message_new(SignalMessage **out,
+                                   uint8_t message_version,
+                                   const unsigned char *mac_key,
+                                   size_t mac_key_len,
+                                   const SignalPublicKey *sender_ratchet_key,
+                                   uint32_t counter,
+                                   uint32_t previous_counter,
+                                   const unsigned char *ciphertext,
+                                   size_t ciphertext_len,
+                                   const SignalPublicKey *sender_identity_key,
+                                   const SignalPublicKey *receiver_identity_key);
+
+SignalFfiError *signal_message_verify_mac(bool *out,
+                                          const SignalMessage *msg,
+                                          const SignalPublicKey *sender_identity_key,
+                                          const SignalPublicKey *receiver_identity_key,
+                                          const unsigned char *mac_key,
+                                          size_t mac_key_len);
+
+SignalFfiError *signal_pre_key_signal_message_new(SignalPreKeySignalMessage **out,
+                                                  uint8_t message_version,
+                                                  uint32_t registration_id,
+                                                  uint32_t pre_key_id,
+                                                  uint32_t signed_pre_key_id,
+                                                  const SignalPublicKey *base_key,
+                                                  const SignalPublicKey *identity_key,
+                                                  const SignalMessage *signal_message);
 
 SignalFfiError *signal_pre_key_signal_message_destroy(SignalPreKeySignalMessage *p);
 


### PR DESCRIPTION
This is *one* approach to generic bridge functions that have the same body in FFI and JNI, with the only difference being input and output types. Here's what it looks like:

```rust
#[bridge_fn(ffi = "publickey_compare")]
fn ECPublicKey_Compare(key1: &PublicKey, key2: &PublicKey) -> i32 {
    match key1.cmp(&key2) {
        std::cmp::Ordering::Less => -1,
        std::cmp::Ordering::Equal => 0,
        std::cmp::Ordering::Greater => 1,
    }
}

#[bridge_fn(ffi = "publickey_verify")]
fn ECPublicKey_Verify(
    key: &PublicKey,
    message: &[u8],
    signature: &[u8],
) -> Result<bool, SignalProtocolError> {
    key.verify_signature(&message, &signature)
}
```

This has a few moving pieces:
- `bridge_fn` is a proc-macro that expands into an FFI entry point and a JNI entry point, each of which call the original function. It classifies arguments as "by value", "by ref", or "array" (pointer + length in FFI).
- Individual input and output types are mapped by "rules" macros in the `ffi` and `jni` submodules, so that cbindgen (which only does a syntactic walk) can output the right types.
- There are specific traits (ArgTypeInfo, RefArgTypeInfo, SizedArgTypeInfo, ResultTypeInfo) for arbitrary conversion logic (what was formerly handled by things like `jint_to_u32`).

Thus, adding a new function is easy; adding a new type is not too bad (about the same as the ad hoc conversion functions from before); adding a new *kind* of type is tricky but won't happen often.