### PR TITLE
Add the logic for handling revoked server certificates

### DIFF
--- a/rust/protocol/src/sealed_sender.rs
+++ b/rust/protocol/src/sealed_sender.rs
@@ -27,6 +27,18 @@ pub struct ServerCertificate {
     signature: Vec<u8>,
 }
 
+/*
+0xDEADC357 is a server certificate ID which is used to test the
+revocation logic. As of this writing, no prod server certificates have
+been revoked. If one ever does, add its key ID here.
+
+If a production server certificate is ever generated which collides
+with this test certificate ID, Bad Things will happen.
+*/
+const REVOKED_SERVER_CERTIFICATE_KEY_IDS : &[u32] = &[
+    0xDEADC357,
+];
+
 impl ServerCertificate {
     pub fn deserialize(data: &[u8]) -> Result<Self> {
         let pb = proto::sealed_sender::ServerCertificate::decode(data)?;
@@ -101,6 +113,9 @@ impl ServerCertificate {
     }
 
     pub fn validate(&self, trust_root: &PublicKey) -> Result<bool> {
+        if REVOKED_SERVER_CERTIFICATE_KEY_IDS.contains(&self.key_id()?) {
+            return Ok(false);
+        }
         trust_root.verify_signature(&self.certificate, &self.signature)
     }
 

--- a/rust/protocol/src/sealed_sender.rs
+++ b/rust/protocol/src/sealed_sender.rs
@@ -35,9 +35,7 @@ been revoked. If one ever does, add its key ID here.
 If a production server certificate is ever generated which collides
 with this test certificate ID, Bad Things will happen.
 */
-const REVOKED_SERVER_CERTIFICATE_KEY_IDS : &[u32] = &[
-    0xDEADC357,
-];
+const REVOKED_SERVER_CERTIFICATE_KEY_IDS: &[u32] = &[0xDEADC357];
 
 impl ServerCertificate {
     pub fn deserialize(data: &[u8]) -> Result<Self> {

--- a/rust/protocol/tests/sealed_sender.rs
+++ b/rust/protocol/tests/sealed_sender.rs
@@ -53,6 +53,26 @@ fn test_server_cert() -> Result<(), SignalProtocolError> {
 }
 
 #[test]
+fn test_revoked_server_cert() -> Result<(), SignalProtocolError> {
+    let mut rng = OsRng;
+    let trust_root = KeyPair::generate(&mut rng);
+    let server_key = KeyPair::generate(&mut rng);
+
+    let revoked_id = 0xDEADC357;
+
+    let server_cert =
+        ServerCertificate::new(revoked_id, server_key.public_key, &trust_root.private_key, &mut rng)?;
+
+    let serialized = server_cert.serialized()?.to_vec();
+
+    let recovered = ServerCertificate::deserialize(&serialized)?;
+
+    assert_eq!(recovered.validate(&trust_root.public_key), Ok(false));
+
+    Ok(())
+}
+
+#[test]
 fn test_sender_cert() -> Result<(), SignalProtocolError> {
     let mut rng = OsRng;
     let trust_root = KeyPair::generate(&mut rng);

--- a/rust/protocol/tests/sealed_sender.rs
+++ b/rust/protocol/tests/sealed_sender.rs
@@ -60,8 +60,12 @@ fn test_revoked_server_cert() -> Result<(), SignalProtocolError> {
 
     let revoked_id = 0xDEADC357;
 
-    let server_cert =
-        ServerCertificate::new(revoked_id, server_key.public_key, &trust_root.private_key, &mut rng)?;
+    let server_cert = ServerCertificate::new(
+        revoked_id,
+        server_key.public_key,
+        &trust_root.private_key,
+        &mut rng,
+    )?;
 
     let serialized = server_cert.serialized()?.to_vec();
 


### PR DESCRIPTION
Reserve one ID for testing

ServerCertificates are created by
https://github.com/signalapp/Signal-Server-Private/blob/master/service/src/main/java/org/whispersystems/textsecuregcm/workers/CertificateCommand.java I'm going to open a PR reserving this value there so we never have a tragic collision between test and prod values
