### PR TITLE
Node: list files for `yarn pack`; add an alias `yarn build` for faster Rust turnaround

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build/Release/*.node"
   ],
   "scripts": {
+    "build": "node-gyp build",
     "tsc": "tsc -p node && cp node/*.d.ts node/dist",
     "clean": "rimraf node/dist build",
     "test": "electron-mocha --recursive node/dist/test",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "private": true,
   "main": "node/dist/index.js",
   "types": "node/dist/index.d.ts",
+  "files": [
+    "node/dist/**",
+    "build/Release/*.node"
+  ],
   "scripts": {
     "tsc": "tsc -p node && cp node/*.d.ts node/dist",
     "clean": "rimraf node/dist build",


### PR DESCRIPTION
My hope is that `yarn pack` (on each build platform) will do the copying we need for the artifact repo, making it a drop-in change to use the source repo instead, but for now it's just there. `yarn build` addresses Jack's complaint in #124 that `yarn install` always calls `yarn node-gyp rebuild`, which does a clean.