### PR TITLE
Swift: fix Xcode build on Big Sur

### DIFF
--- a/swift/build_ffi.sh
+++ b/swift/build_ffi.sh
@@ -42,5 +42,13 @@ done
 
 check_rust
 
+if [[ -n "${DEVELOPER_SDK_DIR:-}" ]]; then
+  # Assume we're in Xcode, which means we're probably cross-compiling.
+  # In this case, we need to add an extra library search path for build scripts and proc-macros,
+  # which run on the host instead of the target.
+  # (macOS Big Sur does not have linkable libraries in /usr/lib/.)
+  export LIBRARY_PATH="${DEVELOPER_SDK_DIR}/MacOSX.sdk/usr/lib:${LIBRARY_PATH:-}"
+fi
+
 set -x
 cargo build -p libsignal-ffi ${RELEASE_BUILD:+--release}


### PR DESCRIPTION
Rust build scripts and proc-macros are compiled for the host, rather than the target, which means they need a search path to link against the host's libraries. macOS Big Sur doesn't provide that in the default search paths anymore, so we add one manually based on an environment variable provided by Xcode.

Fixes #84.