### PR TITLE
Rust: Move deny-warnings behavior into CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -105,7 +105,7 @@ jobs:
       run: cargo test --all --verbose
 
     - name: Clippy
-      run: cargo clippy --all
+      run: cargo clippy --all -- -D warnings
 
   java:
     name: Java

--- a/rust/aes-gcm-siv/src/lib.rs
+++ b/rust/aes-gcm-siv/src/lib.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-#![deny(warnings)]
 #![cfg_attr(target_arch = "aarch64", feature(stdsimd))]
 #![cfg_attr(target_arch = "aarch64", feature(aarch64_target_feature))]
 

--- a/rust/bridge/ffi/src/lib.rs
+++ b/rust/bridge/ffi/src/lib.rs
@@ -4,7 +4,6 @@
 //
 
 #![allow(clippy::missing_safety_doc)]
-#![deny(warnings)]
 
 use async_trait::async_trait;
 use libc::{c_char, c_int, c_uchar, c_uint, c_ulonglong, size_t};

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -4,7 +4,6 @@
 //
 
 #![allow(clippy::missing_safety_doc)]
-#![deny(warnings)]
 
 use async_trait::async_trait;
 use jni::objects::{JClass, JObject, JString, JValue};

--- a/rust/bridge/shared/src/lib.rs
+++ b/rust/bridge/shared/src/lib.rs
@@ -4,7 +4,6 @@
 //
 
 #![allow(clippy::missing_safety_doc)]
-// #![deny(warnings)]
 
 use aes_gcm_siv::Aes256GcmSiv;
 use libsignal_protocol_rust::*;

--- a/rust/protocol/src/lib.rs
+++ b/rust/protocol/src/lib.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-#![deny(warnings)]
 #![deny(unsafe_code)]
 
 mod address;


### PR DESCRIPTION
Warnings don't need to be immediately fixed locally, and they make it harder to test with newer nightlies. CI is the place to enforce it.