### PR TITLE
Swift: add SessionRecord.hasCurrentState

### DIFF
--- a/rust/bridge/ffi/src/lib.rs
+++ b/rust/bridge/ffi/src/lib.rs
@@ -147,6 +147,21 @@ pub unsafe extern "C" fn signal_session_record_archive_current_state(
     })
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn signal_session_record_has_current_state(
+    result: *mut bool,
+    session_record: *const SessionRecord,
+) -> *mut SignalFfiError {
+    run_ffi_safe(|| {
+        if result.is_null() {
+            return Err(SignalFfiError::NullPointer);
+        }
+        let session_record = native_handle_cast::<SessionRecord>(session_record)?;
+        *result = session_record.has_current_session_state();
+        Ok(())
+    })
+}
+
 ffi_fn_clone!(signal_session_record_clone clones SessionRecord);
 
 #[no_mangle]

--- a/rust/protocol/src/state/session.rs
+++ b/rust/protocol/src/state/session.rs
@@ -500,6 +500,10 @@ impl SessionRecord {
         Ok(false)
     }
 
+    pub fn has_current_session_state(&self) -> bool {
+        self.current_session.is_some()
+    }
+
     pub(crate) fn session_state(&self) -> Result<&SessionState> {
         if let Some(ref session) = self.current_session {
             Ok(session)

--- a/swift/Sources/SignalClient/state/SessionRecord.swift
+++ b/swift/Sources/SignalClient/state/SessionRecord.swift
@@ -36,13 +36,19 @@ public class SessionRecord: ClonableHandleOwner {
         }
     }
 
+    public var hasCurrentState: Bool {
+        var result = false
+        failOnError(signal_session_record_has_current_state(&result, nativeHandle))
+        return result
+    }
+
+    public func archiveCurrentState() {
+        failOnError(signal_session_record_archive_current_state(nativeHandle))
+    }
+
     public func remoteRegistrationId() throws -> UInt32 {
         return try invokeFnReturningInteger {
             signal_session_record_get_remote_registration_id(nativeHandle, $0)
         }
-    }
-
-    public func archiveCurrentState() {
-        return failOnError(signal_session_record_archive_current_state(nativeHandle))
     }
 }

--- a/swift/Sources/SignalFfi/signal_ffi.h
+++ b/swift/Sources/SignalFfi/signal_ffi.h
@@ -215,6 +215,9 @@ SignalFfiError *signal_session_record_get_remote_registration_id(const SignalSes
 
 SignalFfiError *signal_session_record_archive_current_state(SignalSessionRecord *session_record);
 
+SignalFfiError *signal_session_record_has_current_state(bool *result,
+                                                        const SignalSessionRecord *session_record);
+
 SignalFfiError *signal_session_record_clone(SignalSessionRecord **new_obj,
                                             const SignalSessionRecord *obj);
 

--- a/swift/Tests/SignalClientTests/SessionTests.swift
+++ b/swift/Tests/SignalClientTests/SessionTests.swift
@@ -37,6 +37,7 @@ class SessionTests: TestCaseBase {
                                  identityStore: alice_store,
                                  context: NullContext())
 
+        XCTAssertEqual(try! alice_store.loadSession(for: bob_address, context: NullContext())?.hasCurrentState, true)
         XCTAssertEqual(try! alice_store.loadSession(for: bob_address, context: NullContext())?.remoteRegistrationId(),
                        try! bob_store.localRegistrationId(context: NullContext()))
 
@@ -191,11 +192,30 @@ class SessionTests: TestCaseBase {
         XCTAssertEqual(plaintext.sender, sender_addr)
     }
 
+    func testArchiveSession() throws {
+        let bob_address = try! ProtocolAddress(name: "+14151111112", deviceId: 1)
+
+        let alice_store = InMemorySignalProtocolStore()
+        let bob_store = InMemorySignalProtocolStore()
+
+        initializeSessions(alice_store: alice_store, bob_store: bob_store, bob_address: bob_address)
+
+        let session: SessionRecord! = try! alice_store.loadSession(for: bob_address, context: NullContext())
+        XCTAssertNotNil(session)
+        XCTAssertTrue(session.hasCurrentState)
+        session.archiveCurrentState()
+        XCTAssertFalse(session.hasCurrentState)
+        // A redundant archive shouldn't break anything.
+        session.archiveCurrentState()
+        XCTAssertFalse(session.hasCurrentState)
+    }
+
     static var allTests: [(String, (SessionTests) -> () throws -> Void)] {
         return [
             ("testSessionCipher", testSessionCipher),
             ("testSessionCipherWithBadStore", testSessionCipherWithBadStore),
             ("testSealedSenderSession", testSealedSenderSession),
+            ("testArchiveSession", testArchiveSession),
         ]
     }
 }


### PR DESCRIPTION
If a session has just been reset (`archiveCurrentState()`), then there won't be an active state in the session and sends will fail until a new session is properly established by the client.