### PR TITLE
Install toolchains after cargo ndk

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -148,11 +148,11 @@ jobs:
       with:
         profile: minimal
 
-    - name: Install Android toolchains
-      run: rustup target add aarch64-linux-android armv7-linux-androideabi x86_64-linux-android i686-linux-android
-
     - name: Install NDK tool
       run: cargo install cargo-ndk
+
+    - name: Install Android toolchains
+      run: rustup target add aarch64-linux-android armv7-linux-androideabi x86_64-linux-android i686-linux-android
 
     - name: Verify that the JNI bindings are up to date
       run: rust/bridge/jni/bin/gen_java_decl.py --verify


### PR DESCRIPTION
This seems to be required with cargo-ndk 2.0.0