### PR TITLE
protocol: Remove spurious session state archiving processing a prekey

### DIFF
--- a/rust/protocol/src/session.rs
+++ b/rust/protocol/src/session.rs
@@ -109,8 +109,6 @@ async fn process_prekey_v3(
         *message.base_key(),
     );
 
-    session_record.archive_current_state()?;
-
     let mut new_session = ratchet::initialize_bob_session(&parameters)?;
 
     new_session.set_local_registration_id(identity_store.get_local_registration_id(ctx).await?)?;


### PR DESCRIPTION
`promote_state`, called below, is already going to archive the previous session state.