### PR TITLE
Convert fingerprints to use proto2 encoding

### DIFF
--- a/rust/protocol/src/fingerprint.rs
+++ b/rust/protocol/src/fingerprint.rs
@@ -223,6 +223,26 @@ mod test {
     const BOB_STABLE_ID: &str = "+14153333333";
 
     #[test]
+    fn fingerprint_encodings() -> Result<()> {
+        let l = vec![0x12; 32];
+        let r = vec![0xBA; 32];
+
+        let fprint0 = ScannableFingerprint::new(0, &l, &r);
+        let proto0 = fprint0.serialize()?;
+
+        let expected0_encoding = "12220a20".to_owned() + &"12".repeat(32) + "1a220a20" + &"ba".repeat(32);
+        assert_eq!(hex::encode(proto0), expected0_encoding);
+
+        let fprint2 = ScannableFingerprint::new(2, &l, &r);
+        let proto2 = fprint2.serialize()?;
+
+        let expected2_encoding = "080212220a20".to_owned() + &"12".repeat(32) + "1a220a20" + &"ba".repeat(32);
+        assert_eq!(hex::encode(proto2), expected2_encoding);
+
+        Ok(())
+    }
+
+    #[test]
     fn fingerprint_test_v1() {
         // testVectorsVersion1 in Java
 

--- a/rust/protocol/src/fingerprint.rs
+++ b/rust/protocol/src/fingerprint.rs
@@ -83,7 +83,9 @@ impl ScannableFingerprint {
         let fingerprint = proto::fingerprint::CombinedFingerprints::decode(protobuf)?;
 
         Ok(Self {
-            version: fingerprint.version.ok_or(SignalProtocolError::InvalidProtobufEncoding)?,
+            version: fingerprint
+                .version
+                .ok_or(SignalProtocolError::InvalidProtobufEncoding)?,
             local_fingerprint: fingerprint
                 .local_fingerprint
                 .ok_or(SignalProtocolError::InvalidProtobufEncoding)?
@@ -236,7 +238,8 @@ mod test {
         let fprint2 = ScannableFingerprint::new(2, &l, &r);
         let proto2 = fprint2.serialize()?;
 
-        let expected2_encoding = "080212220a20".to_owned() + &"12".repeat(32) + "1a220a20" + &"ba".repeat(32);
+        let expected2_encoding =
+            "080212220a20".to_owned() + &"12".repeat(32) + "1a220a20" + &"ba".repeat(32);
         assert_eq!(hex::encode(proto2), expected2_encoding);
 
         Ok(())

--- a/rust/protocol/src/fingerprint.rs
+++ b/rust/protocol/src/fingerprint.rs
@@ -83,26 +83,28 @@ impl ScannableFingerprint {
         let fingerprint = proto::fingerprint::CombinedFingerprints::decode(protobuf)?;
 
         Ok(Self {
-            version: fingerprint.version,
+            version: fingerprint.version.ok_or(SignalProtocolError::InvalidProtobufEncoding)?,
             local_fingerprint: fingerprint
                 .local_fingerprint
                 .ok_or(SignalProtocolError::InvalidProtobufEncoding)?
-                .content,
+                .content
+                .ok_or(SignalProtocolError::InvalidProtobufEncoding)?,
             remote_fingerprint: fingerprint
                 .remote_fingerprint
                 .ok_or(SignalProtocolError::InvalidProtobufEncoding)?
-                .content,
+                .content
+                .ok_or(SignalProtocolError::InvalidProtobufEncoding)?,
         })
     }
 
     pub fn serialize(&self) -> Result<Vec<u8>> {
         let combined_fingerprints = proto::fingerprint::CombinedFingerprints {
-            version: self.version,
+            version: Some(self.version),
             local_fingerprint: Some(proto::fingerprint::LogicalFingerprint {
-                content: self.local_fingerprint.to_owned(),
+                content: Some(self.local_fingerprint.to_owned()),
             }),
             remote_fingerprint: Some(proto::fingerprint::LogicalFingerprint {
-                content: self.remote_fingerprint.to_owned(),
+                content: Some(self.remote_fingerprint.to_owned()),
             }),
         };
 
@@ -114,7 +116,7 @@ impl ScannableFingerprint {
     pub fn compare(&self, combined: &[u8]) -> Result<bool> {
         let combined = proto::fingerprint::CombinedFingerprints::decode(combined)?;
 
-        if combined.version != self.version {
+        if combined.version.unwrap_or(0) != self.version {
             return Err(SignalProtocolError::FingerprintVersionMismatch);
         }
 
@@ -128,12 +130,16 @@ impl ScannableFingerprint {
             .as_ref()
             .unwrap()
             .content
+            .as_ref()
+            .ok_or(SignalProtocolError::InvalidProtobufEncoding)?
             .ct_eq(&self.remote_fingerprint);
         let same2 = combined
             .remote_fingerprint
             .as_ref()
             .unwrap()
             .content
+            .as_ref()
+            .ok_or(SignalProtocolError::InvalidProtobufEncoding)?
             .ct_eq(&self.local_fingerprint);
 
         Ok(same1.into() && same2.into())
@@ -226,12 +232,6 @@ mod test {
     fn fingerprint_encodings() -> Result<()> {
         let l = vec![0x12; 32];
         let r = vec![0xBA; 32];
-
-        let fprint0 = ScannableFingerprint::new(0, &l, &r);
-        let proto0 = fprint0.serialize()?;
-
-        let expected0_encoding = "12220a20".to_owned() + &"12".repeat(32) + "1a220a20" + &"ba".repeat(32);
-        assert_eq!(hex::encode(proto0), expected0_encoding);
 
         let fprint2 = ScannableFingerprint::new(2, &l, &r);
         let proto2 = fprint2.serialize()?;

--- a/rust/protocol/src/proto/fingerprint.proto
+++ b/rust/protocol/src/proto/fingerprint.proto
@@ -1,4 +1,4 @@
-syntax = "proto3";
+syntax = "proto2";
 
 //
 // Copyright 2020 Signal Messenger, LLC.
@@ -8,12 +8,12 @@ syntax = "proto3";
 package signal.proto.fingerprint;
 
 message LogicalFingerprint {
-  bytes content = 1;
+  optional bytes content = 1;
   // bytes identifier = 2;
 }
 
 message CombinedFingerprints {
-  uint32             version            = 1;
-  LogicalFingerprint local_fingerprint  = 2;
-  LogicalFingerprint remote_fingerprint = 3;
+  optional uint32             version            = 1;
+  optional LogicalFingerprint local_fingerprint  = 2;
+  optional LogicalFingerprint remote_fingerprint = 3;
 }


### PR DESCRIPTION
The encoding test was generated before switching to proto2 so we can feel comfortable that nothing is broken.

The encoding does change in the case of version == 0 since in proto2 the value is still included whereas in proto3 the version would be omitted in that case. This is harmless in this situation since the earliest valid fingerprint version is 1.