### PR TITLE
Resolve difference in behavior between Java and Rust SessionRecord

### DIFF
--- a/java/tests/src/test/java/org/whispersystems/libsignal/SessionRecordTest.java
+++ b/java/tests/src/test/java/org/whispersystems/libsignal/SessionRecordTest.java
@@ -1,0 +1,20 @@
+//
+// Copyright 2021 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+package org.whispersystems.libsignal;
+
+import junit.framework.TestCase;
+import org.whispersystems.libsignal.state.SessionRecord;
+
+public class SessionRecordTest extends TestCase {
+
+  public void testUninitAccess() {
+    SessionRecord empty_record = new SessionRecord();
+
+    assertFalse(empty_record.hasSenderChain());
+
+    assertEquals(empty_record.getSessionVersion(), 0);
+  }
+}

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -1518,8 +1518,11 @@ jni_fn_get_jint!(Java_org_signal_client_internal_Native_SessionRecord_1GetLocalR
 jni_fn_get_jint!(Java_org_signal_client_internal_Native_SessionRecord_1GetRemoteRegistrationId(SessionRecord) using SessionRecord::remote_registration_id);
 
 // For historical reasons Android assumes this function will return zero if there is no session state
-jni_fn_get_jint!(Java_org_signal_client_internal_Native_SessionRecord_1GetSessionVersion(SessionRecord) using
-                 |s: &SessionRecord| Ok(s.session_version().unwrap_or(0)));
+jni_fn_get_jint!(Java_org_signal_client_internal_Native_SessionRecord_1GetSessionVersion(SessionRecord) using |s: &SessionRecord| match s.session_version() {
+    Ok(v) => Ok(v),
+    Err(SignalProtocolError::InvalidState(_, _)) => Ok(0),
+    Err(e) => Err(e)
+});
 
 jni_fn_get_jboolean!(Java_org_signal_client_internal_Native_SessionRecord_1HasSenderChain(SessionRecord) using SessionRecord::has_sender_chain);
 

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -1516,7 +1516,10 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SessionRecord_1F
 
 jni_fn_get_jint!(Java_org_signal_client_internal_Native_SessionRecord_1GetLocalRegistrationId(SessionRecord) using SessionRecord::local_registration_id);
 jni_fn_get_jint!(Java_org_signal_client_internal_Native_SessionRecord_1GetRemoteRegistrationId(SessionRecord) using SessionRecord::remote_registration_id);
-jni_fn_get_jint!(Java_org_signal_client_internal_Native_SessionRecord_1GetSessionVersion(SessionRecord) using SessionRecord::session_version);
+
+// For historical reasons Android assumes this function will return zero if there is no session state
+jni_fn_get_jint!(Java_org_signal_client_internal_Native_SessionRecord_1GetSessionVersion(SessionRecord) using
+                 |s: &SessionRecord| Ok(s.session_version().unwrap_or(0)));
 
 jni_fn_get_jboolean!(Java_org_signal_client_internal_Native_SessionRecord_1HasSenderChain(SessionRecord) using SessionRecord::has_sender_chain);
 

--- a/rust/protocol/src/state/session.rs
+++ b/rust/protocol/src/state/session.rs
@@ -577,7 +577,10 @@ impl SessionRecord {
     }
 
     pub fn has_sender_chain(&self) -> Result<bool> {
-        self.session_state()?.has_sender_chain()
+        match &self.current_session {
+            Some(session) => session.has_sender_chain(),
+            None => Ok(false),
+        }
     }
 
     pub fn alice_base_key(&self) -> Result<&[u8]> {

--- a/rust/protocol/tests/sealed_sender.rs
+++ b/rust/protocol/tests/sealed_sender.rs
@@ -100,6 +100,7 @@ fn test_sender_cert() -> Result<(), SignalProtocolError> {
             Err(e) => match e {
                 SignalProtocolError::InvalidProtobufEncoding
                 | SignalProtocolError::ProtobufDecodingError(_)
+                | SignalProtocolError::BadKeyLength(_, _)
                 | SignalProtocolError::BadKeyType(_) => {}
 
                 unexpected_err => {


### PR DESCRIPTION
In libsignal-protocol-java, SessionRecord holds a SesssionState struct which is the "active" session plus a list of old states. If the record is freshly created, there is still a SessionState, but it is an uninitialized/new protobuf structure which causes all fields to be empty/zero/false.

So in the original Java logic you can call for example hasSenderChain, and on an empty/fresh record it will return false. However in Rust, in this case the Option is empty and we return an error instead.

For hasSenderChain, it seems reasonable to return false if there is no active session, since if there is no session there is certainly no chain.

Android also expects the session version to be == 0 on such sessions, but this makes less sense, so have this logic only in the Java binding and not in the Rust library proper.