### PR TITLE
Implement IdentityKeyPair Deserialize

### DIFF
--- a/java/java/src/main/java/org/signal/internal/Native.java
+++ b/java/java/src/main/java/org/signal/internal/Native.java
@@ -96,6 +96,7 @@ public final class Native {
 
   public static native byte[] HKDF_DeriveSecrets(int version, byte[] inputKeyMaterial, byte[] salt, byte[] info, int outputLength);
 
+  public static native long[] IdentityKeyPair_Deserialize(byte[] data);
   public static native byte[] IdentityKeyPair_Serialize(long publicKeyHandle, long privateKeyHandle);
 
   public static native void NumericFingerprintGenerator_Destroy(long handle);

--- a/java/java/src/main/java/org/whispersystems/libsignal/IdentityKey.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/IdentityKey.java
@@ -32,6 +32,10 @@ public class IdentityKey {
     this.publicKey = Curve.decodePoint(bytes, 0);
   }
 
+  public IdentityKey(long nativeHandle) {
+    this.publicKey = new ECPublicKey(nativeHandle);
+  }
+
   public ECPublicKey getPublicKey() {
     return publicKey;
   }

--- a/java/java/src/main/java/org/whispersystems/libsignal/IdentityKeyPair.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/IdentityKeyPair.java
@@ -23,6 +23,15 @@ public class IdentityKeyPair {
     this.privateKey = privateKey;
   }
 
+  public IdentityKeyPair(byte[] serialized) {
+    long[] tuple = Native.IdentityKeyPair_Deserialize(serialized);
+    long publicKeyHandle = tuple[0];
+    long privateKeyHandle = tuple[1];
+
+    this.publicKey = new IdentityKey(publicKeyHandle);
+    this.privateKey = new ECPrivateKey(privateKeyHandle);
+  }
+
   public IdentityKey getPublicKey() {
     return publicKey;
   }
@@ -31,7 +40,7 @@ public class IdentityKeyPair {
     return privateKey;
   }
 
-  byte[] serialize() {
+  public byte[] serialize() {
     return Native.IdentityKeyPair_Serialize(this.publicKey.nativeHandle(), this.privateKey.nativeHandle());
   }
 }

--- a/rust/bridge/jni/bin/gen_java_decl.py
+++ b/rust/bridge/jni/bin/gen_java_decl.py
@@ -46,6 +46,7 @@ def translate_to_java(typ):
         "jstring": "String",
         "JString": "String",
         "jbyteArray": "byte[]",
+        "jlongArray": "long[]",
         "ObjectHandle": "long",
         "jint": "int",
         "jlong": "long",


### PR DESCRIPTION
This PR adds jni glue code for the `IdentityKeyPair` `deserialize` method and makes the `serialize` method public, as it was previously in the libsignal-protocol-java library.
The `IdentityKeyPair` consists of a private and public key, so the deserialize method needs to return a handle for each key. I've implemented the tuple as a simple java array with two elements. It's not very type safe but seemed the simplest solution here.

Is this something you'd consider merging?
I use these two methods in my signal-cli project.