### PR TITLE
Use the correct handle

### DIFF
--- a/swift/Sources/SignalClient/state/SenderKeyRecord.swift
+++ b/swift/Sources/SignalClient/state/SenderKeyRecord.swift
@@ -15,8 +15,6 @@ public class SenderKeyRecord: ClonableHandleOwner {
         return signal_sender_key_record_clone(&newHandle, currentHandle)
     }
 
-    private var handle: OpaquePointer?
-
     public init<Bytes: ContiguousBytes>(bytes: Bytes) throws {
         let handle: OpaquePointer? = try bytes.withUnsafeBytes {
             var result: OpaquePointer?

--- a/swift/Sources/SignalClient/state/SenderKeyRecord.swift
+++ b/swift/Sources/SignalClient/state/SenderKeyRecord.swift
@@ -43,7 +43,7 @@ public class SenderKeyRecord: ClonableHandleOwner {
     public func serialize() -> [UInt8] {
         return failOnError {
             try invokeFnReturningArray {
-                signal_sender_key_record_serialize(handle, $0, $1)
+                signal_sender_key_record_serialize(nativeHandle, $0, $1)
             }
         }
     }


### PR DESCRIPTION
Fixes #120

I am not happy that this is not caught by the compiler. A grep seems to indicate this was the only such mistake.

Possibly ClonableOwnerHandle.handle should be `fileprivate`?