### PR TITLE
Use `thiserror` for error type

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -152,7 +152,7 @@ jobs:
       run: rustup target add aarch64-linux-android armv7-linux-androideabi x86_64-linux-android i686-linux-android
 
     - name: Install NDK tool
-      run: cargo install cargo-ndk
+      run: cargo install --version=1.0.0 cargo-ndk
 
     - name: Verify that the JNI bindings are up to date
       run: rust/bridge/jni/bin/gen_java_decl.py --verify

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -107,6 +107,9 @@ jobs:
     - name: Run tests
       run: cargo test --all --verbose
 
+    - name: Build benches
+      run: cargo build --benches --verbose
+
     - name: Clippy
       run: cargo clippy --all -- -D warnings
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,6 +864,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+ "syn-mid",
  "unzip3",
 ]
 
@@ -1634,6 +1635,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "syn-mid"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baa8e7560a164edb1621a55d18a0c59abf49d360f47aa7b821061dd7eea7fac9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,6 +909,7 @@ dependencies = [
  "rand",
  "sha2",
  "subtle",
+ "thiserror",
  "x25519-dalek",
 ]
 
@@ -1663,6 +1664,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,10 +849,21 @@ dependencies = [
  "futures",
  "jni",
  "libc",
+ "libsignal-bridge-macros",
  "libsignal-protocol-rust",
  "log",
  "paste",
  "thiserror",
+]
+
+[[package]]
+name = "libsignal-bridge-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unzip3",
 ]
 
 [[package]]
@@ -1773,6 +1784,12 @@ dependencies = [
  "generic-array",
  "subtle",
 ]
+
+[[package]]
+name = "unzip3"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99c0ec316ab08201476c032feb2f94a5c8ece5b209765c1fbc4430dd6e931ad6"
 
 [[package]]
 name = "ureq"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,6 +860,7 @@ dependencies = [
 name = "libsignal-bridge-macros"
 version = "0.1.0"
 dependencies = [
+ "heck",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,6 +849,7 @@ dependencies = [
  "jni",
  "libc",
  "libsignal-protocol-rust",
+ "log",
  "paste",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,7 @@ dependencies = [
  "serde",
  "serde_json",
  "subtle",
+ "thiserror",
 ]
 
 [[package]]
@@ -849,6 +850,7 @@ dependencies = [
  "libc",
  "libsignal-protocol-rust",
  "paste",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,6 +846,7 @@ name = "libsignal-bridge"
 version = "0.1.0"
 dependencies = [
  "aes-gcm-siv",
+ "futures",
  "jni",
  "libc",
  "libsignal-protocol-rust",
@@ -860,7 +861,6 @@ version = "0.1.0"
 dependencies = [
  "aes-gcm-siv",
  "async-trait",
- "futures",
  "libc",
  "libsignal-bridge",
  "libsignal-protocol-rust",
@@ -875,7 +875,6 @@ version = "0.1.0"
 dependencies = [
  "aes-gcm-siv",
  "async-trait",
- "futures",
  "jni",
  "libsignal-bridge",
  "libsignal-protocol-rust",

--- a/binding.gyp
+++ b/binding.gyp
@@ -4,9 +4,14 @@
 #
 
 {
+    'conditions': [
+        ['OS=="mac"', {'variables': {'NODE_OS_NAME': 'darwin'}},
+         'OS=="win"', {'variables': {'NODE_OS_NAME': 'win32'}},
+         {'variables': {'NODE_OS_NAME': '<(OS)'}}],
+    ],
     'targets': [
         {
-            'target_name': 'libsignal_client.node',
+            'target_name': 'libsignal_client_<(NODE_OS_NAME).node',
             'type': 'none',
             'actions': [
                 {
@@ -15,11 +20,12 @@
                         'env',
                         'CONFIGURATION_NAME=<(CONFIGURATION_NAME)',
                         'CARGO_BUILD_TARGET_DIR=<(INTERMEDIATE_DIR)/rust',
+                        'NODE_OS_NAME=<(NODE_OS_NAME)',
                         'node/build_node_bridge.sh',
                         '-o', '<(PRODUCT_DIR)/'],
                     'inputs': [],
                     'outputs': [
-                        '<(PRODUCT_DIR)/libsignal_client.node',
+                        '<(PRODUCT_DIR)/<(_target_name)',
                         # This really needs to be environment-variable-sensitive, but node-gyp doesn't support that. Cargo will still save work if possible.
                         '<(PRODUCT_DIR)/nonexistent-file-to-force-rebuild'
                     ]

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -1,5 +1,5 @@
 subprojects {
-    ext.version_number     = "0.2.0"
+    ext.version_number     = "0.2.1"
     ext.group_info         = "org.whispersystems"
 
     if (JavaVersion.current().isJava8Compatible()) {

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -1,5 +1,5 @@
 subprojects {
-    ext.version_number     = "0.2.1"
+    ext.version_number     = "0.2.2"
     ext.group_info         = "org.whispersystems"
 
     if (JavaVersion.current().isJava8Compatible()) {

--- a/java/java/src/main/java/org/signal/internal/Native.java
+++ b/java/java/src/main/java/org/signal/internal/Native.java
@@ -86,7 +86,7 @@ public final class Native {
   public static native void ECPublicKey_Destroy(long handle);
   public static native byte[] ECPublicKey_GetPublicKeyBytes(long handle);
   public static native byte[] ECPublicKey_Serialize(long handle);
-  public static native boolean ECPublicKey_Verify(long handle, byte[] message, byte[] signature);
+  public static native boolean ECPublicKey_Verify(long key, byte[] message, byte[] signature);
 
   public static native byte[] GroupCipher_DecryptMessage(long senderKeyName, byte[] message, SenderKeyStore store);
   public static native byte[] GroupCipher_EncryptMessage(long senderKeyName, byte[] message, SenderKeyStore store);

--- a/java/java/src/main/java/org/signal/internal/Native.java
+++ b/java/java/src/main/java/org/signal/internal/Native.java
@@ -133,7 +133,7 @@ public final class Native {
   public static native byte[] PreKeySignalMessage_GetSignalMessage(long handle);
   public static native int PreKeySignalMessage_GetSignedPreKeyId(long handle);
   public static native int PreKeySignalMessage_GetVersion(long handle);
-  public static native long PreKeySignalMessage_New(int messageVersion, int registrationId, int preKeyId, int signedPreKeyId, long baseKeyHandle, long identityKeyHandle, long signalMessageHandle);
+  public static native long PreKeySignalMessage_New(int messageVersion, int registrationId, int preKeyId, int signedPreKeyId, long baseKey, long identityKey, long signalMessage);
 
   public static native void ProtocolAddress_Destroy(long handle);
   public static native int ProtocolAddress_DeviceId(long handle);
@@ -230,7 +230,7 @@ public final class Native {
   public static native byte[] SignalMessage_GetSenderRatchetKey(long handle);
   public static native byte[] SignalMessage_GetSerialized(long handle);
   public static native long SignalMessage_New(int messageVersion, byte[] macKey, long senderRatchetKey, int counter, int previousCounter, byte[] ciphertext, long senderIdentityKey, long receiverIdentityKey);
-  public static native boolean SignalMessage_VerifyMac(long handle, long senderIdentityKey, long receiverIdentityKey, byte[] macKey);
+  public static native boolean SignalMessage_VerifyMac(long msg, long senderIdentityKey, long receiverIdentityKey, byte[] macKey);
 
   public static native long SignedPreKeyRecord_Deserialize(byte[] data);
   public static native void SignedPreKeyRecord_Destroy(long handle);

--- a/java/tests/src/test/java/org/whispersystems/libsignal/SessionBuilderTest.java
+++ b/java/tests/src/test/java/org/whispersystems/libsignal/SessionBuilderTest.java
@@ -293,8 +293,7 @@ public class SessionBuilderTest extends TestCase {
       plaintext = bobSessionCipher.decrypt(incomingMessage);
       throw new AssertionError("Decrypt should have failed!");
     } catch (InvalidKeyIdException e) {
-      // Note: This is the message coming from libsignal-client, NOT from TestNoSignedPreKeysStore.
-      assertEquals("invalid signed prekey identifier", e.getMessage());
+      assertEquals("TestNoSignedPreKeysStore rejected loading 22", e.getMessage());
     }
   }
 
@@ -335,10 +334,8 @@ public class SessionBuilderTest extends TestCase {
       throw new AssertionError("Decrypt should have failed!");
     } catch (InvalidKeyIdException e) {
       throw new AssertionError("libsignal-client swallowed the exception");
-    } catch (RuntimeException e) {
-      assertEquals("exception thrown while calling 'loadSignedPreKey'", e.getMessage());
-      assertNotNull(e.getCause());
-      assertTrue(e.getCause() instanceof TestBadSignedPreKeysStore.CustomException);
+    } catch (TestBadSignedPreKeysStore.CustomException e) {
+      // success!
     }
   }
 

--- a/java/tests/src/test/java/org/whispersystems/libsignal/TestBadSignedPreKeysStore.java
+++ b/java/tests/src/test/java/org/whispersystems/libsignal/TestBadSignedPreKeysStore.java
@@ -1,0 +1,17 @@
+package org.whispersystems.libsignal;
+
+import org.whispersystems.libsignal.InvalidKeyIdException;
+import org.whispersystems.libsignal.state.SignedPreKeyRecord;
+
+public class TestBadSignedPreKeysStore extends TestInMemorySignalProtocolStore {
+  public static class CustomException extends RuntimeException {
+    CustomException(String message) {
+      super(message);
+    }
+  }
+
+  @Override
+  public SignedPreKeyRecord loadSignedPreKey(int signedPreKeyId) throws InvalidKeyIdException {
+    throw new CustomException("TestBadSignedPreKeysStore rejected loading " + signedPreKeyId);
+  }
+}

--- a/java/tests/src/test/java/org/whispersystems/libsignal/groups/GroupCipherTest.java
+++ b/java/tests/src/test/java/org/whispersystems/libsignal/groups/GroupCipherTest.java
@@ -229,7 +229,7 @@ public class GroupCipherTest extends TestCase {
 
     bobSessionBuilder.process(aliceName, aliceDistributionMessage);
 
-    for (int i=0;i<1000001;i++) {
+    for (int i=0;i<25001;i++) {
       aliceGroupCipher.encrypt("up the punks".getBytes());
     }
 

--- a/java/tests/src/test/java/org/whispersystems/libsignal/groups/GroupCipherTest.java
+++ b/java/tests/src/test/java/org/whispersystems/libsignal/groups/GroupCipherTest.java
@@ -229,7 +229,7 @@ public class GroupCipherTest extends TestCase {
 
     bobSessionBuilder.process(aliceName, aliceDistributionMessage);
 
-    for (int i=0;i<2001;i++) {
+    for (int i=0;i<1000001;i++) {
       aliceGroupCipher.encrypt("up the punks".getBytes());
     }
 

--- a/node/build_node_bridge.sh
+++ b/node/build_node_bridge.sh
@@ -15,9 +15,15 @@ usage() {
   cat >&2 <<END
 Usage: $(basename "$0") [-d] [-o DIR/]
 
+This script is intended to be run as part of \`node-gyp build\` (or
+\`yarn install\`). If you run it manually, you must provide certain environment
+variables (see below).
+
 Options:
 	-d -- debug build (default is release, follows \$CONFIGURATION_NAME)
 	-o -- where to copy the built module (default: build/\$CONFIGURATION_NAME)
+
+\$NODE_OS_NAME must also be set to the value of Node's \`os.platform()\`.
 END
 }
 
@@ -57,10 +63,16 @@ case ${CONFIGURATION_NAME} in
     exit 1
 esac
 
+if [[ -z "${NODE_OS_NAME:-}" ]]; then
+  echo 'error: NODE_OS_NAME not set' >&2
+  echo "note: run through \`yarn install\` to populate this automatically" >&2
+  exit 1
+fi
+
 OUT_DIR=${OUT_DIR:-build/${CONFIGURATION_NAME}}
 
 check_rust
 
 echo_then_run cargo build -p libsignal-node ${CARGO_PROFILE_ARG}
 
-copy_built_library "${CARGO_BUILD_TARGET_DIR:-target}/${CARGO_BUILD_TARGET:-}/${CARGO_PROFILE_DIR}" signal_node "${OUT_DIR}"/libsignal_client.node
+copy_built_library "${CARGO_BUILD_TARGET_DIR:-target}/${CARGO_BUILD_TARGET:-}/${CARGO_PROFILE_DIR}" signal_node "${OUT_DIR}"/libsignal_client_"${NODE_OS_NAME}".node

--- a/node/index.ts
+++ b/node/index.ts
@@ -3,10 +3,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+import * as os from 'os';
 import bindings = require('bindings'); // eslint-disable-line @typescript-eslint/no-require-imports
 import * as SignalClient from './libsignal_client';
 
-const SC = bindings('libsignal_client') as typeof SignalClient;
+const SC = bindings('libsignal_client_' + os.platform()) as typeof SignalClient;
 
 export class PublicKey {
   private readonly nativeHandle: SignalClient.PublicKey;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build/Release/*.node"
   ],
   "scripts": {
+    "build": "node-gyp build",
     "tsc": "tsc -p node && cp node/*.d.ts node/dist",
     "clean": "rimraf node/dist build",
     "test": "electron-mocha --recursive node/dist/test",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "private": true,
   "main": "node/dist/index.js",
   "types": "node/dist/index.d.ts",
+  "files": [
+    "node/dist/**",
+    "build/Release/*.node"
+  ],
   "scripts": {
     "tsc": "tsc -p node && cp node/*.d.ts node/dist",
     "clean": "rimraf node/dist build",

--- a/rust/aes-gcm-siv/Cargo.toml
+++ b/rust/aes-gcm-siv/Cargo.toml
@@ -18,6 +18,7 @@ polyval = "0.4"
 subtle = "2.3"
 cipher = "0.2"
 generic-array = "0.14"
+thiserror = "1.0"
 
 [target.'cfg(all(target_arch = "aarch64", any(target_os = "linux")))'.dependencies]
 libc = "0.2" # for getauxval

--- a/rust/aes-gcm-siv/src/error.rs
+++ b/rust/aes-gcm-siv/src/error.rs
@@ -3,27 +3,16 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use std::fmt;
-
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(thiserror::Error, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
+    #[error("invalid AES-GCM-SIV key size")]
     InvalidKeySize,
+    #[error("invalid AES-GCM-SIV nonce size")]
     InvalidNonceSize,
+    #[error("invalid AES-GCM-SIV input size")]
     InvalidInputSize,
+    #[error("invalid AES-GCM-SIV tag")]
     InvalidTag,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let err_msg = match self {
-            Error::InvalidKeySize => "invalid AES-GCM-SIV key size",
-            Error::InvalidNonceSize => "invalid AES-GCM-SIV nonce size",
-            Error::InvalidInputSize => "invalid AES-GCM-SIV input size",
-            Error::InvalidTag => "invalid AES-GCM-SIV tag",
-        };
-
-        write!(f, "{}", err_msg)
-    }
-}

--- a/rust/bridge/ffi/Cargo.toml
+++ b/rust/bridge/ffi/Cargo.toml
@@ -20,7 +20,6 @@ aes-gcm-siv = { path = "../../aes-gcm-siv" }
 libsignal-bridge = { path = "../shared", features = ["ffi"] }
 async-trait = "0.1.41"
 libc = "0.2"
-futures = "0.3.7"
 rand = "0.7.3"
 static_assertions = "1.1"
 log = "0.4.11"

--- a/rust/bridge/ffi/src/lib.rs
+++ b/rust/bridge/ffi/src/lib.rs
@@ -117,25 +117,6 @@ ffi_fn_get_uint32!(signal_address_get_device_id(ProtocolAddress) using
 ffi_fn_clone!(signal_address_clone clones ProtocolAddress);
 
 #[no_mangle]
-pub unsafe extern "C" fn signal_publickey_compare(
-    result: *mut i32,
-    key1: *const PublicKey,
-    key2: *const PublicKey,
-) -> *mut SignalFfiError {
-    run_ffi_safe(|| {
-        let key1 = native_handle_cast::<PublicKey>(key1)?;
-        let key2 = native_handle_cast::<PublicKey>(key2)?;
-
-        *result = match key1.cmp(&key2) {
-            std::cmp::Ordering::Less => -1,
-            std::cmp::Ordering::Equal => 0,
-            std::cmp::Ordering::Greater => 1,
-        };
-        Ok(())
-    })
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn signal_publickey_verify(
     key: *const PublicKey,
     result: *mut bool,

--- a/rust/bridge/ffi/src/lib.rs
+++ b/rust/bridge/ffi/src/lib.rs
@@ -116,26 +116,6 @@ ffi_fn_get_uint32!(signal_address_get_device_id(ProtocolAddress) using
 
 ffi_fn_clone!(signal_address_clone clones ProtocolAddress);
 
-#[no_mangle]
-pub unsafe extern "C" fn signal_publickey_verify(
-    key: *const PublicKey,
-    result: *mut bool,
-    message: *const c_uchar,
-    message_len: size_t,
-    signature: *const c_uchar,
-    signature_len: size_t,
-) -> *mut SignalFfiError {
-    run_ffi_safe(|| {
-        *result = false; // pre-set to invalid state
-        let key = native_handle_cast::<PublicKey>(key)?;
-        let message = as_slice(message, message_len)?;
-        let signature = as_slice(signature, signature_len)?;
-
-        *result = key.verify_signature(&message, &signature)?;
-        Ok(())
-    })
-}
-
 ffi_fn_clone!(signal_publickey_clone clones PublicKey);
 
 #[no_mangle]

--- a/rust/bridge/ffi/src/lib.rs
+++ b/rust/bridge/ffi/src/lib.rs
@@ -111,18 +111,6 @@ pub unsafe extern "C" fn signal_hkdf_derive(
     })
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn signal_address_new(
-    address: *mut *mut ProtocolAddress,
-    name: *const c_char,
-    device_id: c_uint,
-) -> *mut SignalFfiError {
-    run_ffi_safe(|| {
-        let name = read_c_string(name)?;
-        box_object(address, Ok(ProtocolAddress::new(name, device_id)))
-    })
-}
-
 ffi_fn_get_uint32!(signal_address_get_device_id(ProtocolAddress) using
                    |obj: &ProtocolAddress| { Ok(obj.device_id()) });
 

--- a/rust/bridge/ffi/src/lib.rs
+++ b/rust/bridge/ffi/src/lib.rs
@@ -213,22 +213,6 @@ pub unsafe extern "C" fn signal_session_record_archive_current_state(
 ffi_fn_clone!(signal_session_record_clone clones SessionRecord);
 
 #[no_mangle]
-pub unsafe extern "C" fn signal_fingerprint_format(
-    fprint: *mut *const c_char,
-    local: *const c_uchar,
-    local_len: size_t,
-    remote: *const c_uchar,
-    remote_len: size_t,
-) -> *mut SignalFfiError {
-    run_ffi_safe(|| {
-        let local = as_slice(local, local_len)?;
-        let remote = as_slice(remote, remote_len)?;
-        let fingerprint = DisplayableFingerprint::new(&local, &remote).map(|f| format!("{}", f));
-        write_cstr_to(fprint, fingerprint)
-    })
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn signal_fingerprint_new(
     obj: *mut *mut Fingerprint,
     iterations: c_uint,
@@ -261,27 +245,6 @@ pub unsafe extern "C" fn signal_fingerprint_new(
 }
 
 ffi_fn_clone!(signal_fingerprint_clone clones Fingerprint);
-
-#[no_mangle]
-pub unsafe extern "C" fn signal_fingerprint_compare(
-    result: *mut bool,
-    fprint1: *const c_uchar,
-    fprint1_len: size_t,
-    fprint2: *const c_uchar,
-    fprint2_len: size_t,
-) -> *mut SignalFfiError {
-    run_ffi_safe(|| {
-        if fprint1.is_null() || fprint2.is_null() || result.is_null() {
-            return Err(SignalFfiError::NullPointer);
-        }
-        let fprint1 = as_slice(fprint1, fprint1_len)?;
-        let fprint2 = as_slice(fprint2, fprint2_len)?;
-
-        let fprint1 = ScannableFingerprint::deserialize(&fprint1)?;
-        *result = fprint1.compare(&fprint2)?;
-        Ok(())
-    })
-}
 
 #[no_mangle]
 pub unsafe extern "C" fn signal_message_new(

--- a/rust/bridge/ffi/src/lib.rs
+++ b/rust/bridge/ffi/src/lib.rs
@@ -12,6 +12,7 @@ use libsignal_protocol_rust::*;
 use static_assertions::const_assert_eq;
 use std::convert::TryFrom;
 use std::ffi::{c_void, CString};
+use std::fmt;
 
 use aes_gcm_siv::Aes256GcmSiv;
 
@@ -747,6 +748,26 @@ impl FfiIdentityKeyStore {
     }
 }
 
+#[derive(Debug)]
+struct CallbackError {
+    value: std::num::NonZeroI32,
+}
+
+impl CallbackError {
+    fn check(value: i32) -> Option<Self> {
+        let value = std::num::NonZeroI32::try_from(value).ok()?;
+        Some(Self { value })
+    }
+}
+
+impl fmt::Display for CallbackError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "error code {}", self.value)
+    }
+}
+
+impl std::error::Error for CallbackError {}
+
 #[async_trait(?Send)]
 impl IdentityKeyStore for FfiIdentityKeyStore {
     async fn get_identity_key_pair(
@@ -757,13 +778,11 @@ impl IdentityKeyStore for FfiIdentityKeyStore {
         let mut key = std::ptr::null_mut();
         let result = (self.store.get_identity_key_pair)(self.store.ctx, &mut key, ctx);
 
-        if result != 0 {
-            return Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError(
-                    "get_identity_key_pair",
-                    result,
-                ),
-            );
+        if let Some(error) = CallbackError::check(result) {
+            return Err(SignalProtocolError::ApplicationCallbackError(
+                "get_identity_key_pair",
+                Box::new(error),
+            ));
         }
 
         if key.is_null() {
@@ -781,13 +800,11 @@ impl IdentityKeyStore for FfiIdentityKeyStore {
         let mut id = 0;
         let result = (self.store.get_local_registration_id)(self.store.ctx, &mut id, ctx);
 
-        if result != 0 {
-            return Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError(
-                    "get_local_registration_id",
-                    result,
-                ),
-            );
+        if let Some(error) = CallbackError::check(result) {
+            return Err(SignalProtocolError::ApplicationCallbackError(
+                "get_local_registration_id",
+                Box::new(error),
+            ));
         }
 
         Ok(id)
@@ -806,9 +823,10 @@ impl IdentityKeyStore for FfiIdentityKeyStore {
         match result {
             0 => Ok(false),
             1 => Ok(true),
-            r => Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError("save_identity", r),
-            ),
+            r => Err(SignalProtocolError::ApplicationCallbackError(
+                "save_identity",
+                Box::new(CallbackError::check(r).unwrap()),
+            )),
         }
     }
 
@@ -835,12 +853,10 @@ impl IdentityKeyStore for FfiIdentityKeyStore {
         match result {
             0 => Ok(false),
             1 => Ok(true),
-            r => Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError(
-                    "is_trusted_identity",
-                    r,
-                ),
-            ),
+            r => Err(SignalProtocolError::ApplicationCallbackError(
+                "is_trusted_identity",
+                Box::new(CallbackError::check(r).unwrap()),
+            )),
         }
     }
 
@@ -853,13 +869,11 @@ impl IdentityKeyStore for FfiIdentityKeyStore {
         let mut key = std::ptr::null_mut();
         let result = (self.store.get_identity)(self.store.ctx, &mut key, &*address, ctx);
 
-        if result != 0 {
-            return Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError(
-                    "get_identity",
-                    result,
-                ),
-            );
+        if let Some(error) = CallbackError::check(result) {
+            return Err(SignalProtocolError::ApplicationCallbackError(
+                "get_identity",
+                Box::new(error),
+            ));
         }
 
         if key.is_null() {
@@ -918,13 +932,11 @@ impl PreKeyStore for FfiPreKeyStore {
         let mut record = std::ptr::null_mut();
         let result = (self.store.load_pre_key)(self.store.ctx, &mut record, prekey_id, ctx);
 
-        if result != 0 {
-            return Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError(
-                    "load_pre_key",
-                    result,
-                ),
-            );
+        if let Some(error) = CallbackError::check(result) {
+            return Err(SignalProtocolError::ApplicationCallbackError(
+                "load_pre_key",
+                Box::new(error),
+            ));
         }
 
         if record.is_null() {
@@ -944,13 +956,11 @@ impl PreKeyStore for FfiPreKeyStore {
         let ctx = ctx.unwrap_or(std::ptr::null_mut());
         let result = (self.store.store_pre_key)(self.store.ctx, prekey_id, &*record, ctx);
 
-        if result != 0 {
-            return Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError(
-                    "store_pre_key",
-                    result,
-                ),
-            );
+        if let Some(error) = CallbackError::check(result) {
+            return Err(SignalProtocolError::ApplicationCallbackError(
+                "store_pre_key",
+                Box::new(error),
+            ));
         }
 
         Ok(())
@@ -964,13 +974,11 @@ impl PreKeyStore for FfiPreKeyStore {
         let ctx = ctx.unwrap_or(std::ptr::null_mut());
         let result = (self.store.remove_pre_key)(self.store.ctx, prekey_id, ctx);
 
-        if result != 0 {
-            return Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError(
-                    "remove_pre_key",
-                    result,
-                ),
-            );
+        if let Some(error) = CallbackError::check(result) {
+            return Err(SignalProtocolError::ApplicationCallbackError(
+                "remove_pre_key",
+                Box::new(error),
+            ));
         }
 
         Ok(())
@@ -1021,13 +1029,11 @@ impl SignedPreKeyStore for FfiSignedPreKeyStore {
         let mut record = std::ptr::null_mut();
         let result = (self.store.load_signed_pre_key)(self.store.ctx, &mut record, prekey_id, ctx);
 
-        if result != 0 {
-            return Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError(
-                    "load_signed_pre_key",
-                    result,
-                ),
-            );
+        if let Some(error) = CallbackError::check(result) {
+            return Err(SignalProtocolError::ApplicationCallbackError(
+                "load_signed_pre_key",
+                Box::new(error),
+            ));
         }
 
         if record.is_null() {
@@ -1048,13 +1054,11 @@ impl SignedPreKeyStore for FfiSignedPreKeyStore {
         let ctx = ctx.unwrap_or(std::ptr::null_mut());
         let result = (self.store.store_signed_pre_key)(self.store.ctx, prekey_id, &*record, ctx);
 
-        if result != 0 {
-            return Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError(
-                    "store_signed_pre_key",
-                    result,
-                ),
-            );
+        if let Some(error) = CallbackError::check(result) {
+            return Err(SignalProtocolError::ApplicationCallbackError(
+                "store_signed_pre_key",
+                Box::new(error),
+            ));
         }
 
         Ok(())
@@ -1105,13 +1109,11 @@ impl SessionStore for FfiSessionStore {
         let mut record = std::ptr::null_mut();
         let result = (self.store.load_session)(self.store.ctx, &mut record, &*address, ctx);
 
-        if result != 0 {
-            return Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError(
-                    "load_session",
-                    result,
-                ),
-            );
+        if let Some(error) = CallbackError::check(result) {
+            return Err(SignalProtocolError::ApplicationCallbackError(
+                "load_session",
+                Box::new(error),
+            ));
         }
 
         if record.is_null() {
@@ -1132,13 +1134,11 @@ impl SessionStore for FfiSessionStore {
         let ctx = ctx.unwrap_or(std::ptr::null_mut());
         let result = (self.store.store_session)(self.store.ctx, &*address, &*record, ctx);
 
-        if result != 0 {
-            return Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError(
-                    "store_session",
-                    result,
-                ),
-            );
+        if let Some(error) = CallbackError::check(result) {
+            return Err(SignalProtocolError::ApplicationCallbackError(
+                "store_session",
+                Box::new(error),
+            ));
         }
 
         Ok(())
@@ -1365,13 +1365,11 @@ impl SenderKeyStore for FfiSenderKeyStore {
         let result =
             (self.store.store_sender_key)(self.store.ctx, &*sender_key_name, &*record, ctx);
 
-        if result != 0 {
-            return Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError(
-                    "store_sender_key",
-                    result,
-                ),
-            );
+        if let Some(error) = CallbackError::check(result) {
+            return Err(SignalProtocolError::ApplicationCallbackError(
+                "store_sender_key",
+                Box::new(error),
+            ));
         }
 
         Ok(())
@@ -1387,13 +1385,11 @@ impl SenderKeyStore for FfiSenderKeyStore {
         let result =
             (self.store.load_sender_key)(self.store.ctx, &mut record, &*sender_key_name, ctx);
 
-        if result != 0 {
-            return Err(
-                SignalProtocolError::ApplicationCallbackReturnedIntegerError(
-                    "load_sender_key",
-                    result,
-                ),
-            );
+        if let Some(error) = CallbackError::check(result) {
+            return Err(SignalProtocolError::ApplicationCallbackError(
+                "load_sender_key",
+                Box::new(error),
+            ));
         }
 
         if record.is_null() {

--- a/rust/bridge/ffi/src/util.rs
+++ b/rust/bridge/ffi/src/util.rs
@@ -58,7 +58,6 @@ impl From<&SignalFfiError> for SignalErrorCode {
             SignalFfiError::InvalidType => SignalErrorCode::InvalidType,
             SignalFfiError::UnexpectedPanic(_) => SignalErrorCode::InternalError,
 
-            SignalFfiError::CallbackError(_) => SignalErrorCode::CallbackError,
             SignalFfiError::InvalidUtf8String => SignalErrorCode::InvalidUtf8String,
             SignalFfiError::InsufficientOutputSize(_, _) => SignalErrorCode::InsufficientOutputSize,
 
@@ -137,6 +136,10 @@ impl From<&SignalFfiError> for SignalErrorCode {
 
             SignalFfiError::Signal(SignalProtocolError::InvalidArgument(_))
             | SignalFfiError::AesGcmSiv(_) => SignalErrorCode::InvalidArgument,
+
+            SignalFfiError::Signal(SignalProtocolError::ApplicationCallbackError(_, _)) => {
+                SignalErrorCode::CallbackError
+            }
 
             _ => SignalErrorCode::UnknownError,
         }

--- a/rust/bridge/ffi/src/util.rs
+++ b/rust/bridge/ffi/src/util.rs
@@ -3,14 +3,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use futures::pin_mut;
-use futures::task::noop_waker_ref;
 use libc::{c_char, c_uchar, c_uint, c_ulonglong, size_t};
 use libsignal_bridge::ffi::*;
 use libsignal_protocol_rust::*;
 use std::ffi::CStr;
-use std::future::Future;
-use std::task::{self, Poll};
 
 use aes_gcm_siv::Error as AesGcmSivError;
 
@@ -143,15 +139,6 @@ impl From<&SignalFfiError> for SignalErrorCode {
 
             _ => SignalErrorCode::UnknownError,
         }
-    }
-}
-
-#[track_caller]
-pub fn expect_ready<F: Future>(future: F) -> F::Output {
-    pin_mut!(future);
-    match future.poll(&mut task::Context::from_waker(noop_waker_ref())) {
-        Poll::Ready(result) => result,
-        Poll::Pending => panic!("future was not ready"),
     }
 }
 

--- a/rust/bridge/ffi/src/util.rs
+++ b/rust/bridge/ffi/src/util.rs
@@ -83,7 +83,7 @@ impl From<&SignalFfiError> for SignalErrorCode {
                 SignalErrorCode::InvalidKey
             }
 
-            SignalFfiError::Signal(SignalProtocolError::SessionNotFound) => {
+            SignalFfiError::Signal(SignalProtocolError::SessionNotFound(_)) => {
                 SignalErrorCode::SessionNotFound
             }
 

--- a/rust/bridge/ffi/src/util.rs
+++ b/rust/bridge/ffi/src/util.rs
@@ -111,6 +111,7 @@ impl From<&SignalFfiError> for SignalErrorCode {
             }
 
             SignalFfiError::Signal(SignalProtocolError::InvalidMessage(_))
+            | SignalFfiError::Signal(SignalProtocolError::MessageDecryptionFailed(_))
             | SignalFfiError::Signal(SignalProtocolError::InvalidProtobufEncoding)
             | SignalFfiError::Signal(SignalProtocolError::InvalidSealedSenderMessage(_)) => {
                 SignalErrorCode::InvalidMessage

--- a/rust/bridge/jni/Cargo.toml
+++ b/rust/bridge/jni/Cargo.toml
@@ -21,6 +21,5 @@ libsignal-protocol-rust = { path = "../../protocol" }
 aes-gcm-siv = { path = "../../aes-gcm-siv" }
 libsignal-bridge = { path = "../shared", features = ["jni"] }
 async-trait = "0.1.41"
-futures = "0.3.7"
 jni = "0.17"
 rand = "0.7.3"

--- a/rust/bridge/jni/bin/gen_java_decl.py
+++ b/rust/bridge/jni/bin/gen_java_decl.py
@@ -35,7 +35,11 @@ cbindgen = subprocess.Popen(['cbindgen'], cwd=os.path.join(our_abs_dir, '..'), s
 stdout = str(stdout.decode('utf8'))
 stderr = str(stderr.decode('utf8'))
 
-ignore_this_warning = re.compile(r"WARN: Can't find .*\. This usually means that this type was incompatible or not found\.")
+ignore_this_warning = re.compile(
+    "("
+    r"WARN: Can't find .*\. This usually means that this type was incompatible or not found\.|"
+    r"WARN: Missing `\[defines\]` entry for `feature = \"jni\"` in cbindgen config\."
+    ")")
 
 unknown_warning = False
 

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -201,113 +201,11 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_HKDF_1DeriveSecr
     })
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SignalMessage_1New(
-    env: JNIEnv,
-    _class: JClass,
-    message_version: jint,
-    mac_key: jbyteArray,
-    sender_ratchet_key: ObjectHandle,
-    counter: jint,
-    previous_counter: jint,
-    ciphertext: jbyteArray,
-    sender_identity_key: ObjectHandle,
-    receiver_identity_key: ObjectHandle,
-) -> ObjectHandle {
-    run_ffi_safe(&env, || {
-        let message_version = jint_to_u8(message_version)?;
-        let mac_key = env.convert_byte_array(mac_key)?;
-        let sender_ratchet_key = native_handle_cast::<PublicKey>(sender_ratchet_key)?;
-        let counter = jint_to_u32(counter)?;
-        let previous_counter = jint_to_u32(previous_counter)?;
-        let ciphertext = env.convert_byte_array(ciphertext)?;
-
-        let sender_identity_key = native_handle_cast::<PublicKey>(sender_identity_key)?;
-        let receiver_identity_key = native_handle_cast::<PublicKey>(receiver_identity_key)?;
-
-        let msg = SignalMessage::new(
-            message_version,
-            &mac_key,
-            *sender_ratchet_key,
-            counter,
-            previous_counter,
-            &ciphertext,
-            &IdentityKey::new(*sender_identity_key),
-            &IdentityKey::new(*receiver_identity_key),
-        )?;
-
-        box_object::<SignalMessage>(Ok(msg))
-    })
-}
-
 jni_fn_get_jint!(Java_org_signal_client_internal_Native_SignalMessage_1GetMessageVersion(SignalMessage) using
                  |msg: &SignalMessage| { Ok(msg.message_version() as u32) });
 
 jni_fn_get_jint!(Java_org_signal_client_internal_Native_SignalMessage_1GetCounter(SignalMessage) using
                  |msg: &SignalMessage| { Ok(msg.counter()) });
-
-#[no_mangle]
-pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SignalMessage_1VerifyMac(
-    env: JNIEnv,
-    _class: JClass,
-    handle: ObjectHandle,
-    sender_identity_key: ObjectHandle,
-    receiver_identity_key: ObjectHandle,
-    mac_key: jbyteArray,
-) -> jboolean {
-    run_ffi_safe(&env, || {
-        let msg = native_handle_cast::<SignalMessage>(handle)?;
-        let sender_identity_key = native_handle_cast::<PublicKey>(sender_identity_key)?;
-        let receiver_identity_key = native_handle_cast::<PublicKey>(receiver_identity_key)?;
-        let mac_key = env.convert_byte_array(mac_key)?;
-
-        let valid = msg.verify_mac(
-            &IdentityKey::new(*sender_identity_key),
-            &IdentityKey::new(*receiver_identity_key),
-            &mac_key,
-        )?;
-
-        Ok(valid as jboolean)
-    })
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn Java_org_signal_client_internal_Native_PreKeySignalMessage_1New(
-    env: JNIEnv,
-    _class: JClass,
-    message_version: jint,
-    registration_id: jint,
-    pre_key_id: jint,
-    signed_pre_key_id: jint,
-    base_key_handle: ObjectHandle,
-    identity_key_handle: ObjectHandle,
-    signal_message_handle: ObjectHandle,
-) -> ObjectHandle {
-    run_ffi_safe(&env, || {
-        let message_version = message_version as u8;
-        let registration_id = jint_to_u32(registration_id)?;
-        let pre_key_id = if pre_key_id < 0 {
-            None
-        } else {
-            Some(jint_to_u32(pre_key_id)?)
-        };
-        let signed_pre_key_id = jint_to_u32(signed_pre_key_id)?;
-        let base_key = native_handle_cast::<PublicKey>(base_key_handle)?;
-        let identity_key = native_handle_cast::<PublicKey>(identity_key_handle)?;
-        let signal_message = native_handle_cast::<SignalMessage>(signal_message_handle)?;
-
-        let msg = PreKeySignalMessage::new(
-            message_version,
-            registration_id,
-            pre_key_id,
-            signed_pre_key_id,
-            *base_key,
-            IdentityKey::new(*identity_key),
-            signal_message.clone(),
-        );
-        box_object::<PreKeySignalMessage>(msg)
-    })
-}
 
 jni_fn_get_jint!(Java_org_signal_client_internal_Native_PreKeySignalMessage_1GetVersion(PreKeySignalMessage) using
                  |m: &PreKeySignalMessage| Ok(m.message_version() as u32));

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -26,21 +26,6 @@ type JavaSignedPreKeyStore = jobject;
 type JavaCiphertextMessage = jobject;
 type JavaSenderKeyStore = jobject;
 
-#[no_mangle]
-pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ProtocolAddress_1New(
-    env: JNIEnv,
-    _class: JClass,
-    name: JString,
-    device_id: jint,
-) -> ObjectHandle {
-    run_ffi_safe(&env, || {
-        let name: String = env.get_string(name)?.into();
-        let device_id = jint_to_u32(device_id)?;
-        let address = ProtocolAddress::new(name, device_id);
-        box_object::<ProtocolAddress>(Ok(address))
-    })
-}
-
 jni_fn_get_jint!(Java_org_signal_client_internal_Native_ProtocolAddress_1DeviceId(ProtocolAddress) using
                  |obj: &ProtocolAddress| { Ok(obj.device_id()) });
 

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -45,25 +45,6 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ECPublicKey_1Des
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ECPublicKey_1Compare(
-    env: JNIEnv,
-    _class: JClass,
-    key1: ObjectHandle,
-    key2: ObjectHandle,
-) -> jint {
-    run_ffi_safe(&env, || {
-        let key1 = native_handle_cast::<PublicKey>(key1)?;
-        let key2 = native_handle_cast::<PublicKey>(key2)?;
-
-        match key1.cmp(&key2) {
-            std::cmp::Ordering::Less => Ok(-1),
-            std::cmp::Ordering::Equal => Ok(0),
-            std::cmp::Ordering::Greater => Ok(1),
-        }
-    })
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ECPublicKey_1Verify(
     env: JNIEnv,
     _class: JClass,

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -7,7 +7,7 @@
 
 use async_trait::async_trait;
 use jni::objects::{JClass, JObject, JString, JValue};
-use jni::sys::{jboolean, jbyteArray, jint, jlong, jlongArray, jobject, jstring};
+use jni::sys::{jboolean, jbyteArray, jint, jlong, jlongArray, jobject};
 use jni::JNIEnv;
 use std::convert::TryFrom;
 
@@ -127,22 +127,6 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_IdentityKeyPair_
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Java_org_signal_client_internal_Native_DisplayableFingerprint_1Format(
-    env: JNIEnv,
-    _class: JClass,
-    local: jbyteArray,
-    remote: jbyteArray,
-) -> jstring {
-    run_ffi_safe(&env, || {
-        let local = env.convert_byte_array(local)?;
-        let remote = env.convert_byte_array(remote)?;
-        let fingerprint = DisplayableFingerprint::new(&local, &remote)?;
-        let result = env.new_string(format!("{}", fingerprint))?;
-        Ok(result.into_inner())
-    })
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn Java_org_signal_client_internal_Native_NumericFingerprintGenerator_1New(
     env: JNIEnv,
     _class: JClass,
@@ -175,22 +159,6 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_NumericFingerpri
         )?;
 
         box_object::<Fingerprint>(Ok(fprint))
-    })
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ScannableFingerprint_1Compare(
-    env: JNIEnv,
-    _class: JClass,
-    fprint1: jbyteArray,
-    fprint2: jbyteArray,
-) -> jboolean {
-    run_ffi_safe(&env, || {
-        let fprint1 = env.convert_byte_array(fprint1)?;
-        let fprint2 = env.convert_byte_array(fprint2)?;
-
-        let fprint1 = ScannableFingerprint::deserialize(&fprint1)?;
-        Ok(fprint1.compare(&fprint2)? as jboolean)
     })
 }
 

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -45,22 +45,6 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ECPublicKey_1Des
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ECPublicKey_1Verify(
-    env: JNIEnv,
-    _class: JClass,
-    handle: ObjectHandle,
-    message: jbyteArray,
-    signature: jbyteArray,
-) -> jboolean {
-    run_ffi_safe(&env, || {
-        let key = native_handle_cast::<PublicKey>(handle)?;
-        let message = env.convert_byte_array(message)?;
-        let signature = env.convert_byte_array(signature)?;
-        Ok(key.verify_signature(&message, &signature)? as jboolean)
-    })
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ECPrivateKey_1Generate(
     env: JNIEnv,
     _class: JClass,

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -919,7 +919,7 @@ impl<'a> JniPreKeyStore<'a> {
             &callback_args,
             callback_sig,
             "loadPreKey",
-            Some("org/whispersystems/libsignal/InvalidKeyIdException"),
+            None,
         )?;
         match pk {
             Some(pk) => Ok(pk),
@@ -1020,7 +1020,7 @@ impl<'a> JniSignedPreKeyStore<'a> {
             &callback_args,
             callback_sig,
             "loadSignedPreKey",
-            Some("org/whispersystems/libsignal/InvalidKeyIdException"),
+            None,
         )?;
         match spk {
             Some(spk) => Ok(spk),

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -919,7 +919,6 @@ impl<'a> JniPreKeyStore<'a> {
             &callback_args,
             callback_sig,
             "loadPreKey",
-            None,
         )?;
         match pk {
             Some(pk) => Ok(pk),
@@ -1020,7 +1019,6 @@ impl<'a> JniSignedPreKeyStore<'a> {
             &callback_args,
             callback_sig,
             "loadSignedPreKey",
-            None,
         )?;
         match spk {
             Some(spk) => Ok(spk),
@@ -1107,7 +1105,6 @@ impl<'a> JniSessionStore<'a> {
             &callback_args,
             callback_sig,
             "loadSession",
-            None,
         )
     }
 
@@ -1354,7 +1351,6 @@ impl<'a> JniSenderKeyStore<'a> {
             &callback_args,
             callback_sig,
             "loadSenderKey",
-            None,
         )?;
 
         Ok(skr)

--- a/rust/bridge/jni/src/util.rs
+++ b/rust/bridge/jni/src/util.rs
@@ -111,16 +111,8 @@ pub fn get_object_with_native_handle<T: 'static + Clone>(
     callback_args: &[JValue],
     callback_sig: &'static str,
     callback_fn: &'static str,
-    exception_to_treat_as_none: Option<&'static str>,
 ) -> Result<Option<T>, SignalJniError> {
-    let rvalue = call_method_with_exception_as_null(
-        env,
-        store_obj,
-        callback_fn,
-        callback_sig,
-        &callback_args,
-        exception_to_treat_as_none,
-    )?;
+    let rvalue = call_method_checked(env, store_obj, callback_fn, callback_sig, &callback_args)?;
 
     let obj = match rvalue {
         JValue::Object(o) => *o,

--- a/rust/bridge/jni/src/util.rs
+++ b/rust/bridge/jni/src/util.rs
@@ -5,11 +5,10 @@
 
 use futures::pin_mut;
 use futures::task::noop_waker_ref;
-use jni::objects::{JObject, JString, JThrowable, JValue};
+use jni::objects::{JObject, JValue};
 use jni::sys::{jint, jlong, jobject};
 use jni::JNIEnv;
 use std::convert::TryFrom;
-use std::fmt;
 use std::future::Future;
 use std::task::{self, Poll};
 
@@ -86,117 +85,6 @@ pub fn jlong_from_u64(value: Result<u64, SignalProtocolError>) -> Result<jlong, 
         }
         Err(e) => Err(SignalJniError::Signal(e)),
     }
-}
-
-#[derive(Debug)]
-struct ThrownException {
-    exn_type: Option<String>,
-    message: Option<String>,
-}
-
-impl fmt::Display for ThrownException {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let exn_type = self.exn_type.as_deref().unwrap_or("<unknown>");
-        if let Some(message) = &self.message {
-            write!(f, "exception {} \"{}\"", exn_type, message)
-        } else {
-            write!(f, "exception {}", exn_type)
-        }
-    }
-}
-
-impl std::error::Error for ThrownException {}
-
-pub fn call_method_with_exception_as_null<'a>(
-    env: &JNIEnv<'a>,
-    obj: impl Into<JObject<'a>>,
-    fn_name: &'static str,
-    sig: &'static str,
-    args: &[JValue<'_>],
-    exception_to_treat_as_null: Option<&'static str>,
-) -> Result<JValue<'a>, SignalJniError> {
-    // Note that we are *not* unwrapping the result yet!
-    // We need to check for exceptions *first*.
-    let result = env.call_method(obj, fn_name, sig, args);
-
-    fn exception_class_name(env: &JNIEnv, exn: JThrowable) -> Result<String, SignalJniError> {
-        let class_type = env.call_method(exn, "getClass", "()Ljava/lang/Class;", &[])?;
-        if let JValue::Object(class_type) = class_type {
-            let class_name =
-                env.call_method(class_type, "getCanonicalName", "()Ljava/lang/String;", &[])?;
-
-            if let JValue::Object(class_name) = class_name {
-                let class_name: String = env.get_string(JString::from(class_name))?.into();
-                Ok(class_name)
-            } else {
-                Err(SignalJniError::UnexpectedJniResultType(
-                    "getCanonicalName",
-                    class_name.type_name(),
-                ))
-            }
-        } else {
-            Err(SignalJniError::UnexpectedJniResultType(
-                "getClass",
-                class_type.type_name(),
-            ))
-        }
-    }
-
-    if env.exception_check()? {
-        let throwable = env.exception_occurred()?;
-        env.exception_clear()?;
-
-        if let Some(exception_to_treat_as_null) = exception_to_treat_as_null {
-            if env.is_instance_of(throwable, exception_to_treat_as_null)? {
-                return Ok(JValue::Object(JObject::null()));
-            }
-        }
-
-        let getmessage_sig = "()Ljava/lang/String;";
-
-        let exn_type = exception_class_name(env, throwable).ok();
-        // Clear again in case we got an exception looking up the class name.
-        env.exception_clear()?;
-
-        if let Ok(jmessage) = env.call_method(throwable, "getMessage", getmessage_sig, &[]) {
-            if let JValue::Object(o) = jmessage {
-                let message: String = env.get_string(JString::from(o))?.into();
-                return Err(SignalJniError::Signal(
-                    SignalProtocolError::ApplicationCallbackError(
-                        fn_name,
-                        Box::new(ThrownException {
-                            exn_type,
-                            message: Some(message),
-                        }),
-                    ),
-                ));
-            }
-        }
-        // Clear *again* in case we got an exception reading the message.
-        env.exception_clear()?;
-
-        return Err(SignalJniError::Signal(
-            SignalProtocolError::ApplicationCallbackError(
-                fn_name,
-                Box::new(ThrownException {
-                    exn_type,
-                    message: None,
-                }),
-            ),
-        ));
-    }
-
-    Ok(result?)
-}
-
-pub fn call_method_checked<'a>(
-    env: &JNIEnv<'a>,
-    obj: impl Into<JObject<'a>>,
-    fn_name: &'static str,
-    sig: &'static str,
-    args: &[JValue<'_>],
-) -> Result<JValue<'a>, SignalJniError> {
-    call_method_with_exception_as_null(env, obj, fn_name, sig, args, None)
 }
 
 pub fn check_jobject_type(

--- a/rust/bridge/jni/src/util.rs
+++ b/rust/bridge/jni/src/util.rs
@@ -21,13 +21,6 @@ pub unsafe fn native_handle_cast_optional<T>(
     Ok(Some(&mut *(handle as *mut T)))
 }
 
-pub fn jint_to_u32(v: jint) -> Result<u32, SignalJniError> {
-    if v < 0 {
-        return Err(SignalJniError::IntegerOverflow(format!("{} to u32", v)));
-    }
-    Ok(v as u32)
-}
-
 pub fn jlong_to_u64(v: jlong) -> Result<u64, SignalJniError> {
     if v < 0 {
         return Err(SignalJniError::IntegerOverflow(format!("{} to u64", v)));

--- a/rust/bridge/jni/src/util.rs
+++ b/rust/bridge/jni/src/util.rs
@@ -6,7 +6,6 @@
 use jni::objects::{JObject, JValue};
 use jni::sys::{jint, jlong, jobject};
 use jni::JNIEnv;
-use std::convert::TryFrom;
 
 use libsignal_bridge::jni::*;
 use libsignal_protocol_rust::SignalProtocolError;
@@ -26,13 +25,6 @@ pub fn jlong_to_u64(v: jlong) -> Result<u64, SignalJniError> {
         return Err(SignalJniError::IntegerOverflow(format!("{} to u64", v)));
     }
     Ok(v as u64)
-}
-
-pub fn jint_to_u8(v: jint) -> Result<u8, SignalJniError> {
-    match u8::try_from(v) {
-        Err(_) => Err(SignalJniError::IntegerOverflow(format!("{} to u8", v))),
-        Ok(v) => Ok(v),
-    }
 }
 
 pub fn jint_from_u32(value: Result<u32, SignalProtocolError>) -> Result<jint, SignalJniError> {

--- a/rust/bridge/jni/src/util.rs
+++ b/rust/bridge/jni/src/util.rs
@@ -3,14 +3,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use futures::pin_mut;
-use futures::task::noop_waker_ref;
 use jni::objects::{JObject, JValue};
 use jni::sys::{jint, jlong, jobject};
 use jni::JNIEnv;
 use std::convert::TryFrom;
-use std::future::Future;
-use std::task::{self, Poll};
 
 use libsignal_bridge::jni::*;
 use libsignal_protocol_rust::SignalProtocolError;
@@ -23,15 +19,6 @@ pub unsafe fn native_handle_cast_optional<T>(
     }
 
     Ok(Some(&mut *(handle as *mut T)))
-}
-
-#[track_caller]
-pub fn expect_ready<F: Future>(future: F) -> F::Output {
-    pin_mut!(future);
-    match future.poll(&mut task::Context::from_waker(noop_waker_ref())) {
-        Poll::Ready(result) => result,
-        Poll::Pending => panic!("future was not ready"),
-    }
 }
 
 pub fn jint_to_u32(v: jint) -> Result<u32, SignalJniError> {

--- a/rust/bridge/shared/Cargo.toml
+++ b/rust/bridge/shared/Cargo.toml
@@ -13,6 +13,7 @@ license = "AGPL-3.0-only"
 [dependencies]
 libsignal-protocol-rust = { path = "../../protocol" }
 aes-gcm-siv = { path = "../../aes-gcm-siv" }
+libsignal-bridge-macros = { path = "macros" }
 futures = "0.3.7"
 log = "0.4.11"
 paste = "1.0"

--- a/rust/bridge/shared/Cargo.toml
+++ b/rust/bridge/shared/Cargo.toml
@@ -13,6 +13,7 @@ license = "AGPL-3.0-only"
 [dependencies]
 libsignal-protocol-rust = { path = "../../protocol" }
 aes-gcm-siv = { path = "../../aes-gcm-siv" }
+log = "0.4.11"
 paste = "1.0"
 thiserror = "1.0"
 

--- a/rust/bridge/shared/Cargo.toml
+++ b/rust/bridge/shared/Cargo.toml
@@ -13,6 +13,7 @@ license = "AGPL-3.0-only"
 [dependencies]
 libsignal-protocol-rust = { path = "../../protocol" }
 aes-gcm-siv = { path = "../../aes-gcm-siv" }
+futures = "0.3.7"
 log = "0.4.11"
 paste = "1.0"
 thiserror = "1.0"

--- a/rust/bridge/shared/Cargo.toml
+++ b/rust/bridge/shared/Cargo.toml
@@ -14,6 +14,7 @@ license = "AGPL-3.0-only"
 libsignal-protocol-rust = { path = "../../protocol" }
 aes-gcm-siv = { path = "../../aes-gcm-siv" }
 paste = "1.0"
+thiserror = "1.0"
 
 libc = { version = "0.2", optional = true }
 jni = { version = "0.17", optional = true }

--- a/rust/bridge/shared/macros/Cargo.toml
+++ b/rust/bridge/shared/macros/Cargo.toml
@@ -14,7 +14,8 @@ license = "AGPL-3.0-only"
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0", features = ["full"] }
+heck = "0.3.1"
 proc-macro2 = "1.0"
 quote = "1.0"
+syn = { version = "1.0", features = ["full"] }
 unzip3 = "1.0.0"

--- a/rust/bridge/shared/macros/Cargo.toml
+++ b/rust/bridge/shared/macros/Cargo.toml
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2020 Signal Messenger, LLC.
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+
+[package]
+name = "libsignal-bridge-macros"
+version = "0.1.0"
+authors = ["Jack Lloyd <jack@signal.org>", "Jordan Rose <jrose@signal.org>"]
+edition = "2018"
+license = "AGPL-3.0-only"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "1.0", features = ["full"] }
+proc-macro2 = "1.0"
+quote = "1.0"
+unzip3 = "1.0.0"

--- a/rust/bridge/shared/macros/Cargo.toml
+++ b/rust/bridge/shared/macros/Cargo.toml
@@ -17,5 +17,6 @@ proc-macro = true
 heck = "0.3.1"
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["full"] }
+syn = { version = "1.0" }
+syn-mid = "0.5"
 unzip3 = "1.0.0"

--- a/rust/bridge/shared/macros/src/lib.rs
+++ b/rust/bridge/shared/macros/src/lib.rs
@@ -9,9 +9,9 @@ use heck::SnakeCase;
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::*;
-use syn::*;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
+use syn::*;
 use unzip3::Unzip3;
 
 fn ffi_bridge_fn(name: String, sig: &Signature) -> TokenStream2 {
@@ -21,35 +21,65 @@ fn ffi_bridge_fn(name: String, sig: &Signature) -> TokenStream2 {
         ReturnType::Default => (quote!(), quote!()),
         ReturnType::Type(_, ref ty) => (
             quote!(out: *mut ffi_result_type!(#ty),), // note the trailing comma
-            quote!(<#ty as ffi::ResultTypeInfo>::write_to(out, __result)?)
-        )
+            quote!(<#ty as ffi::ResultTypeInfo>::write_to(out, __result)?),
+        ),
     };
 
-    let (input_names, input_args, input_processing): (Vec<Ident>, Vec<TokenStream2>, Vec<TokenStream2>) = sig.inputs.iter().map(|arg| match arg {
-        FnArg::Receiver(tokens) => (
-            Ident::new("self", tokens.self_token.span),
-            Error::new(tokens.self_token.span, "cannot have 'self' parameter").to_compile_error(),
-            quote!()
-        ),
-        FnArg::Typed(PatType { attrs, pat: box Pat::Ident(name), colon_token, ty: ty @ box Type::Reference(TypeReference { elem: box Type::Slice(_), .. }) }) => {
-            let size_arg = format_ident!("{}_len", name.ident);
-            (
+    let (input_names, input_args, input_processing): (
+        Vec<Ident>,
+        Vec<TokenStream2>,
+        Vec<TokenStream2>,
+    ) = sig
+        .inputs
+        .iter()
+        .map(|arg| match arg {
+            FnArg::Receiver(tokens) => (
+                Ident::new("self", tokens.self_token.span),
+                Error::new(tokens.self_token.span, "cannot have 'self' parameter")
+                    .to_compile_error(),
+                quote!(),
+            ),
+            FnArg::Typed(PatType {
+                attrs,
+                pat: box Pat::Ident(name),
+                colon_token,
+                ty:
+                    ty
+                    @
+                    box Type::Reference(TypeReference {
+                        elem: box Type::Slice(_),
+                        ..
+                    }),
+            }) => {
+                let size_arg = format_ident!("{}_len", name.ident);
+                (
+                    name.ident.clone(),
+                    quote!(
+                        #(#attrs)* #name #colon_token ffi_arg_type!(#ty),
+                        #size_arg: libc::size_t
+                    ),
+                    quote!(
+                        let #name = <#ty as ffi::SizedArgTypeInfo>::convert_from(#name, #size_arg)?
+                    ),
+                )
+            }
+            FnArg::Typed(PatType {
+                attrs,
+                pat: box Pat::Ident(name),
+                colon_token,
+                ty,
+            }) => (
                 name.ident.clone(),
-                quote!(#(#attrs)* #name #colon_token ffi_arg_type!(#ty), #size_arg: libc::size_t),
-                quote!(let #name = <#ty as ffi::SizedArgTypeInfo>::convert_from(#name, #size_arg)?),
-            )
-        }
-        FnArg::Typed(PatType { attrs, pat: box Pat::Ident(name), colon_token, ty }) => (
-            name.ident.clone(),
-            quote!(#(#attrs)* #name #colon_token ffi_arg_type!(#ty)),
-            quote!(let #name = <#ty as ffi::ArgTypeInfo>::convert_from(#name)?),
-        ),
-        FnArg::Typed(PatType { pat, .. }) => (
-            Ident::new("unexpected", pat.span()),
-            Error::new(pat.span(), "cannot use patterns in paramater").to_compile_error(),
-            quote!()
-        )
-    }).unzip3();
+                quote!(#(#attrs)* #name #colon_token ffi_arg_type!(#ty)),
+                quote!(let #name = <#ty as ffi::ArgTypeInfo>::convert_from(#name)?),
+            ),
+            FnArg::Typed(PatType { pat, .. }) => (
+                Ident::new("unexpected", pat.span()),
+                Error::new(pat.span(), "cannot use patterns in paramater").to_compile_error(),
+                quote!(),
+            ),
+        })
+        .unzip3();
 
     let orig_name = sig.ident.clone();
 
@@ -82,28 +112,50 @@ fn jni_bridge_fn(name: String, sig: &Signature) -> TokenStream2 {
         ReturnType::Type(_, ref ty) => quote!(-> jni_result_type!(#ty)),
     };
 
-    let (input_names, input_args, input_processing): (Vec<Ident>, Vec<TokenStream2>, Vec<TokenStream2>) = sig.inputs.iter().map(|arg| match arg {
-        FnArg::Receiver(tokens) => (
-            Ident::new("self", tokens.self_token.span),
-            Error::new(tokens.self_token.span, "cannot have 'self' parameter").to_compile_error(),
-            quote!()
-        ),
-        FnArg::Typed(PatType { attrs, pat: box Pat::Ident(name), colon_token, ty: ty @ box Type::Reference(_) }) => (
-            name.ident.clone(),
-            quote!(#(#attrs)* #name #colon_token jni_arg_type!(#ty)),
-            quote!(let #name = <#ty as jni::RefArgTypeInfo>::convert_from(&env, #name)?; let #name = std::borrow::Borrow::borrow(&#name)),
-        ),
-        FnArg::Typed(PatType { attrs, pat: box Pat::Ident(name), colon_token, ty }) => (
-            name.ident.clone(),
-            quote!(#(#attrs)* #name #colon_token jni_arg_type!(#ty)),
-            quote!(let #name = <#ty as jni::ArgTypeInfo>::convert_from(&env, #name)?),
-        ),
-        FnArg::Typed(PatType { pat, .. }) => (
-            Ident::new("unexpected", pat.span()),
-            Error::new(pat.span(), "cannot use patterns in paramater").to_compile_error(),
-            quote!()
-        )
-    }).unzip3();
+    let (input_names, input_args, input_processing): (
+        Vec<Ident>,
+        Vec<TokenStream2>,
+        Vec<TokenStream2>,
+    ) = sig
+        .inputs
+        .iter()
+        .map(|arg| match arg {
+            FnArg::Receiver(tokens) => (
+                Ident::new("self", tokens.self_token.span),
+                Error::new(tokens.self_token.span, "cannot have 'self' parameter")
+                    .to_compile_error(),
+                quote!(),
+            ),
+            FnArg::Typed(PatType {
+                attrs,
+                pat: box Pat::Ident(name),
+                colon_token,
+                ty: ty @ box Type::Reference(_),
+            }) => (
+                name.ident.clone(),
+                quote!(#(#attrs)* #name #colon_token jni_arg_type!(#ty)),
+                quote!(
+                    let #name = <#ty as jni::RefArgTypeInfo>::convert_from(&env, #name)?;
+                    let #name = std::borrow::Borrow::borrow(&#name)
+                ),
+            ),
+            FnArg::Typed(PatType {
+                attrs,
+                pat: box Pat::Ident(name),
+                colon_token,
+                ty,
+            }) => (
+                name.ident.clone(),
+                quote!(#(#attrs)* #name #colon_token jni_arg_type!(#ty)),
+                quote!(let #name = <#ty as jni::ArgTypeInfo>::convert_from(&env, #name)?),
+            ),
+            FnArg::Typed(PatType { pat, .. }) => (
+                Ident::new("unexpected", pat.span()),
+                Error::new(pat.span(), "cannot use patterns in paramater").to_compile_error(),
+                quote!(),
+            ),
+        })
+        .unzip3();
 
     let orig_name = sig.ident.clone();
 
@@ -131,15 +183,36 @@ fn jni_name_from_ident(ident: &Ident) -> String {
 pub fn bridge_fn(attr: TokenStream, item: TokenStream) -> TokenStream {
     let function = parse_macro_input!(item as ItemFn);
 
-    let item_names = parse_macro_input!(attr with Punctuated<MetaNameValue, Token![,]>::parse_terminated);
-    let ffi_name = match item_names.iter().find(|meta| meta.path.get_ident().map_or(false, |ident| ident == "ffi")) {
-        Some(MetaNameValue { lit: Lit::Str(name_str), .. }) => name_str.value(),
-        Some(meta) => return Error::new(meta.lit.span(), "ffi name must be a string literal").to_compile_error().into(),
-        None => ffi_name_from_ident(&function.sig.ident)
+    let item_names =
+        parse_macro_input!(attr with Punctuated<MetaNameValue, Token![,]>::parse_terminated);
+    let ffi_name = match item_names
+        .iter()
+        .find(|meta| meta.path.get_ident().map_or(false, |ident| ident == "ffi"))
+    {
+        Some(MetaNameValue {
+            lit: Lit::Str(name_str),
+            ..
+        }) => name_str.value(),
+        Some(meta) => {
+            return Error::new(meta.lit.span(), "ffi name must be a string literal")
+                .to_compile_error()
+                .into()
+        }
+        None => ffi_name_from_ident(&function.sig.ident),
     };
-    let jni_name = match item_names.iter().find(|meta| meta.path.get_ident().map_or(false, |ident| ident == "jni")) {
-        Some(MetaNameValue { lit: Lit::Str(name_str), .. }) => name_str.value(),
-        Some(meta) => return Error::new(meta.lit.span(), "jni name must be a string literal").to_compile_error().into(),
+    let jni_name = match item_names
+        .iter()
+        .find(|meta| meta.path.get_ident().map_or(false, |ident| ident == "jni"))
+    {
+        Some(MetaNameValue {
+            lit: Lit::Str(name_str),
+            ..
+        }) => name_str.value(),
+        Some(meta) => {
+            return Error::new(meta.lit.span(), "jni name must be a string literal")
+                .to_compile_error()
+                .into()
+        }
         None => jni_name_from_ident(&function.sig.ident),
     };
 
@@ -153,5 +226,6 @@ pub fn bridge_fn(attr: TokenStream, item: TokenStream) -> TokenStream {
         #ffi_fn
 
         #jni_fn
-    ).into()
+    )
+    .into()
 }

--- a/rust/bridge/shared/macros/src/lib.rs
+++ b/rust/bridge/shared/macros/src/lib.rs
@@ -1,0 +1,139 @@
+//
+// Copyright 2020 Signal Messenger, LLC.
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+#![feature(box_patterns)]
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::*;
+use syn::*;
+use syn::punctuated::Punctuated;
+use syn::spanned::Spanned;
+use unzip3::Unzip3;
+
+fn ffi_bridge_fn(name: String, sig: &Signature) -> TokenStream2 {
+    let name = format_ident!("signal_{}", name);
+
+    let (output_args, output_processing) = match sig.output {
+        ReturnType::Default => (quote!(), quote!()),
+        ReturnType::Type(_, ref ty) => (
+            quote!(out: *mut ffi_result_type!(#ty),), // note the trailing comma
+            quote!(<#ty as ffi::ResultTypeInfo>::write_to(out, __result)?)
+        )
+    };
+
+    let (input_names, input_args, input_processing): (Vec<Ident>, Vec<TokenStream2>, Vec<TokenStream2>) = sig.inputs.iter().map(|arg| match arg {
+        FnArg::Receiver(tokens) => (
+            Ident::new("self", tokens.self_token.span),
+            Error::new(tokens.self_token.span, "cannot have 'self' parameter").to_compile_error(),
+            quote!()
+        ),
+        FnArg::Typed(PatType { attrs, pat: box Pat::Ident(name), colon_token, ty: ty @ box Type::Reference(TypeReference { elem: box Type::Array(_), .. }) }) => {
+            let size_arg = format_ident!("{}_size", name.ident);
+            (
+                name.ident.clone(),
+                quote!(#(#attrs)* #name #colon_token ffi_arg_type!(#ty), #size_arg: usize),
+                quote!(let #name = <#ty as ffi::SizedArgTypeInfo>::convert_from(#name, #size_arg)?),
+            )
+        }
+        FnArg::Typed(PatType { attrs, pat: box Pat::Ident(name), colon_token, ty }) => (
+            name.ident.clone(),
+            quote!(#(#attrs)* #name #colon_token ffi_arg_type!(#ty)),
+            quote!(let #name = <#ty as ffi::ArgTypeInfo>::convert_from(#name)?),
+        ),
+        FnArg::Typed(PatType { pat, .. }) => (
+            Ident::new("unexpected", pat.span()),
+            Error::new(pat.span(), "cannot use patterns in paramater").to_compile_error(),
+            quote!()
+        )
+    }).unzip3();
+
+    let orig_name = sig.ident.clone();
+
+    quote! {
+        #[cfg(feature = "ffi")]
+        #[no_mangle]
+        pub unsafe extern "C" fn #name(
+            #output_args
+            #(#input_args),*
+        ) -> *mut ffi::SignalFfiError {
+            ffi::run_ffi_safe(|| {
+                #(#input_processing);*;
+                let __result = #orig_name(#(#input_names),*);
+                #output_processing;
+                Ok(())
+            })
+        }
+    }
+}
+
+fn jni_bridge_fn(name: String, sig: &Signature) -> TokenStream2 {
+    let name = format_ident!("Java_org_signal_client_internal_Native_{}", name);
+
+    let output = match sig.output {
+        ReturnType::Default => quote!(),
+        ReturnType::Type(_, ref ty) => quote!(-> jni_result_type!(#ty)),
+    };
+
+    let (input_names, input_args, input_processing): (Vec<Ident>, Vec<TokenStream2>, Vec<TokenStream2>) = sig.inputs.iter().map(|arg| match arg {
+        FnArg::Receiver(tokens) => (
+            Ident::new("self", tokens.self_token.span),
+            Error::new(tokens.self_token.span, "cannot have 'self' parameter").to_compile_error(),
+            quote!()
+        ),
+        FnArg::Typed(PatType { attrs, pat: box Pat::Ident(name), colon_token, ty }) => (
+            name.ident.clone(),
+            quote!(#(#attrs)* #name #colon_token jni_arg_type!(#ty)),
+            quote!(let #name = <#ty as jni::ArgTypeInfo>::convert_from(&env, #name)?),
+        ),
+        FnArg::Typed(PatType { pat, .. }) => (
+            Ident::new("unexpected", pat.span()),
+            Error::new(pat.span(), "cannot use patterns in paramater").to_compile_error(),
+            quote!()
+        )
+    }).unzip3();
+
+    let orig_name = sig.ident.clone();
+
+    quote! {
+        #[cfg(feature = "jni")]
+        #[no_mangle]
+        pub unsafe extern "C" fn #name(
+            env: jni::JNIEnv,
+            _class: jni::JClass,
+            #(#input_args),*
+        ) #output {
+            jni::run_ffi_safe(&env, || {
+                #(#input_processing);*;
+                jni::ResultTypeInfo::convert_into(#orig_name(#(#input_names),*), &env)
+            })
+        }
+    }
+}
+
+#[proc_macro_attribute]
+pub fn bridge_fn(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let function = parse_macro_input!(item as ItemFn);
+
+    let item_names = parse_macro_input!(attr with Punctuated<MetaNameValue, Token![,]>::parse_terminated);
+    let ffi_name = match item_names.iter().find(|meta| meta.path.get_ident().map_or(false, |ident| ident == "ffi")) {
+        Some(MetaNameValue { lit: Lit::Str(name_str), .. }) => name_str.value(),
+        Some(meta) => return Error::new(meta.lit.span(), "ffi name must be a string literal").to_compile_error().into(),
+        None => function.sig.ident.to_string(),
+    };
+    let jni_name = match item_names.iter().find(|meta| meta.path.get_ident().map_or(false, |ident| ident == "jni")) {
+        Some(MetaNameValue { lit: Lit::Str(name_str), .. }) => name_str.value(),
+        Some(meta) => return Error::new(meta.lit.span(), "jni name must be a string literal").to_compile_error().into(),
+        None => function.sig.ident.to_string(),
+    };
+
+    let ffi_fn = ffi_bridge_fn(ffi_name, &function.sig);
+    let jni_fn = jni_bridge_fn(jni_name, &function.sig);
+
+    let mut result = function.into_token_stream();
+    result.extend(ffi_fn);
+    result.extend(jni_fn);
+    result.into()
+}

--- a/rust/bridge/shared/macros/src/lib.rs
+++ b/rust/bridge/shared/macros/src/lib.rs
@@ -30,11 +30,11 @@ fn ffi_bridge_fn(name: String, sig: &Signature) -> TokenStream2 {
             Error::new(tokens.self_token.span, "cannot have 'self' parameter").to_compile_error(),
             quote!()
         ),
-        FnArg::Typed(PatType { attrs, pat: box Pat::Ident(name), colon_token, ty: ty @ box Type::Reference(TypeReference { elem: box Type::Array(_), .. }) }) => {
-            let size_arg = format_ident!("{}_size", name.ident);
+        FnArg::Typed(PatType { attrs, pat: box Pat::Ident(name), colon_token, ty: ty @ box Type::Reference(TypeReference { elem: box Type::Slice(_), .. }) }) => {
+            let size_arg = format_ident!("{}_len", name.ident);
             (
                 name.ident.clone(),
-                quote!(#(#attrs)* #name #colon_token ffi_arg_type!(#ty), #size_arg: usize),
+                quote!(#(#attrs)* #name #colon_token ffi_arg_type!(#ty), #size_arg: libc::size_t),
                 quote!(let #name = <#ty as ffi::SizedArgTypeInfo>::convert_from(#name, #size_arg)?),
             )
         }
@@ -82,6 +82,11 @@ fn jni_bridge_fn(name: String, sig: &Signature) -> TokenStream2 {
             Ident::new("self", tokens.self_token.span),
             Error::new(tokens.self_token.span, "cannot have 'self' parameter").to_compile_error(),
             quote!()
+        ),
+        FnArg::Typed(PatType { attrs, pat: box Pat::Ident(name), colon_token, ty: ty @ box Type::Reference(_) }) => (
+            name.ident.clone(),
+            quote!(#(#attrs)* #name #colon_token jni_arg_type!(#ty)),
+            quote!(let #name = <#ty as jni::RefArgTypeInfo>::convert_from(&env, #name)?; let #name = std::borrow::Borrow::borrow(&#name)),
         ),
         FnArg::Typed(PatType { attrs, pat: box Pat::Ident(name), colon_token, ty }) => (
             name.ident.clone(),

--- a/rust/bridge/shared/macros/src/lib.rs
+++ b/rust/bridge/shared/macros/src/lib.rs
@@ -12,6 +12,7 @@ use quote::*;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::*;
+use syn_mid::{FnArg, ItemFn, Pat, PatType, Signature};
 use unzip3::Unzip3;
 
 fn value_for_meta_key<'a>(

--- a/rust/bridge/shared/src/ffi/convert.rs
+++ b/rust/bridge/shared/src/ffi/convert.rs
@@ -76,6 +76,15 @@ impl<T: ResultTypeInfo> ResultTypeInfo for Result<T, SignalProtocolError> {
     }
 }
 
+impl ResultTypeInfo for String {
+    type ResultType = *const libc::c_char;
+    fn convert_into(self) -> Result<Self::ResultType, SignalFfiError> {
+        let cstr =
+            CString::new(self).expect("No NULL characters in string being returned to C");
+        Ok(cstr.into_raw())
+    }
+}
+
 impl ResultTypeInfo for ProtocolAddress {
     type ResultType = *mut ProtocolAddress;
     fn convert_into(self) -> Result<Self::ResultType, SignalFfiError> {
@@ -113,5 +122,6 @@ macro_rules! ffi_result_type {
     (Result<$typ:tt, $_:tt>) => (ffi_result_type!($typ));
     (i32) => (i32);
     (bool) => (bool);
+    (String) => (*const libc::c_char);
     ( $typ:ty ) => (*mut $typ);
 }

--- a/rust/bridge/shared/src/ffi/convert.rs
+++ b/rust/bridge/shared/src/ffi/convert.rs
@@ -69,6 +69,13 @@ impl<T> ArgTypeInfo for &'static T {
     }
 }
 
+impl<T: ResultTypeInfo> ResultTypeInfo for Result<T, SignalProtocolError> {
+    type ResultType = T::ResultType;
+    fn convert_into(self) -> Result<Self::ResultType, SignalFfiError> {
+        T::convert_into(self?)
+    }
+}
+
 impl ResultTypeInfo for ProtocolAddress {
     type ResultType = *mut ProtocolAddress;
     fn convert_into(self) -> Result<Self::ResultType, SignalFfiError> {
@@ -92,6 +99,7 @@ macro_rules! trivial {
 trivial!(i32);
 trivial!(u32);
 trivial!(usize);
+trivial!(bool);
 
 macro_rules! ffi_arg_type {
     (u32) => (u32);
@@ -102,6 +110,8 @@ macro_rules! ffi_arg_type {
 }
 
 macro_rules! ffi_result_type {
+    (Result<$typ:tt, $_:tt>) => (ffi_result_type!($typ));
     (i32) => (i32);
+    (bool) => (bool);
     ( $typ:ty ) => (*mut $typ);
 }

--- a/rust/bridge/shared/src/ffi/convert.rs
+++ b/rust/bridge/shared/src/ffi/convert.rs
@@ -1,0 +1,95 @@
+//
+// Copyright 2020 Signal Messenger, LLC.
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+use libc::{c_char, c_uchar};
+use libsignal_protocol_rust::*;
+use std::ffi::CStr;
+
+use crate::ffi::error::*;
+
+pub(crate) trait ArgTypeInfo: Sized {
+    type ArgType;
+    fn convert_from(foreign: Self::ArgType) -> Result<Self, SignalFfiError>;
+}
+
+pub(crate) trait SizedArgTypeInfo: Sized {
+    type ArgType;
+    fn convert_from(foreign: Self::ArgType, size: usize) -> Result<Self, SignalFfiError>;
+}
+
+pub(crate) trait ResultTypeInfo: Sized {
+    type ResultType;
+    fn convert_into(self) -> Result<Self::ResultType, SignalFfiError>;
+    fn write_to(ptr: *mut Self::ResultType, value: Self) -> Result<(), SignalFfiError> {
+        if ptr.is_null() {
+            return Err(SignalFfiError::NullPointer);
+        }
+        unsafe { *ptr = value.convert_into()? };
+        Ok(())
+    }
+}
+
+pub(crate) trait TrivialTypeInfo {}
+
+impl<T: TrivialTypeInfo> ArgTypeInfo for T {
+    type ArgType = Self;
+    fn convert_from(foreign: Self) -> Result<Self, SignalFfiError> { Ok(foreign) }
+}
+
+impl<T: TrivialTypeInfo> ResultTypeInfo for T {
+    type ResultType = Self;
+    fn convert_into(self) -> Result<Self, SignalFfiError> { Ok(self) }
+}
+
+impl SizedArgTypeInfo for &[u8] {
+    type ArgType = *const c_uchar;
+    fn convert_from(input: Self::ArgType, input_len: usize) -> Result<Self, SignalFfiError> {
+        if input.is_null() {
+            if input_len != 0 {
+                return Err(SignalFfiError::NullPointer);
+            }
+            // We can't just fall through because slice::from_raw_parts still expects a non-null pointer. Reference a dummy buffer instead.
+            return Ok(&[]);
+        }
+
+        unsafe { Ok(std::slice::from_raw_parts(input, input_len)) }
+    }
+}
+
+impl ArgTypeInfo for String {
+    type ArgType = *const c_char;
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    fn convert_from(foreign: *const c_char) -> Result<Self, SignalFfiError> {
+        if foreign.is_null() {
+            return Err(SignalFfiError::NullPointer);
+        }
+
+        match unsafe { CStr::from_ptr(foreign).to_str() } {
+            Ok(s) => Ok(s.to_owned()),
+            Err(_) => Err(SignalFfiError::InvalidUtf8String),
+        }
+    }
+}
+
+impl TrivialTypeInfo for u32 {}
+impl TrivialTypeInfo for usize {}
+
+impl ResultTypeInfo for ProtocolAddress {
+    type ResultType = *mut ProtocolAddress;
+    fn convert_into(self) -> Result<Self::ResultType, SignalFfiError> {
+        Ok(Box::into_raw(Box::new(self)))
+    }
+}
+
+macro_rules! ffi_arg_type {
+    (u32) => (u32);
+    (usize) => (libc::size_t);
+    (&[u8]) => (*const libc::c_uchar);
+    (String) => (*const libc::c_char);
+}
+
+macro_rules! ffi_result_type {
+    ( $typ:ty ) => (*mut $typ);
+}

--- a/rust/bridge/shared/src/ffi/convert.rs
+++ b/rust/bridge/shared/src/ffi/convert.rs
@@ -82,8 +82,7 @@ impl<T: ResultTypeInfo> ResultTypeInfo for Result<T, SignalProtocolError> {
 impl ResultTypeInfo for String {
     type ResultType = *const libc::c_char;
     fn convert_into(self) -> Result<Self::ResultType, SignalFfiError> {
-        let cstr =
-            CString::new(self).expect("No NULL characters in string being returned to C");
+        let cstr = CString::new(self).expect("No NULL characters in string being returned to C");
         Ok(cstr.into_raw())
     }
 }
@@ -103,7 +102,7 @@ macro_rules! native_handle {
                 Ok(Box::into_raw(Box::new(self)))
             }
         }
-    }
+    };
 }
 
 native_handle!(ProtocolAddress);
@@ -115,13 +114,17 @@ macro_rules! trivial {
     ($typ:ty) => {
         impl ArgTypeInfo for $typ {
             type ArgType = Self;
-            fn convert_from(foreign: Self) -> Result<Self, SignalFfiError> { Ok(foreign) }
+            fn convert_from(foreign: Self) -> Result<Self, SignalFfiError> {
+                Ok(foreign)
+            }
         }
         impl ResultTypeInfo for $typ {
             type ResultType = Self;
-            fn convert_into(self) -> Result<Self, SignalFfiError> { Ok(self) }
+            fn convert_into(self) -> Result<Self, SignalFfiError> {
+                Ok(self)
+            }
         }
-    }
+    };
 }
 
 trivial!(i32);

--- a/rust/bridge/shared/src/ffi/convert.rs
+++ b/rust/bridge/shared/src/ffi/convert.rs
@@ -87,28 +87,23 @@ impl ResultTypeInfo for String {
     }
 }
 
-macro_rules! native_handle {
+macro_rules! ffi_bridge_handle {
     ($typ:ty) => {
-        impl ArgTypeInfo for &'static $typ {
+        impl ffi::ArgTypeInfo for &'static $typ {
             type ArgType = *const $typ;
             #[allow(clippy::not_unsafe_ptr_arg_deref)]
-            fn convert_from(foreign: *const $typ) -> Result<Self, SignalFfiError> {
-                unsafe { native_handle_cast(foreign) }
+            fn convert_from(foreign: *const $typ) -> Result<Self, ffi::SignalFfiError> {
+                unsafe { ffi::native_handle_cast(foreign) }
             }
         }
-        impl ResultTypeInfo for $typ {
+        impl ffi::ResultTypeInfo for $typ {
             type ResultType = *mut $typ;
-            fn convert_into(self) -> Result<Self::ResultType, SignalFfiError> {
+            fn convert_into(self) -> Result<Self::ResultType, ffi::SignalFfiError> {
                 Ok(Box::into_raw(Box::new(self)))
             }
         }
     };
 }
-
-native_handle!(ProtocolAddress);
-native_handle!(PublicKey);
-native_handle!(SignalMessage);
-native_handle!(PreKeySignalMessage);
 
 macro_rules! trivial {
     ($typ:ty) => {

--- a/rust/bridge/shared/src/ffi/error.rs
+++ b/rust/bridge/shared/src/ffi/error.rs
@@ -27,21 +27,3 @@ pub enum SignalFfiError {
     InvalidType,
 }
 
-#[cfg(test)]
-mod formatting_tests {
-    use super::SignalFfiError::UnexpectedPanic;
-
-    #[test]
-    fn test_unexpected_panic_downcast() {
-        let err = UnexpectedPanic(Box::new("error message"));
-
-        assert_eq!(err.to_string(), "unexpected panic: error message")
-    }
-
-    #[test]
-    fn test_unexpected_panic_no_downcast() {
-        let err = UnexpectedPanic(Box::new(0));
-
-        assert_eq!(err.to_string(), "unknown unexpected panic")
-    }
-}

--- a/rust/bridge/shared/src/ffi/error.rs
+++ b/rust/bridge/shared/src/ffi/error.rs
@@ -19,7 +19,7 @@ pub enum SignalFfiError {
     #[error("invalid UTF8 string")]
     InvalidUtf8String,
     // try to identify error or return unknown error
-    #[error("{}", .0.downcast_ref::<&'static str>().map(|s| format!("unexpected panic: {}", s)).unwrap_or("unknown unexpected panic".to_owned()))]
+    #[error("{}", .0.downcast_ref::<&'static str>().map(|s| format!("unexpected panic: {}", s)).unwrap_or_else(|| "unknown unexpected panic".to_owned()))]
     UnexpectedPanic(std::boxed::Box<dyn std::any::Any + std::marker::Send>),
     #[error("invalid type")]
     InvalidType,

--- a/rust/bridge/shared/src/ffi/error.rs
+++ b/rust/bridge/shared/src/ffi/error.rs
@@ -34,7 +34,7 @@ mod formatting_tests {
     #[test]
     fn test_unexpected_panic_downcast() {
         let err = UnexpectedPanic(Box::new("error message"));
-        
+
         assert_eq!(err.to_string(), "unexpected panic: error message")
     }
 

--- a/rust/bridge/shared/src/ffi/error.rs
+++ b/rust/bridge/shared/src/ffi/error.rs
@@ -26,3 +26,22 @@ pub enum SignalFfiError {
     #[error("invalid type")]
     InvalidType,
 }
+
+#[cfg(test)]
+mod formatting_tests {
+    use super::SignalFfiError::UnexpectedPanic;
+
+    #[test]
+    fn test_unexpected_panic_downcast() {
+        let err = UnexpectedPanic(Box::new("error message"));
+        
+        assert_eq!(err.to_string(), "unexpected panic: error message")
+    }
+
+    #[test]
+    fn test_unexpected_panic_no_downcast() {
+        let err = UnexpectedPanic(Box::new(0));
+
+        assert_eq!(err.to_string(), "unknown unexpected panic")
+    }
+}

--- a/rust/bridge/shared/src/ffi/error.rs
+++ b/rust/bridge/shared/src/ffi/error.rs
@@ -19,11 +19,8 @@ pub enum SignalFfiError {
     #[error("invalid UTF8 string")]
     InvalidUtf8String,
     // try to identify error or return unknown error
-    #[error("{}", .0.downcast_ref::<&'static str>().map(|s| format!("unexpected panic: {}", s)).unwrap_or_else(|| "unknown unexpected panic".to_owned()))]
+    #[error("{}", .0.downcast_ref::<&'static str>().map(|s| format!("unexpected panic: {}", s)).unwrap_or("unknown unexpected panic".to_owned()))]
     UnexpectedPanic(std::boxed::Box<dyn std::any::Any + std::marker::Send>),
-    #[error("callback invocation returned error code {0}")]
-    CallbackError(i32),
     #[error("invalid type")]
     InvalidType,
 }
-

--- a/rust/bridge/shared/src/ffi/error.rs
+++ b/rust/bridge/shared/src/ffi/error.rs
@@ -19,7 +19,7 @@ pub enum SignalFfiError {
     #[error("invalid UTF8 string")]
     InvalidUtf8String,
     // try to identify error or return unknown error
-    #[error("{}", .0.downcast_ref::<&'static str>().map(|s| format!("unexpected panic: {}", s)).unwrap_or("unknown unexpected panic".to_owned()))]
+    #[error("{}", .0.downcast_ref::<&'static str>().map(|s| format!("unexpected panic: {}", s)).unwrap_or_else(|| "unknown unexpected panic".to_owned()))]
     UnexpectedPanic(std::boxed::Box<dyn std::any::Any + std::marker::Send>),
     #[error("callback invocation returned error code {0}")]
     CallbackError(i32),

--- a/rust/bridge/shared/src/ffi/error.rs
+++ b/rust/bridge/shared/src/ffi/error.rs
@@ -24,3 +24,22 @@ pub enum SignalFfiError {
     #[error("invalid type")]
     InvalidType,
 }
+
+#[cfg(test)]
+mod formatting_tests {
+    use super::SignalFfiError::UnexpectedPanic;
+
+    #[test]
+    fn test_unexpected_panic_downcast() {
+        let err = UnexpectedPanic(Box::new("error message"));
+        
+        assert_eq!(err.to_string(), "unexpected panic: error message")
+    }
+
+    #[test]
+    fn test_unexpected_panic_no_downcast() {
+        let err = UnexpectedPanic(Box::new(0));
+
+        assert_eq!(err.to_string(), "unknown unexpected panic")
+    }
+}

--- a/rust/bridge/shared/src/ffi/mod.rs
+++ b/rust/bridge/shared/src/ffi/mod.rs
@@ -10,6 +10,8 @@ use std::ffi::CString;
 mod error;
 pub use error::*;
 
+pub use crate::support::expect_ready;
+
 pub fn run_ffi_safe<F: FnOnce() -> Result<(), SignalFfiError> + std::panic::UnwindSafe>(
     f: F,
 ) -> *mut SignalFfiError {

--- a/rust/bridge/shared/src/ffi/mod.rs
+++ b/rust/bridge/shared/src/ffi/mod.rs
@@ -7,6 +7,10 @@ use libc::{c_char, c_uchar, size_t};
 use libsignal_protocol_rust::*;
 use std::ffi::CString;
 
+#[macro_use]
+mod convert;
+pub(crate) use convert::*;
+
 mod error;
 pub use error::*;
 

--- a/rust/bridge/shared/src/jni/convert.rs
+++ b/rust/bridge/shared/src/jni/convert.rs
@@ -5,13 +5,22 @@
 
 use jni::JNIEnv;
 use jni::objects::JString;
+use jni::sys::{JNI_FALSE, JNI_TRUE};
 use libsignal_protocol_rust::*;
+use std::borrow::Borrow;
+use std::ops::Deref;
 
 use crate::jni::*;
 
 pub(crate) trait ArgTypeInfo<'a>: Sized {
     type ArgType;
     fn convert_from(env: &JNIEnv<'a>, foreign: Self::ArgType) -> Result<Self, SignalJniError>;
+}
+
+pub(crate) trait RefArgTypeInfo<'a>: Deref {
+    type ArgType;
+    type StoredType: Borrow<Self::Target> + 'a;
+    fn convert_from(env: &JNIEnv<'a>, foreign: Self::ArgType) -> Result<Self::StoredType, SignalJniError>;
 }
 
 pub(crate) trait ResultTypeInfo<'a>: Sized {
@@ -33,19 +42,48 @@ impl<'a> ArgTypeInfo<'a> for String {
     }
 }
 
-impl<'a, T> ArgTypeInfo<'a> for &'static T {
-    type ArgType = ObjectHandle;
-    fn convert_from(_env: &JNIEnv<'a>, foreign: Self::ArgType) -> Result<Self, SignalJniError> {
-        Ok(unsafe { native_handle_cast(foreign) }?)
+impl<'a> RefArgTypeInfo<'a> for &'_ [u8] {
+    type ArgType = jbyteArray;
+    type StoredType = Vec<u8>;
+    fn convert_from(env: &JNIEnv<'a>, foreign: Self::ArgType) -> Result<Vec<u8>, SignalJniError> {
+        Ok(env.convert_byte_array(foreign)?)
     }
 }
 
-impl<'a> ResultTypeInfo<'a> for ProtocolAddress {
-    type ResultType = ObjectHandle;
+impl<'a> ResultTypeInfo<'a> for bool {
+    type ResultType = jboolean;
     fn convert_into(self, _env: &JNIEnv<'a>) -> Result<Self::ResultType, SignalJniError> {
-        box_object(Ok(self))
+        Ok(if self { JNI_TRUE } else { JNI_FALSE })
     }
 }
+
+impl<'a, T: ResultTypeInfo<'a>> ResultTypeInfo<'a> for Result<T, SignalProtocolError> {
+    type ResultType = T::ResultType;
+    fn convert_into(self, env: &JNIEnv<'a>) -> Result<Self::ResultType, SignalJniError> {
+        T::convert_into(self?, env)
+    }
+}
+
+macro_rules! native_handle {
+    ($typ:ty) => {
+        impl<'a> RefArgTypeInfo<'a> for &$typ {
+            type ArgType = ObjectHandle;
+            type StoredType = &'static $typ;
+            fn convert_from(_env: &JNIEnv<'a>, foreign: Self::ArgType) -> Result<Self::StoredType, SignalJniError> {
+                Ok(unsafe { native_handle_cast(foreign) }?)
+            }
+        }
+        impl<'a> ResultTypeInfo<'a> for $typ {
+            type ResultType = ObjectHandle;
+            fn convert_into(self, _env: &JNIEnv<'a>) -> Result<Self::ResultType, SignalJniError> {
+                box_object(Ok(self))
+            }
+        }
+    }
+}
+
+native_handle!(PublicKey);
+native_handle!(ProtocolAddress);
 
 macro_rules! trivial {
     ($typ:ty) => {
@@ -65,10 +103,13 @@ trivial!(i32);
 macro_rules! jni_arg_type {
     (u32) => (jni::jint);
     (String) => (jni::JString);
+    (&[u8]) => (jni::jbyteArray);
     (& $typ:ty) => (jni::ObjectHandle);
 }
 
 macro_rules! jni_result_type {
+    (Result<$typ:tt, $_:tt>) => (jni_result_type!($typ));
+    (bool) => (jni::jboolean);
     (i32) => (jni::jint);
     ( $typ:ty ) => (jni::ObjectHandle);
 }

--- a/rust/bridge/shared/src/jni/convert.rs
+++ b/rust/bridge/shared/src/jni/convert.rs
@@ -35,6 +35,24 @@ impl<'a> ArgTypeInfo<'a> for u32 {
     }
 }
 
+impl<'a> ArgTypeInfo<'a> for Option<u32> {
+    type ArgType = jint;
+    fn convert_from(env: &JNIEnv<'a>, foreign: jint) -> Result<Self, SignalJniError> {
+        if foreign < 0 {
+            Ok(None)
+        } else {
+            u32::convert_from(env, foreign).map(Some)
+        }
+    }
+}
+
+impl<'a> ArgTypeInfo<'a> for u8 {
+    type ArgType = jint;
+    fn convert_from(_env: &JNIEnv<'a>, foreign: jint) -> Result<Self, SignalJniError> {
+        jint_to_u8(foreign)
+    }
+}
+
 impl<'a> ArgTypeInfo<'a> for String {
     type ArgType = JString<'a>;
     fn convert_from(env: &JNIEnv<'a>, foreign: JString<'a>) -> Result<Self, SignalJniError> {
@@ -91,6 +109,8 @@ macro_rules! native_handle {
 
 native_handle!(PublicKey);
 native_handle!(ProtocolAddress);
+native_handle!(SignalMessage);
+native_handle!(PreKeySignalMessage);
 
 macro_rules! trivial {
     ($typ:ty) => {
@@ -108,7 +128,9 @@ macro_rules! trivial {
 trivial!(i32);
 
 macro_rules! jni_arg_type {
+    (u8) => (jni::jint);
     (u32) => (jni::jint);
+    (Option<u32>) => (jni::jint);
     (String) => (jni::JString);
     (&[u8]) => (jni::jbyteArray);
     (& $typ:ty) => (jni::ObjectHandle);

--- a/rust/bridge/shared/src/jni/convert.rs
+++ b/rust/bridge/shared/src/jni/convert.rs
@@ -1,0 +1,62 @@
+//
+// Copyright 2020 Signal Messenger, LLC.
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+use jni::JNIEnv;
+use jni::objects::JString;
+use libsignal_protocol_rust::*;
+
+use crate::jni::*;
+
+pub(crate) trait ArgTypeInfo<'a>: Sized {
+    type ArgType;
+    fn convert_from(env: &JNIEnv<'a>, foreign: Self::ArgType) -> Result<Self, SignalJniError>;
+}
+
+pub(crate) trait ResultTypeInfo<'a>: Sized {
+    type ResultType;
+    fn convert_into(self, env: &JNIEnv<'a>) -> Result<Self::ResultType, SignalJniError>;
+}
+
+pub(crate) trait TrivialTypeInfo {}
+
+impl<'a, T: TrivialTypeInfo> ArgTypeInfo<'a> for T {
+    type ArgType = Self;
+    fn convert_from(_env: &JNIEnv<'a>, foreign: Self) -> Result<Self, SignalJniError> { Ok(foreign) }
+}
+
+impl<'a, T: TrivialTypeInfo> ResultTypeInfo<'a> for T {
+    type ResultType = Self;
+    fn convert_into(self, _env: &JNIEnv<'a>) -> Result<Self, SignalJniError> { Ok(self) }
+}
+
+impl<'a> ArgTypeInfo<'a> for u32 {
+    type ArgType = jint;
+    fn convert_from(_env: &JNIEnv<'a>, foreign: jint) -> Result<Self, SignalJniError> {
+        jint_to_u32(foreign)
+    }
+}
+
+impl<'a> ArgTypeInfo<'a> for String {
+    type ArgType = JString<'a>;
+    fn convert_from(env: &JNIEnv<'a>, foreign: JString<'a>) -> Result<Self, SignalJniError> {
+        Ok(env.get_string(foreign)?.into())
+    }
+}
+
+impl<'a> ResultTypeInfo<'a> for ProtocolAddress {
+    type ResultType = ObjectHandle;
+    fn convert_into(self, _env: &JNIEnv<'a>) -> Result<Self::ResultType, SignalJniError> {
+        box_object(Ok(self))
+    }
+}
+
+macro_rules! jni_arg_type {
+    (u32) => (jni::jint);
+    (String) => (jni::JString);
+}
+
+macro_rules! jni_result_type {
+    ( $typ:ty ) => (jni::ObjectHandle);
+}

--- a/rust/bridge/shared/src/jni/convert.rs
+++ b/rust/bridge/shared/src/jni/convert.rs
@@ -57,6 +57,13 @@ impl<'a> ResultTypeInfo<'a> for bool {
     }
 }
 
+impl<'a> ResultTypeInfo<'a> for String {
+    type ResultType = jstring;
+    fn convert_into(self, env: &JNIEnv<'a>) -> Result<Self::ResultType, SignalJniError> {
+        Ok(env.new_string(self)?.into_inner())
+    }
+}
+
 impl<'a, T: ResultTypeInfo<'a>> ResultTypeInfo<'a> for Result<T, SignalProtocolError> {
     type ResultType = T::ResultType;
     fn convert_into(self, env: &JNIEnv<'a>) -> Result<Self::ResultType, SignalJniError> {
@@ -111,5 +118,6 @@ macro_rules! jni_result_type {
     (Result<$typ:tt, $_:tt>) => (jni_result_type!($typ));
     (bool) => (jni::jboolean);
     (i32) => (jni::jint);
+    (String) => (jni::jstring);
     ( $typ:ty ) => (jni::ObjectHandle);
 }

--- a/rust/bridge/shared/src/jni/convert.rs
+++ b/rust/bridge/shared/src/jni/convert.rs
@@ -111,31 +111,29 @@ impl<T: ResultTypeInfo> ResultTypeInfo for Result<T, SignalProtocolError> {
     }
 }
 
-macro_rules! native_handle {
+macro_rules! jni_bridge_handle {
     ($typ:ty) => {
-        impl<'a> RefArgTypeInfo<'a> for &$typ {
-            type ArgType = ObjectHandle;
+        impl<'a> jni::RefArgTypeInfo<'a> for &$typ {
+            type ArgType = jni::ObjectHandle;
             type StoredType = &'static $typ;
             fn convert_from(
-                _env: &'a JNIEnv,
+                _env: &'a jni::JNIEnv,
                 foreign: Self::ArgType,
-            ) -> Result<Self::StoredType, SignalJniError> {
-                Ok(unsafe { native_handle_cast(foreign) }?)
+            ) -> Result<Self::StoredType, jni::SignalJniError> {
+                Ok(unsafe { jni::native_handle_cast(foreign) }?)
             }
         }
-        impl ResultTypeInfo for $typ {
-            type ResultType = ObjectHandle;
-            fn convert_into(self, _env: &JNIEnv) -> Result<Self::ResultType, SignalJniError> {
-                box_object(Ok(self))
+        impl jni::ResultTypeInfo for $typ {
+            type ResultType = jni::ObjectHandle;
+            fn convert_into(
+                self,
+                _env: &jni::JNIEnv,
+            ) -> Result<Self::ResultType, jni::SignalJniError> {
+                jni::box_object(Ok(self))
             }
         }
     };
 }
-
-native_handle!(PublicKey);
-native_handle!(ProtocolAddress);
-native_handle!(SignalMessage);
-native_handle!(PreKeySignalMessage);
 
 macro_rules! trivial {
     ($typ:ty) => {

--- a/rust/bridge/shared/src/jni/error.rs
+++ b/rust/bridge/shared/src/jni/error.rs
@@ -12,7 +12,7 @@ use libsignal_protocol_rust::*;
 
 use super::*;
 
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum SignalJniError {
     #[error(transparent)]
     Signal(#[from] SignalProtocolError),

--- a/rust/bridge/shared/src/jni/error.rs
+++ b/rust/bridge/shared/src/jni/error.rs
@@ -123,3 +123,22 @@ impl fmt::Debug for ThrownException {
 }
 
 impl std::error::Error for ThrownException {}
+
+#[cfg(test)]
+mod formatting_tests {
+    use super::SignalJniError::UnexpectedPanic;
+
+    #[test]
+    fn test_unexpected_panic_downcast() {
+        let err = UnexpectedPanic(Box::new("error message"));
+        
+        assert_eq!(err.to_string(), "unexpected panic: error message")
+    }
+
+    #[test]
+    fn test_unexpected_panic_no_downcast() {
+        let err = UnexpectedPanic(Box::new(0));
+
+        assert_eq!(err.to_string(), "unknown unexpected panic")
+    }
+}

--- a/rust/bridge/shared/src/jni/error.rs
+++ b/rust/bridge/shared/src/jni/error.rs
@@ -12,7 +12,7 @@ use libsignal_protocol_rust::*;
 
 use super::*;
 
-#[derive(thiserror::Error, Debug)]
+#[derive(Debug)]
 pub enum SignalJniError {
     #[error(transparent)]
     Signal(#[from] SignalProtocolError),

--- a/rust/bridge/shared/src/jni/error.rs
+++ b/rust/bridge/shared/src/jni/error.rs
@@ -61,7 +61,7 @@ mod formatting_tests {
     #[test]
     fn test_unexpected_panic_downcast() {
         let err = UnexpectedPanic(Box::new("error message"));
-        
+
         assert_eq!(err.to_string(), "unexpected panic: error message")
     }
 

--- a/rust/bridge/shared/src/jni/error.rs
+++ b/rust/bridge/shared/src/jni/error.rs
@@ -30,64 +30,6 @@ pub enum SignalJniError {
     IntegerOverflow(String),
     #[error("{}", .0.downcast_ref::<&'static str>().map(|s| format!("unexpected panic: {}", s)).unwrap_or_else(|| "unknown unexpected panic".to_owned()))]
     UnexpectedPanic(std::boxed::Box<dyn std::any::Any + std::marker::Send>),
-    #[error("exception recieved during callback {0}")]
-    ExceptionDuringCallback(String),
-}
-
-impl fmt::Display for SignalJniError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            SignalJniError::Signal(s) => write!(f, "{}", s),
-            SignalJniError::AesGcmSiv(s) => write!(f, "{}", s),
-            SignalJniError::Jni(s) => write!(f, "JNI error {}", s),
-            SignalJniError::ExceptionDuringCallback(s) => {
-                write!(f, "exception recieved during callback {}", s)
-            }
-            SignalJniError::NullHandle => write!(f, "null handle"),
-            SignalJniError::BadJniParameter(m) => write!(f, "bad parameter type {}", m),
-            SignalJniError::UnexpectedJniResultType(m, t) => {
-                write!(f, "calling {} returned unexpected type {}", m, t)
-            }
-            SignalJniError::IntegerOverflow(m) => {
-                write!(f, "integer overflow during conversion of {}", m)
-            }
-            SignalJniError::UnexpectedPanic(e) => match e.downcast_ref::<&'static str>() {
-                Some(s) => write!(f, "unexpected panic: {}", s),
-                None => write!(f, "unknown unexpected panic"),
-            },
-        }
-    }
-}
-
-impl From<SignalProtocolError> for SignalJniError {
-    fn from(e: SignalProtocolError) -> SignalJniError {
-        SignalJniError::Signal(e)
-    }
-}
-
-impl From<AesGcmSivError> for SignalJniError {
-    fn from(e: AesGcmSivError) -> SignalJniError {
-        SignalJniError::AesGcmSiv(e)
-    }
-}
-
-impl From<jni::errors::Error> for SignalJniError {
-    fn from(e: jni::errors::Error) -> SignalJniError {
-        SignalJniError::Jni(e)
-    }
-}
-
-impl From<SignalJniError> for SignalProtocolError {
-    fn from(err: SignalJniError) -> SignalProtocolError {
-        match err {
-            SignalJniError::Signal(e) => e,
-            SignalJniError::Jni(e) => SignalProtocolError::FfiBindingError(e.to_string()),
-            SignalJniError::BadJniParameter(m) => {
-                SignalProtocolError::InvalidArgument(m.to_string())
-            }
-            _ => SignalProtocolError::FfiBindingError(format!("{}", err)),
-        }
-    }
 }
 
 pub struct ThrownException {

--- a/rust/bridge/shared/src/jni/error.rs
+++ b/rust/bridge/shared/src/jni/error.rs
@@ -28,16 +28,46 @@ pub enum SignalJniError {
     ExceptionDuringCallback(String),
 }
 
-impl SignalJniError {
-    pub fn to_signal_protocol_error(&self) -> SignalProtocolError {
+impl fmt::Display for SignalJniError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            SignalJniError::Signal(e) => e.clone(),
-            SignalJniError::Jni(e) => SignalProtocolError::FfiBindingError(e.to_string()),
-            SignalJniError::BadJniParameter(m) => {
-                SignalProtocolError::InvalidArgument(m.to_string())
+            SignalJniError::Signal(s) => write!(f, "{}", s),
+            SignalJniError::AesGcmSiv(s) => write!(f, "{}", s),
+            SignalJniError::Jni(s) => write!(f, "JNI error {}", s),
+            SignalJniError::ExceptionDuringCallback(s) => {
+                write!(f, "exception recieved during callback {}", s)
             }
-            _ => SignalProtocolError::FfiBindingError(format!("{}", self)),
+            SignalJniError::NullHandle => write!(f, "null handle"),
+            SignalJniError::BadJniParameter(m) => write!(f, "bad parameter type {}", m),
+            SignalJniError::UnexpectedJniResultType(m, t) => {
+                write!(f, "calling {} returned unexpected type {}", m, t)
+            }
+            SignalJniError::IntegerOverflow(m) => {
+                write!(f, "integer overflow during conversion of {}", m)
+            }
+            SignalJniError::UnexpectedPanic(e) => match e.downcast_ref::<&'static str>() {
+                Some(s) => write!(f, "unexpected panic: {}", s),
+                None => write!(f, "unknown unexpected panic"),
+            },
         }
+    }
+}
+
+impl From<SignalProtocolError> for SignalJniError {
+    fn from(e: SignalProtocolError) -> SignalJniError {
+        SignalJniError::Signal(e)
+    }
+}
+
+impl From<AesGcmSivError> for SignalJniError {
+    fn from(e: AesGcmSivError) -> SignalJniError {
+        SignalJniError::AesGcmSiv(e)
+    }
+}
+
+impl From<jni::errors::Error> for SignalJniError {
+    fn from(e: jni::errors::Error) -> SignalJniError {
+        SignalJniError::Jni(e)
     }
 }
 

--- a/rust/bridge/shared/src/jni/error.rs
+++ b/rust/bridge/shared/src/jni/error.rs
@@ -3,21 +3,28 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use std::fmt;
-
 use aes_gcm_siv::Error as AesGcmSivError;
 use libsignal_protocol_rust::*;
 
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum SignalJniError {
-    Signal(SignalProtocolError),
-    AesGcmSiv(AesGcmSivError),
-    Jni(jni::errors::Error),
+    #[error(transparent)]
+    Signal(#[from] SignalProtocolError),
+    #[error(transparent)]
+    AesGcmSiv(#[from] AesGcmSivError),
+    #[error(transparent)]
+    Jni(#[from] jni::errors::Error),
+    #[error("bad parameter type {0}")]
     BadJniParameter(&'static str),
+    #[error("calling {0} returned unexpected type {1}")]
     UnexpectedJniResultType(&'static str, &'static str),
+    #[error("null handle")]
     NullHandle,
+    #[error("integer overflow during conversion of {0}")]
     IntegerOverflow(String),
+    #[error("{}", .0.downcast_ref::<&'static str>().map(|s| format!("unexpected panic: {}", s)).unwrap_or("unknown unexpected panic".to_owned()))]
     UnexpectedPanic(std::boxed::Box<dyn std::any::Any + std::marker::Send>),
+    #[error("exception recieved during callback {0}")]
     ExceptionDuringCallback(String),
 }
 
@@ -31,49 +38,6 @@ impl SignalJniError {
             }
             _ => SignalProtocolError::FfiBindingError(format!("{}", self)),
         }
-    }
-}
-
-impl fmt::Display for SignalJniError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            SignalJniError::Signal(s) => write!(f, "{}", s),
-            SignalJniError::AesGcmSiv(s) => write!(f, "{}", s),
-            SignalJniError::Jni(s) => write!(f, "JNI error {}", s),
-            SignalJniError::ExceptionDuringCallback(s) => {
-                write!(f, "exception recieved during callback {}", s)
-            }
-            SignalJniError::NullHandle => write!(f, "null handle"),
-            SignalJniError::BadJniParameter(m) => write!(f, "bad parameter type {}", m),
-            SignalJniError::UnexpectedJniResultType(m, t) => {
-                write!(f, "calling {} returned unexpected type {}", m, t)
-            }
-            SignalJniError::IntegerOverflow(m) => {
-                write!(f, "integer overflow during conversion of {}", m)
-            }
-            SignalJniError::UnexpectedPanic(e) => match e.downcast_ref::<&'static str>() {
-                Some(s) => write!(f, "unexpected panic: {}", s),
-                None => write!(f, "unknown unexpected panic"),
-            },
-        }
-    }
-}
-
-impl From<SignalProtocolError> for SignalJniError {
-    fn from(e: SignalProtocolError) -> SignalJniError {
-        SignalJniError::Signal(e)
-    }
-}
-
-impl From<AesGcmSivError> for SignalJniError {
-    fn from(e: AesGcmSivError) -> SignalJniError {
-        SignalJniError::AesGcmSiv(e)
-    }
-}
-
-impl From<jni::errors::Error> for SignalJniError {
-    fn from(e: jni::errors::Error) -> SignalJniError {
-        SignalJniError::Jni(e)
     }
 }
 

--- a/rust/bridge/shared/src/jni/error.rs
+++ b/rust/bridge/shared/src/jni/error.rs
@@ -22,7 +22,7 @@ pub enum SignalJniError {
     NullHandle,
     #[error("integer overflow during conversion of {0}")]
     IntegerOverflow(String),
-    #[error("{}", .0.downcast_ref::<&'static str>().map(|s| format!("unexpected panic: {}", s)).unwrap_or("unknown unexpected panic".to_owned()))]
+    #[error("{}", .0.downcast_ref::<&'static str>().map(|s| format!("unexpected panic: {}", s)).unwrap_or_else(|| "unknown unexpected panic".to_owned()))]
     UnexpectedPanic(std::boxed::Box<dyn std::any::Any + std::marker::Send>),
     #[error("exception recieved during callback {0}")]
     ExceptionDuringCallback(String),

--- a/rust/bridge/shared/src/jni/error.rs
+++ b/rust/bridge/shared/src/jni/error.rs
@@ -53,3 +53,22 @@ impl From<SignalJniError> for SignalProtocolError {
         }
     }
 }
+
+#[cfg(test)]
+mod formatting_tests {
+    use super::SignalJniError::UnexpectedPanic;
+
+    #[test]
+    fn test_unexpected_panic_downcast() {
+        let err = UnexpectedPanic(Box::new("error message"));
+        
+        assert_eq!(err.to_string(), "unexpected panic: error message")
+    }
+
+    #[test]
+    fn test_unexpected_panic_no_downcast() {
+        let err = UnexpectedPanic(Box::new(0));
+
+        assert_eq!(err.to_string(), "unknown unexpected panic")
+    }
+}

--- a/rust/bridge/shared/src/jni/mod.rs
+++ b/rust/bridge/shared/src/jni/mod.rs
@@ -47,8 +47,6 @@ fn throw_error(env: &JNIEnv, error: SignalJniError) {
         SignalJniError::UnexpectedJniResultType(_, _) => "java/lang/AssertionError",
         SignalJniError::IntegerOverflow(_) => "java/lang/RuntimeException",
 
-        SignalJniError::ExceptionDuringCallback(_) => "java/lang/RuntimeException",
-
         SignalJniError::Signal(SignalProtocolError::DuplicatedMessage(_, _)) => {
             "org/whispersystems/libsignal/DuplicateMessageException"
         }

--- a/rust/bridge/shared/src/jni/mod.rs
+++ b/rust/bridge/shared/src/jni/mod.rs
@@ -17,6 +17,8 @@ pub(crate) use jni::JNIEnv;
 mod error;
 pub use error::*;
 
+pub use crate::support::expect_ready;
+
 pub type ObjectHandle = jlong;
 
 fn throw_error(env: &JNIEnv, error: SignalJniError) {

--- a/rust/bridge/shared/src/jni/mod.rs
+++ b/rust/bridge/shared/src/jni/mod.rs
@@ -4,15 +4,19 @@
 //
 
 use jni::objects::{JObject, JValue};
-use jni::sys::{_jobject, jboolean, jint, jlong};
+use jni::sys::{_jobject, jboolean, jlong};
 
 use aes_gcm_siv::Error as AesGcmSivError;
 use libsignal_protocol_rust::*;
 
-pub(crate) use jni::objects::JClass;
+pub(crate) use jni::objects::{JClass, JString};
 pub(crate) use jni::strings::JNIString;
-pub(crate) use jni::sys::{jbyteArray, jstring};
+pub(crate) use jni::sys::{jbyteArray, jint, jstring};
 pub(crate) use jni::JNIEnv;
+
+#[macro_use]
+mod convert;
+pub(crate) use convert::*;
 
 mod error;
 pub use error::*;
@@ -198,6 +202,13 @@ pub unsafe fn native_handle_cast<T>(
     }
 
     Ok(&mut *(handle as *mut T))
+}
+
+pub fn jint_to_u32(v: jint) -> Result<u32, SignalJniError> {
+    if v < 0 {
+        return Err(SignalJniError::IntegerOverflow(format!("{} to u32", v)));
+    }
+    Ok(v as u32)
 }
 
 pub fn to_jbytearray<T: AsRef<[u8]>>(

--- a/rust/bridge/shared/src/jni/mod.rs
+++ b/rust/bridge/shared/src/jni/mod.rs
@@ -89,7 +89,7 @@ fn throw_error(env: &JNIEnv, error: SignalJniError) {
             "org/whispersystems/libsignal/InvalidKeyException"
         }
 
-        SignalJniError::Signal(SignalProtocolError::SessionNotFound) => {
+        SignalJniError::Signal(SignalProtocolError::SessionNotFound(_)) => {
             "org/whispersystems/libsignal/NoSessionException"
         }
 

--- a/rust/bridge/shared/src/jni/mod.rs
+++ b/rust/bridge/shared/src/jni/mod.rs
@@ -8,6 +8,7 @@ use jni::sys::{_jobject, jlong};
 
 use aes_gcm_siv::Error as AesGcmSivError;
 use libsignal_protocol_rust::*;
+use std::convert::TryFrom;
 
 pub(crate) use jni::objects::{JClass, JString};
 pub(crate) use jni::strings::JNIString;
@@ -209,6 +210,13 @@ pub fn jint_to_u32(v: jint) -> Result<u32, SignalJniError> {
         return Err(SignalJniError::IntegerOverflow(format!("{} to u32", v)));
     }
     Ok(v as u32)
+}
+
+pub fn jint_to_u8(v: jint) -> Result<u8, SignalJniError> {
+    match u8::try_from(v) {
+        Err(_) => Err(SignalJniError::IntegerOverflow(format!("{} to u8", v))),
+        Ok(v) => Ok(v),
+    }
 }
 
 pub fn to_jbytearray<T: AsRef<[u8]>>(

--- a/rust/bridge/shared/src/jni/mod.rs
+++ b/rust/bridge/shared/src/jni/mod.rs
@@ -4,14 +4,14 @@
 //
 
 use jni::objects::{JObject, JValue};
-use jni::sys::{_jobject, jboolean, jlong};
+use jni::sys::{_jobject, jlong};
 
 use aes_gcm_siv::Error as AesGcmSivError;
 use libsignal_protocol_rust::*;
 
 pub(crate) use jni::objects::{JClass, JString};
 pub(crate) use jni::strings::JNIString;
-pub(crate) use jni::sys::{jbyteArray, jint, jstring};
+pub(crate) use jni::sys::{jboolean, jbyteArray, jint, jstring};
 pub(crate) use jni::JNIEnv;
 
 #[macro_use]

--- a/rust/bridge/shared/src/jni/mod.rs
+++ b/rust/bridge/shared/src/jni/mod.rs
@@ -94,6 +94,7 @@ fn throw_error(env: &JNIEnv, error: SignalJniError) {
         }
 
         SignalJniError::Signal(SignalProtocolError::InvalidMessage(_))
+        | SignalJniError::Signal(SignalProtocolError::MessageDecryptionFailed(_))
         | SignalJniError::Signal(SignalProtocolError::CiphertextMessageTooShort(_))
         | SignalJniError::Signal(SignalProtocolError::UnrecognizedCiphertextVersion(_))
         | SignalJniError::Signal(SignalProtocolError::UnrecognizedMessageVersion(_))

--- a/rust/bridge/shared/src/lib.rs
+++ b/rust/bridge/shared/src/lib.rs
@@ -47,10 +47,7 @@ bridge_get_bytearray!(
 );
 
 #[bridge_fn(ffi = "publickey_compare")]
-fn ECPublicKey_Compare(
-    key1: &PublicKey,
-    key2: &PublicKey,
-) -> i32 {
+fn ECPublicKey_Compare(key1: &PublicKey, key2: &PublicKey) -> i32 {
     match key1.cmp(&key2) {
         std::cmp::Ordering::Less => -1,
         std::cmp::Ordering::Equal => 0,
@@ -66,7 +63,6 @@ fn ECPublicKey_Verify(
 ) -> Result<bool, SignalProtocolError> {
     key.verify_signature(&message, &signature)
 }
-
 
 bridge_destroy!(PrivateKey, ffi = privatekey, jni = ECPrivateKey);
 bridge_deserialize!(
@@ -91,14 +87,19 @@ bridge_get_string!(display_string(Fingerprint), jni = NumericFingerprintGenerato
     Fingerprint::display_string
 );
 #[bridge_fn(ffi = "fingerprint_format")]
-fn DisplayableFingerprint_Format(local: &[u8], remote: &[u8]) -> Result<String, SignalProtocolError> {
+fn DisplayableFingerprint_Format(
+    local: &[u8],
+    remote: &[u8],
+) -> Result<String, SignalProtocolError> {
     DisplayableFingerprint::new(&local, &remote).map(|f| f.to_string())
 }
 #[bridge_fn(ffi = "fingerprint_compare")]
-fn ScannableFingerprint_Compare(fprint1: &[u8], fprint2: &[u8]) -> Result<bool, SignalProtocolError> {
+fn ScannableFingerprint_Compare(
+    fprint1: &[u8],
+    fprint2: &[u8],
+) -> Result<bool, SignalProtocolError> {
     ScannableFingerprint::deserialize(&fprint1)?.compare(fprint2)
 }
-
 
 bridge_destroy!(SignalMessage, ffi = message);
 bridge_deserialize!(SignalMessage::try_from, ffi = message);
@@ -169,7 +170,6 @@ fn PreKeySignalMessage_New(
         signal_message.clone(),
     )
 }
-
 
 bridge_destroy!(PreKeySignalMessage);
 bridge_deserialize!(PreKeySignalMessage::try_from);

--- a/rust/bridge/shared/src/lib.rs
+++ b/rust/bridge/shared/src/lib.rs
@@ -58,6 +58,15 @@ fn publickey_compare(
     }
 }
 
+#[bridge_fn(jni = "ECPublicKey_1Verify")]
+fn publickey_verify(
+    key: &PublicKey,
+    message: &[u8],
+    signature: &[u8],
+) -> Result<bool, SignalProtocolError> {
+    key.verify_signature(&message, &signature)
+}
+
 
 bridge_destroy!(PrivateKey, ffi = privatekey, jni = ECPrivateKey);
 bridge_deserialize!(

--- a/rust/bridge/shared/src/lib.rs
+++ b/rust/bridge/shared/src/lib.rs
@@ -30,8 +30,8 @@ bridge_get_string!(name(ProtocolAddress), ffi = address_get_name =>
     |p| Ok(p.name())
 );
 
-#[bridge_fn(jni = "ProtocolAddress_1New")]
-fn address_new(name: String, device_id: u32) -> ProtocolAddress {
+#[bridge_fn(ffi = "address_new")]
+fn ProtocolAddress_New(name: String, device_id: u32) -> ProtocolAddress {
     ProtocolAddress::new(name, device_id)
 }
 
@@ -46,8 +46,8 @@ bridge_get_bytearray!(
     PublicKey::public_key_bytes
 );
 
-#[bridge_fn(jni = "ECPublicKey_1Compare")]
-fn publickey_compare(
+#[bridge_fn(ffi = "publickey_compare")]
+fn ECPublicKey_Compare(
     key1: &PublicKey,
     key2: &PublicKey,
 ) -> i32 {
@@ -58,8 +58,8 @@ fn publickey_compare(
     }
 }
 
-#[bridge_fn(jni = "ECPublicKey_1Verify")]
-fn publickey_verify(
+#[bridge_fn(ffi = "publickey_verify")]
+fn ECPublicKey_Verify(
     key: &PublicKey,
     message: &[u8],
     signature: &[u8],
@@ -90,12 +90,12 @@ bridge_get_bytearray!(
 bridge_get_string!(display_string(Fingerprint), jni = NumericFingerprintGenerator_1GetDisplayString =>
     Fingerprint::display_string
 );
-#[bridge_fn(jni = "DisplayableFingerprint_1Format")]
-fn fingerprint_format(local: &[u8], remote: &[u8]) -> Result<String, SignalProtocolError> {
-    DisplayableFingerprint::new(&local, &remote).map(|f| format!("{}", f))
+#[bridge_fn(ffi = "fingerprint_format")]
+fn DisplayableFingerprint_Format(local: &[u8], remote: &[u8]) -> Result<String, SignalProtocolError> {
+    DisplayableFingerprint::new(&local, &remote).map(|f| f.to_string())
 }
-#[bridge_fn(jni = "ScannableFingerprint_1Compare")]
-fn fingerprint_compare(fprint1: &[u8], fprint2: &[u8]) -> Result<bool, SignalProtocolError> {
+#[bridge_fn(ffi = "fingerprint_compare")]
+fn ScannableFingerprint_Compare(fprint1: &[u8], fprint2: &[u8]) -> Result<bool, SignalProtocolError> {
     ScannableFingerprint::deserialize(&fprint1)?.compare(fprint2)
 }
 
@@ -112,8 +112,8 @@ bridge_get_bytearray!(get_serialized(SignalMessage), ffi = message_get_serialize
     |m| Ok(m.serialized())
 );
 
-#[bridge_fn(jni = "SignalMessage_1New")]
-fn message_new(
+#[bridge_fn(ffi = "message_new")]
+fn SignalMessage_New(
     message_version: u8,
     mac_key: &[u8],
     sender_ratchet_key: &PublicKey,
@@ -135,8 +135,8 @@ fn message_new(
     )
 }
 
-#[bridge_fn(jni = "SignalMessage_1VerifyMac")]
-fn message_verify_mac(
+#[bridge_fn(ffi = "message_verify_mac")]
+fn SignalMessage_VerifyMac(
     msg: &SignalMessage,
     sender_identity_key: &PublicKey,
     receiver_identity_key: &PublicKey,
@@ -149,8 +149,8 @@ fn message_verify_mac(
     )
 }
 
-#[bridge_fn(jni = "PreKeySignalMessage_1New")]
-fn pre_key_signal_message_new(
+#[bridge_fn]
+fn PreKeySignalMessage_New(
     message_version: u8,
     registration_id: u32,
     pre_key_id: Option<u32>,

--- a/rust/bridge/shared/src/lib.rs
+++ b/rust/bridge/shared/src/lib.rs
@@ -112,6 +112,65 @@ bridge_get_bytearray!(get_serialized(SignalMessage), ffi = message_get_serialize
     |m| Ok(m.serialized())
 );
 
+#[bridge_fn(jni = "SignalMessage_1New")]
+fn message_new(
+    message_version: u8,
+    mac_key: &[u8],
+    sender_ratchet_key: &PublicKey,
+    counter: u32,
+    previous_counter: u32,
+    ciphertext: &[u8],
+    sender_identity_key: &PublicKey,
+    receiver_identity_key: &PublicKey,
+) -> Result<SignalMessage, SignalProtocolError> {
+    SignalMessage::new(
+        message_version,
+        mac_key,
+        *sender_ratchet_key,
+        counter,
+        previous_counter,
+        ciphertext,
+        &IdentityKey::new(*sender_identity_key),
+        &IdentityKey::new(*receiver_identity_key),
+    )
+}
+
+#[bridge_fn(jni = "SignalMessage_1VerifyMac")]
+fn message_verify_mac(
+    msg: &SignalMessage,
+    sender_identity_key: &PublicKey,
+    receiver_identity_key: &PublicKey,
+    mac_key: &[u8],
+) -> Result<bool, SignalProtocolError> {
+    msg.verify_mac(
+        &IdentityKey::new(*sender_identity_key),
+        &IdentityKey::new(*receiver_identity_key),
+        &mac_key,
+    )
+}
+
+#[bridge_fn(jni = "PreKeySignalMessage_1New")]
+fn pre_key_signal_message_new(
+    message_version: u8,
+    registration_id: u32,
+    pre_key_id: Option<u32>,
+    signed_pre_key_id: u32,
+    base_key: &PublicKey,
+    identity_key: &PublicKey,
+    signal_message: &SignalMessage,
+) -> Result<PreKeySignalMessage, SignalProtocolError> {
+    PreKeySignalMessage::new(
+        message_version,
+        registration_id,
+        pre_key_id,
+        signed_pre_key_id,
+        *base_key,
+        IdentityKey::new(*identity_key),
+        signal_message.clone(),
+    )
+}
+
+
 bridge_destroy!(PreKeySignalMessage);
 bridge_deserialize!(PreKeySignalMessage::try_from);
 bridge_get_bytearray!(serialize(PreKeySignalMessage), jni = PreKeySignalMessage_1GetSerialized =>

--- a/rust/bridge/shared/src/lib.rs
+++ b/rust/bridge/shared/src/lib.rs
@@ -90,6 +90,15 @@ bridge_get_bytearray!(
 bridge_get_string!(display_string(Fingerprint), jni = NumericFingerprintGenerator_1GetDisplayString =>
     Fingerprint::display_string
 );
+#[bridge_fn(jni = "DisplayableFingerprint_1Format")]
+fn fingerprint_format(local: &[u8], remote: &[u8]) -> Result<String, SignalProtocolError> {
+    DisplayableFingerprint::new(&local, &remote).map(|f| format!("{}", f))
+}
+#[bridge_fn(jni = "ScannableFingerprint_1Compare")]
+fn fingerprint_compare(fprint1: &[u8], fprint2: &[u8]) -> Result<bool, SignalProtocolError> {
+    ScannableFingerprint::deserialize(&fprint1)?.compare(fprint2)
+}
+
 
 bridge_destroy!(SignalMessage, ffi = message);
 bridge_deserialize!(SignalMessage::try_from, ffi = message);

--- a/rust/bridge/shared/src/lib.rs
+++ b/rust/bridge/shared/src/lib.rs
@@ -46,6 +46,19 @@ bridge_get_bytearray!(
     PublicKey::public_key_bytes
 );
 
+#[bridge_fn(jni = "ECPublicKey_1Compare")]
+fn publickey_compare(
+    key1: &PublicKey,
+    key2: &PublicKey,
+) -> i32 {
+    match key1.cmp(&key2) {
+        std::cmp::Ordering::Less => -1,
+        std::cmp::Ordering::Equal => 0,
+        std::cmp::Ordering::Greater => 1,
+    }
+}
+
+
 bridge_destroy!(PrivateKey, ffi = privatekey, jni = ECPrivateKey);
 bridge_deserialize!(
     PrivateKey::deserialize,

--- a/rust/bridge/shared/src/lib.rs
+++ b/rust/bridge/shared/src/lib.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::missing_safety_doc)]
 
 use aes_gcm_siv::Aes256GcmSiv;
+use libsignal_bridge_macros::*;
 use libsignal_protocol_rust::*;
 use std::convert::TryFrom;
 
@@ -28,6 +29,11 @@ bridge_destroy!(ProtocolAddress, ffi = address);
 bridge_get_string!(name(ProtocolAddress), ffi = address_get_name =>
     |p| Ok(p.name())
 );
+
+#[bridge_fn(jni = "ProtocolAddress_1New")]
+fn address_new(name: String, device_id: u32) -> ProtocolAddress {
+    ProtocolAddress::new(name, device_id)
+}
 
 bridge_destroy!(PublicKey, ffi = publickey, jni = ECPublicKey);
 bridge_deserialize!(PublicKey::deserialize, ffi = publickey, jni = None);

--- a/rust/bridge/shared/src/lib.rs
+++ b/rust/bridge/shared/src/lib.rs
@@ -25,6 +25,11 @@ pub mod jni;
 mod support;
 use support::*;
 
+bridge_handle!(ProtocolAddress);
+bridge_handle!(PublicKey);
+bridge_handle!(SignalMessage);
+bridge_handle!(PreKeySignalMessage);
+
 bridge_destroy!(ProtocolAddress, ffi = address);
 bridge_get_string!(name(ProtocolAddress), ffi = address_get_name =>
     |p| Ok(p.name())

--- a/rust/bridge/shared/src/support.rs
+++ b/rust/bridge/shared/src/support.rs
@@ -3,7 +3,21 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-pub use paste::paste;
+use futures::pin_mut;
+use futures::task::noop_waker_ref;
+use std::future::Future;
+use std::task::{self, Poll};
+
+pub(crate) use paste::paste;
+
+#[track_caller]
+pub fn expect_ready<F: Future>(future: F) -> F::Output {
+    pin_mut!(future);
+    match future.poll(&mut task::Context::from_waker(noop_waker_ref())) {
+        Poll::Ready(result) => result,
+        Poll::Pending => panic!("future was not ready"),
+    }
+}
 
 /// Wraps an expression in a function with a given name and type...
 /// except that if the expression is a closure with a single typeless argument,

--- a/rust/bridge/shared/src/support.rs
+++ b/rust/bridge/shared/src/support.rs
@@ -33,6 +33,15 @@ macro_rules! expr_as_fn {
     };
 }
 
+// macro_rules! bridge_fn {
+//     (ffi = $ffi_name:ident, jni = $jni_name:ident, $($body:tt)+) => {
+//         #[cfg(feature = "ffi")]
+//         ffi_bridge_fn!($ffi_name $($body)+);
+//         // #[cfg(feature = "jni")]
+//         // jni_bridge_get_string!($name($typ) $(as $jni_name)? => $body);
+//     }
+// }
+
 macro_rules! bridge_destroy {
     ($typ:ty $(, ffi = $ffi_name:ident)? $(, jni = $jni_name:ident)? ) => {
         #[cfg(feature = "ffi")]

--- a/rust/bridge/shared/src/support.rs
+++ b/rust/bridge/shared/src/support.rs
@@ -33,14 +33,14 @@ macro_rules! expr_as_fn {
     };
 }
 
-// macro_rules! bridge_fn {
-//     (ffi = $ffi_name:ident, jni = $jni_name:ident, $($body:tt)+) => {
-//         #[cfg(feature = "ffi")]
-//         ffi_bridge_fn!($ffi_name $($body)+);
-//         // #[cfg(feature = "jni")]
-//         // jni_bridge_get_string!($name($typ) $(as $jni_name)? => $body);
-//     }
-// }
+macro_rules! bridge_handle {
+    ($typ:ty) => {
+        #[cfg(feature = "ffi")]
+        ffi_bridge_handle!($typ);
+        #[cfg(feature = "jni")]
+        jni_bridge_handle!($typ);
+    };
+}
 
 macro_rules! bridge_destroy {
     ($typ:ty $(, ffi = $ffi_name:ident)? $(, jni = $jni_name:ident)? ) => {

--- a/rust/protocol/Cargo.toml
+++ b/rust/protocol/Cargo.toml
@@ -27,6 +27,7 @@ rand = "0.7.3"
 sha2 = "0.9"
 subtle = "2.2.3"
 x25519-dalek = "1.0"
+hex = "0.4"
 thiserror = "1.0"
 
 [features]
@@ -37,7 +38,6 @@ simd_backend = ["curve25519-dalek/simd_backend"]
 nightly = ["curve25519-dalek/nightly"]
 
 [dev-dependencies]
-hex = "0.4"
 criterion = "0.3"
 futures = "0.3.7"
 

--- a/rust/protocol/Cargo.toml
+++ b/rust/protocol/Cargo.toml
@@ -47,3 +47,7 @@ prost-build = "0.6"
 [[bench]]
 name = "session"
 harness = false
+
+[[bench]]
+name = "ratchet"
+harness = false

--- a/rust/protocol/Cargo.toml
+++ b/rust/protocol/Cargo.toml
@@ -27,6 +27,7 @@ rand = "0.7.3"
 sha2 = "0.9"
 subtle = "2.2.3"
 x25519-dalek = "1.0"
+thiserror = "1.0"
 
 [features]
 default = ["u64_backend"]

--- a/rust/protocol/benches/ratchet.rs
+++ b/rust/protocol/benches/ratchet.rs
@@ -43,7 +43,7 @@ pub fn ratchet_forward_result(c: &mut Criterion) -> Result<(), SignalProtocolErr
         None,
     ))?;
 
-    for ratchets in [2_000, 10_000, 100_000, 200_000, 500_000, 900_000].iter() {
+    for ratchets in [100, 1000].iter() {
         let ratchets = *ratchets;
 
         for i in 0..ratchets {

--- a/rust/protocol/benches/ratchet.rs
+++ b/rust/protocol/benches/ratchet.rs
@@ -1,0 +1,90 @@
+//
+// Copyright 2020 Signal Messenger, LLC.
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+use criterion::{criterion_group, criterion_main, Criterion, SamplingMode};
+use futures::executor::block_on;
+use libsignal_protocol_rust::*;
+use std::convert::TryFrom;
+
+#[path = "../tests/support/mod.rs"]
+mod support;
+
+pub fn ratchet_forward_result(c: &mut Criterion) -> Result<(), SignalProtocolError> {
+    let mut group = c.benchmark_group("ratchet");
+    group.sampling_mode(SamplingMode::Flat);
+    group.sample_size(10); //minimum allowed...
+    group.warm_up_time(core::time::Duration::from_millis(100));
+
+    let mut csprng = rand::rngs::OsRng;
+
+    let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1);
+    let group_sender =
+        SenderKeyName::new("summer camp planning committee".to_owned(), sender_address)?;
+
+    let mut alice_store = support::test_in_memory_protocol_store();
+    let mut bob_store = support::test_in_memory_protocol_store();
+
+    let sent_distribution_message = block_on(create_sender_key_distribution_message(
+        &group_sender,
+        &mut alice_store,
+        &mut csprng,
+        None,
+    ))?;
+
+    let recv_distribution_message =
+        SenderKeyDistributionMessage::try_from(sent_distribution_message.serialized()).unwrap();
+
+    block_on(process_sender_key_distribution_message(
+        &group_sender,
+        &recv_distribution_message,
+        &mut bob_store,
+        None,
+    ))?;
+
+    for ratchets in [2_000, 10_000, 100_000, 200_000, 500_000, 900_000].iter() {
+        let ratchets = *ratchets;
+
+        for i in 0..ratchets {
+            block_on(group_encrypt(
+                &mut alice_store,
+                &group_sender,
+                format!("nefarious plotting {}", i).as_bytes(),
+                &mut csprng,
+                None,
+            ))?;
+        }
+
+        let alice_ciphertext = block_on(group_encrypt(
+            &mut alice_store,
+            &group_sender,
+            "you got the plan?".as_bytes(),
+            &mut csprng,
+            None,
+        ))?;
+
+        group.bench_function(format!("ratchet {}", ratchets), |b| {
+            b.iter(|| {
+                let mut bob_store = bob_store.clone();
+                block_on(group_decrypt(
+                    &alice_ciphertext,
+                    &mut bob_store,
+                    &group_sender,
+                    None,
+                ))
+                .expect("ok");
+            })
+        });
+    }
+
+    Ok(())
+}
+
+pub fn ratchet_forward(mut c: &mut Criterion) {
+    ratchet_forward_result(&mut c).expect("success");
+}
+
+criterion_group!(ratchet, ratchet_forward);
+
+criterion_main!(ratchet);

--- a/rust/protocol/benches/session.rs
+++ b/rust/protocol/benches/session.rs
@@ -22,27 +22,54 @@ pub fn session_encrypt_result(c: &mut Criterion) -> Result<(), SignalProtocolErr
     block_on(alice_store.store_session(&bob_address, &alice_session_record, None))?;
     block_on(bob_store.store_session(&alice_address, &bob_session_record, None))?;
 
-    let message_to_decrypt = block_on(support::encrypt(&mut alice_store, &bob_address, "a short message"))?;
+    let message_to_decrypt = block_on(support::encrypt(
+        &mut alice_store,
+        &bob_address,
+        "a short message",
+    ))?;
 
     c.bench_function("session decrypt first message", |b| {
         b.iter(|| {
             let mut bob_store = bob_store.clone();
-            block_on(support::decrypt(&mut bob_store, &alice_address, &message_to_decrypt)).expect("success");
+            block_on(support::decrypt(
+                &mut bob_store,
+                &alice_address,
+                &message_to_decrypt,
+            ))
+            .expect("success");
         })
     });
 
-    let _ = block_on(support::decrypt(&mut bob_store, &alice_address, &message_to_decrypt))?;
-    let message_to_decrypt = block_on(support::encrypt(&mut alice_store, &bob_address, "a short message"))?;
+    let _ = block_on(support::decrypt(
+        &mut bob_store,
+        &alice_address,
+        &message_to_decrypt,
+    ))?;
+    let message_to_decrypt = block_on(support::encrypt(
+        &mut alice_store,
+        &bob_address,
+        "a short message",
+    ))?;
 
     c.bench_function("session encrypt", |b| {
         b.iter(|| {
-            block_on(support::encrypt(&mut alice_store, &bob_address, "a short message")).expect("success");
+            block_on(support::encrypt(
+                &mut alice_store,
+                &bob_address,
+                "a short message",
+            ))
+            .expect("success");
         })
     });
     c.bench_function("session decrypt", |b| {
         b.iter(|| {
             let mut bob_store = bob_store.clone();
-            block_on(support::decrypt(&mut bob_store, &alice_address, &message_to_decrypt)).expect("success");
+            block_on(support::decrypt(
+                &mut bob_store,
+                &alice_address,
+                &message_to_decrypt,
+            ))
+            .expect("success");
         })
     });
 
@@ -63,21 +90,36 @@ pub fn session_encrypt_decrypt_result(c: &mut Criterion) -> Result<(), SignalPro
 
     c.bench_function("session encrypt+decrypt 1 way", |b| {
         b.iter(|| {
-            let ctext = block_on(support::encrypt(&mut alice_store, &bob_address, "a short message"))
+            let ctext = block_on(support::encrypt(
+                &mut alice_store,
+                &bob_address,
+                "a short message",
+            ))
+            .expect("success");
+            let _ptext = block_on(support::decrypt(&mut bob_store, &alice_address, &ctext))
                 .expect("success");
-            let _ptext = block_on(support::decrypt(&mut bob_store, &alice_address, &ctext)).expect("success");
         })
     });
 
     c.bench_function("session encrypt+decrypt ping pong", |b| {
         b.iter(|| {
-            let ctext = block_on(support::encrypt(&mut alice_store, &bob_address, "a short message"))
+            let ctext = block_on(support::encrypt(
+                &mut alice_store,
+                &bob_address,
+                "a short message",
+            ))
+            .expect("success");
+            let _ptext = block_on(support::decrypt(&mut bob_store, &alice_address, &ctext))
                 .expect("success");
-            let _ptext = block_on(support::decrypt(&mut bob_store, &alice_address, &ctext)).expect("success");
 
-            let ctext = block_on(support::encrypt(&mut bob_store, &alice_address, "a short message"))
+            let ctext = block_on(support::encrypt(
+                &mut bob_store,
+                &alice_address,
+                "a short message",
+            ))
+            .expect("success");
+            let _ptext = block_on(support::decrypt(&mut alice_store, &bob_address, &ctext))
                 .expect("success");
-            let _ptext = block_on(support::decrypt(&mut alice_store, &bob_address, &ctext)).expect("success");
         })
     });
 

--- a/rust/protocol/benches/session.rs
+++ b/rust/protocol/benches/session.rs
@@ -1,18 +1,17 @@
 //
-// Copyright 2020 Signal Messenger, LLC.
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
 use criterion::{criterion_group, criterion_main, Criterion};
+use futures::executor::block_on;
 use libsignal_protocol_rust::*;
 
 #[path = "../tests/support/mod.rs"]
 mod support;
 
 pub fn session_encrypt_result(c: &mut Criterion) -> Result<(), SignalProtocolError> {
-    let (alice_session, bob_session) = support::initialize_sessions_v3()?;
-    let alice_session_record = SessionRecord::new(alice_session);
-    let bob_session_record = SessionRecord::new(bob_session);
+    let (alice_session_record, bob_session_record) = support::initialize_sessions_v3()?;
 
     let alice_address = ProtocolAddress::new("+14159999999".to_owned(), 1);
     let bob_address = ProtocolAddress::new("+14158888888".to_owned(), 1);
@@ -20,30 +19,30 @@ pub fn session_encrypt_result(c: &mut Criterion) -> Result<(), SignalProtocolErr
     let mut alice_store = support::test_in_memory_protocol_store();
     let mut bob_store = support::test_in_memory_protocol_store();
 
-    alice_store.store_session(&bob_address, &alice_session_record)?;
-    bob_store.store_session(&alice_address, &bob_session_record)?;
+    block_on(alice_store.store_session(&bob_address, &alice_session_record, None))?;
+    block_on(bob_store.store_session(&alice_address, &bob_session_record, None))?;
 
-    let message_to_decrypt = support::encrypt(&mut alice_store, &bob_address, "a short message")?;
+    let message_to_decrypt = block_on(support::encrypt(&mut alice_store, &bob_address, "a short message"))?;
 
     c.bench_function("session decrypt first message", |b| {
         b.iter(|| {
             let mut bob_store = bob_store.clone();
-            support::decrypt(&mut bob_store, &alice_address, &message_to_decrypt).expect("success");
+            block_on(support::decrypt(&mut bob_store, &alice_address, &message_to_decrypt)).expect("success");
         })
     });
 
-    let _ = support::decrypt(&mut bob_store, &alice_address, &message_to_decrypt)?;
-    let message_to_decrypt = support::encrypt(&mut alice_store, &bob_address, "a short message")?;
+    let _ = block_on(support::decrypt(&mut bob_store, &alice_address, &message_to_decrypt))?;
+    let message_to_decrypt = block_on(support::encrypt(&mut alice_store, &bob_address, "a short message"))?;
 
     c.bench_function("session encrypt", |b| {
         b.iter(|| {
-            support::encrypt(&mut alice_store, &bob_address, "a short message").expect("success");
+            block_on(support::encrypt(&mut alice_store, &bob_address, "a short message")).expect("success");
         })
     });
     c.bench_function("session decrypt", |b| {
         b.iter(|| {
             let mut bob_store = bob_store.clone();
-            support::decrypt(&mut bob_store, &alice_address, &message_to_decrypt).expect("success");
+            block_on(support::decrypt(&mut bob_store, &alice_address, &message_to_decrypt)).expect("success");
         })
     });
 
@@ -51,9 +50,7 @@ pub fn session_encrypt_result(c: &mut Criterion) -> Result<(), SignalProtocolErr
 }
 
 pub fn session_encrypt_decrypt_result(c: &mut Criterion) -> Result<(), SignalProtocolError> {
-    let (alice_session, bob_session) = support::initialize_sessions_v3()?;
-    let alice_session_record = SessionRecord::new(alice_session);
-    let bob_session_record = SessionRecord::new(bob_session);
+    let (alice_session_record, bob_session_record) = support::initialize_sessions_v3()?;
 
     let alice_address = ProtocolAddress::new("+14159999999".to_owned(), 1);
     let bob_address = ProtocolAddress::new("+14158888888".to_owned(), 1);
@@ -61,26 +58,26 @@ pub fn session_encrypt_decrypt_result(c: &mut Criterion) -> Result<(), SignalPro
     let mut alice_store = support::test_in_memory_protocol_store();
     let mut bob_store = support::test_in_memory_protocol_store();
 
-    alice_store.store_session(&bob_address, &alice_session_record)?;
-    bob_store.store_session(&alice_address, &bob_session_record)?;
+    block_on(alice_store.store_session(&bob_address, &alice_session_record, None))?;
+    block_on(bob_store.store_session(&alice_address, &bob_session_record, None))?;
 
     c.bench_function("session encrypt+decrypt 1 way", |b| {
         b.iter(|| {
-            let ctext = support::encrypt(&mut alice_store, &bob_address, "a short message")
+            let ctext = block_on(support::encrypt(&mut alice_store, &bob_address, "a short message"))
                 .expect("success");
-            let _ptext = support::decrypt(&mut bob_store, &alice_address, &ctext).expect("success");
+            let _ptext = block_on(support::decrypt(&mut bob_store, &alice_address, &ctext)).expect("success");
         })
     });
 
     c.bench_function("session encrypt+decrypt ping pong", |b| {
         b.iter(|| {
-            let ctext = support::encrypt(&mut alice_store, &bob_address, "a short message")
+            let ctext = block_on(support::encrypt(&mut alice_store, &bob_address, "a short message"))
                 .expect("success");
-            let _ptext = support::decrypt(&mut bob_store, &alice_address, &ctext).expect("success");
+            let _ptext = block_on(support::decrypt(&mut bob_store, &alice_address, &ctext)).expect("success");
 
-            let ctext = support::encrypt(&mut bob_store, &alice_address, "a short message")
+            let ctext = block_on(support::encrypt(&mut bob_store, &alice_address, "a short message"))
                 .expect("success");
-            let _ptext = support::decrypt(&mut alice_store, &bob_address, &ctext).expect("success");
+            let _ptext = block_on(support::decrypt(&mut alice_store, &bob_address, &ctext)).expect("success");
         })
     });
 

--- a/rust/protocol/src/consts.rs
+++ b/rust/protocol/src/consts.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-pub const MAX_FORWARD_JUMPS: usize = 1_000_000;
+pub const MAX_FORWARD_JUMPS: usize = 25_000;
 pub const MAX_MESSAGE_KEYS: usize = 2000;
 pub const MAX_RECEIVER_CHAINS: usize = 5;
 pub const ARCHIVED_STATES_MAX_LENGTH: usize = 40;

--- a/rust/protocol/src/consts.rs
+++ b/rust/protocol/src/consts.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-pub const MAX_FORWARD_JUMPS: usize = 2000;
+pub const MAX_FORWARD_JUMPS: usize = 1_000_000;
 pub const MAX_MESSAGE_KEYS: usize = 2000;
 pub const MAX_RECEIVER_CHAINS: usize = 5;
 pub const ARCHIVED_STATES_MAX_LENGTH: usize = 40;

--- a/rust/protocol/src/error.rs
+++ b/rust/protocol/src/error.rs
@@ -92,6 +92,8 @@ pub enum SignalProtocolError {
     DuplicatedMessage(u32, u32),
     #[error("invalid message {0}")]
     InvalidMessage(&'static str),
+    #[error("{0}")]
+    MessageDecryptionFailed(String),
     #[error("internal error {0}")]
     InternalError(&'static str),
     #[error("error while invoking an ffi callback: {0}")]

--- a/rust/protocol/src/error.rs
+++ b/rust/protocol/src/error.rs
@@ -83,8 +83,8 @@ pub enum SignalProtocolError {
     #[error("sender key signature key missing")]
     SenderKeySigningKeyMissing,
 
-    #[error("session not found")]
-    SessionNotFound,
+    #[error("session with '{0}' not found")]
+    SessionNotFound(String),
     #[error("invalid session structure")]
     InvalidSessionStructure,
 

--- a/rust/protocol/src/error.rs
+++ b/rust/protocol/src/error.rs
@@ -106,3 +106,29 @@ pub enum SignalProtocolError {
     #[error("self send of a sealed sender message")]
     SealedSenderSelfSend,
 }
+
+#[cfg(test)]
+mod formatting_tests {
+    use super::SignalProtocolError::ApplicationCallbackThrewException;
+    #[test]
+    fn test_application_callback_threw_named_exception() {
+        let err = ApplicationCallbackThrewException(
+            "callback_name",
+            Some("exception_name".to_owned()),
+            "an error message".to_owned(),
+        );
+
+        assert_eq!(err.to_string(), "application callback callback_name threw exception exception_name with message an error message")
+    }
+
+    #[test]
+    fn test_application_callback_threw_unknown_exception() {
+        let err =
+            ApplicationCallbackThrewException("callback_name", None, "an error message".to_owned());
+
+        assert_eq!(
+            err.to_string(),
+            "application callback callback_name threw exception with message an error message"
+        )
+    }
+}

--- a/rust/protocol/src/sealed_sender.rs
+++ b/rust/protocol/src/sealed_sender.rs
@@ -612,7 +612,7 @@ pub async fn sealed_sender_encrypt<R: Rng + CryptoRng>(
     let their_identity = identity_store
         .get_identity(destination, ctx)
         .await?
-        .ok_or(SignalProtocolError::SessionNotFound)?;
+        .ok_or_else(|| SignalProtocolError::SessionNotFound(format!("{}", destination)))?;
 
     let ephemeral = KeyPair::generate(rng);
 

--- a/rust/protocol/src/session_cipher.rs
+++ b/rust/protocol/src/session_cipher.rs
@@ -30,7 +30,7 @@ pub async fn message_encrypt(
     let mut session_record = session_store
         .load_session(&remote_address, ctx)
         .await?
-        .ok_or(SignalProtocolError::SessionNotFound)?;
+        .ok_or_else(|| SignalProtocolError::SessionNotFound(format!("{}", remote_address)))?;
     let session_state = session_record.session_state_mut()?;
 
     let chain_key = session_state.get_sender_chain_key()?;
@@ -203,7 +203,7 @@ pub async fn message_decrypt_signal<R: Rng + CryptoRng>(
     let mut session_record = session_store
         .load_session(&remote_address, ctx)
         .await?
-        .ok_or(SignalProtocolError::SessionNotFound)?;
+        .ok_or_else(|| SignalProtocolError::SessionNotFound(format!("{}", remote_address)))?;
 
     let ptext = decrypt_message_with_record(&mut session_record, ciphertext, csprng)?;
 

--- a/rust/protocol/src/session_cipher.rs
+++ b/rust/protocol/src/session_cipher.rs
@@ -179,7 +179,12 @@ pub async fn message_decrypt_prekey<R: Rng + CryptoRng>(
     )
     .await?;
 
-    let ptext = decrypt_message_with_record(&mut session_record, ciphertext.message(), csprng)?;
+    let ptext = decrypt_message_with_record(
+        &remote_address,
+        &mut session_record,
+        ciphertext.message(),
+        csprng,
+    )?;
 
     session_store
         .store_session(&remote_address, &session_record, ctx)
@@ -205,7 +210,8 @@ pub async fn message_decrypt_signal<R: Rng + CryptoRng>(
         .await?
         .ok_or_else(|| SignalProtocolError::SessionNotFound(format!("{}", remote_address)))?;
 
-    let ptext = decrypt_message_with_record(&mut session_record, ciphertext, csprng)?;
+    let ptext =
+        decrypt_message_with_record(&remote_address, &mut session_record, ciphertext, csprng)?;
 
     // Why are we performing this check after decryption instead of before?
     let their_identity_key = session_record
@@ -238,11 +244,60 @@ pub async fn message_decrypt_signal<R: Rng + CryptoRng>(
     Ok(ptext)
 }
 
+fn create_decryption_failure_log(
+    remote_address: &ProtocolAddress,
+    errs: &[SignalProtocolError],
+    record: &SessionRecord,
+    ciphertext: &SignalMessage,
+) -> Result<String> {
+    let mut lines = vec![];
+
+    lines.push(format!(
+        "Message from {}:{} failed to decrypt; sender ratchet public key {} message counter {}",
+        remote_address.name(),
+        remote_address.device_id(),
+        hex::encode(ciphertext.sender_ratchet_key().public_key_bytes()?),
+        ciphertext.counter()
+    ));
+
+    for (idx, (state, err)) in std::iter::once(record.session_state()?)
+        .chain(record.previous_session_states()?)
+        .zip(errs)
+        .enumerate()
+    {
+        let chains = state.all_receiver_chain_logging_info()?;
+        lines.push(format!(
+            "Candidate session {} failed with '{}', had {} receiver chains",
+            idx,
+            err,
+            chains.len()
+        ));
+
+        for chain in chains {
+            let chain_idx = match chain.1 {
+                Some(i) => format!("{}", i),
+                None => "missing in protobuf".to_string(),
+            };
+
+            lines.push(format!(
+                "Receiver chain with sender ratchet public key {} chain key index {}",
+                hex::encode(chain.0),
+                chain_idx
+            ));
+        }
+    }
+
+    Ok(lines.join("\n"))
+}
+
 fn decrypt_message_with_record<R: Rng + CryptoRng>(
+    remote_address: &ProtocolAddress,
     record: &mut SessionRecord,
     ciphertext: &SignalMessage,
     csprng: &mut R,
 ) -> Result<Vec<u8>> {
+    let mut errs = vec![];
+
     if let Ok(current_state) = record.session_state() {
         let mut current_state = current_state.clone();
         let result = decrypt_message_with_state(&mut current_state, ciphertext, csprng);
@@ -255,7 +310,9 @@ fn decrypt_message_with_record<R: Rng + CryptoRng>(
             Err(SignalProtocolError::DuplicatedMessage(_, _)) => {
                 return result;
             }
-            Err(_) => {}
+            Err(e) => {
+                errs.push(e);
+            }
         }
     }
 
@@ -275,7 +332,9 @@ fn decrypt_message_with_record<R: Rng + CryptoRng>(
             Err(SignalProtocolError::DuplicatedMessage(_, _)) => {
                 return result;
             }
-            _ => {}
+            Err(e) => {
+                errs.push(e);
+            }
         }
     }
 
@@ -283,8 +342,8 @@ fn decrypt_message_with_record<R: Rng + CryptoRng>(
         record.promote_old_session(idx, updated_session)?;
         Ok(ptext)
     } else {
-        Err(SignalProtocolError::InvalidMessage(
-            "decryption failed; no matching session state",
+        Err(SignalProtocolError::MessageDecryptionFailed(
+            create_decryption_failure_log(remote_address, &errs, record, ciphertext)?,
         ))
     }
 }

--- a/rust/protocol/src/state/session.rs
+++ b/rust/protocol/src/state/session.rs
@@ -134,6 +134,21 @@ impl SessionState {
         Ok(self.session.sender_chain.is_some())
     }
 
+    pub(crate) fn all_receiver_chain_logging_info(&self) -> Result<Vec<(Vec<u8>, Option<u32>)>> {
+        let mut results = vec![];
+        for chain in self.session.receiver_chains.iter() {
+            let sender_ratchet_public = chain.sender_ratchet_key.clone();
+
+            let chain_key_idx = match &chain.chain_key {
+                Some(chain_key) => Some(chain_key.index),
+                None => None,
+            };
+
+            results.push((sender_ratchet_public, chain_key_idx))
+        }
+        Ok(results)
+    }
+
     pub(crate) fn get_receiver_chain(
         &self,
         sender: &curve::PublicKey,

--- a/rust/protocol/tests/groups.rs
+++ b/rust/protocol/tests/groups.rs
@@ -305,10 +305,10 @@ fn group_basic_ratchet() -> Result<(), SignalProtocolError> {
             group_decrypt(&alice_ciphertext1, &mut bob_store, &group_sender, None).await?;
         assert_eq!(String::from_utf8(bob_plaintext1).unwrap(), "swim camp");
 
-        assert_eq!(
+        assert!(matches!(
             group_decrypt(&alice_ciphertext1, &mut bob_store, &group_sender, None).await,
             Err(SignalProtocolError::DuplicatedMessage(1, 0))
-        );
+        ));
 
         let bob_plaintext3 =
             group_decrypt(&alice_ciphertext3, &mut bob_store, &group_sender, None).await?;

--- a/rust/protocol/tests/groups.rs
+++ b/rust/protocol/tests/groups.rs
@@ -449,7 +449,6 @@ fn group_out_of_order() -> Result<(), SignalProtocolError> {
     })
 }
 
-#[cfg(not(debug_assertions))]
 #[test]
 fn group_too_far_in_the_future() -> Result<(), SignalProtocolError> {
     block_on(async {
@@ -481,7 +480,7 @@ fn group_too_far_in_the_future() -> Result<(), SignalProtocolError> {
         )
         .await?;
 
-        for i in 0..1_000_001 {
+        for i in 0..25001 {
             group_encrypt(
                 &mut alice_store,
                 &group_sender,

--- a/rust/protocol/tests/groups.rs
+++ b/rust/protocol/tests/groups.rs
@@ -449,6 +449,7 @@ fn group_out_of_order() -> Result<(), SignalProtocolError> {
     })
 }
 
+#[cfg(not(debug_assertions))]
 #[test]
 fn group_too_far_in_the_future() -> Result<(), SignalProtocolError> {
     block_on(async {
@@ -480,7 +481,7 @@ fn group_too_far_in_the_future() -> Result<(), SignalProtocolError> {
         )
         .await?;
 
-        for i in 0..2001 {
+        for i in 0..1_000_001 {
             group_encrypt(
                 &mut alice_store,
                 &group_sender,

--- a/rust/protocol/tests/sealed_sender.rs
+++ b/rust/protocol/tests/sealed_sender.rs
@@ -23,7 +23,7 @@ fn test_server_cert() -> Result<(), SignalProtocolError> {
 
     let recovered = ServerCertificate::deserialize(&serialized)?;
 
-    assert_eq!(recovered.validate(&trust_root.public_key), Ok(true));
+    assert_eq!(recovered.validate(&trust_root.public_key)?, true);
 
     let mut cert_data = serialized.clone();
     let cert_bits = cert_data.len() * 8;
@@ -35,7 +35,7 @@ fn test_server_cert() -> Result<(), SignalProtocolError> {
 
         match cert {
             Ok(cert) => {
-                assert_eq!(cert.validate(&trust_root.public_key), Ok(false));
+                assert_eq!(cert.validate(&trust_root.public_key)?, false);
             }
             Err(e) => match e {
                 SignalProtocolError::InvalidProtobufEncoding
@@ -76,13 +76,10 @@ fn test_sender_cert() -> Result<(), SignalProtocolError> {
         &mut rng,
     )?;
 
+    assert_eq!(sender_cert.validate(&trust_root.public_key, expires)?, true);
     assert_eq!(
-        sender_cert.validate(&trust_root.public_key, expires),
-        Ok(true)
-    );
-    assert_eq!(
-        sender_cert.validate(&trust_root.public_key, expires + 1),
-        Ok(false)
+        sender_cert.validate(&trust_root.public_key, expires + 1)?,
+        false
     ); // expired
 
     let mut sender_cert_data = sender_cert.serialized()?.to_vec();
@@ -95,7 +92,7 @@ fn test_sender_cert() -> Result<(), SignalProtocolError> {
 
         match cert {
             Ok(cert) => {
-                assert_eq!(cert.validate(&trust_root.public_key, expires), Ok(false));
+                assert_eq!(cert.validate(&trust_root.public_key, expires)?, false);
             }
             Err(e) => match e {
                 SignalProtocolError::InvalidProtobufEncoding

--- a/rust/protocol/tests/session.rs
+++ b/rust/protocol/tests/session.rs
@@ -190,12 +190,12 @@ fn test_basic_prekey_v3() -> Result<(), SignalProtocolError> {
 
         let outgoing_message = encrypt(&mut alice_store, &bob_address, original_message).await?;
 
-        assert_eq!(
+        assert!(matches!(
             decrypt(&mut bob_store, &alice_address, &outgoing_message)
                 .await
                 .unwrap_err(),
-            SignalProtocolError::UntrustedIdentity(alice_address.clone())
-        );
+            SignalProtocolError::UntrustedIdentity(a) if a == alice_address
+        ));
 
         assert_eq!(
             bob_store
@@ -553,10 +553,10 @@ fn bad_message_bundle() -> Result<(), SignalProtocolError> {
         let ptext = decrypt(&mut bob_store, &alice_address, &incoming_message).await?;
 
         assert_eq!(String::from_utf8(ptext).unwrap(), original_message);
-        assert_eq!(
+        assert!(matches!(
             bob_store.get_pre_key(pre_key_id, None).await.unwrap_err(),
             SignalProtocolError::InvalidPreKeyId
-        );
+        ));
 
         Ok(())
     })
@@ -703,7 +703,10 @@ fn message_key_limits() -> Result<(), SignalProtocolError> {
         let err = decrypt(&mut bob_store, &alice_address, &inflight[5])
             .await
             .unwrap_err();
-        assert_eq!(err, SignalProtocolError::DuplicatedMessage(2300, 5));
+        assert!(matches!(
+            err,
+            SignalProtocolError::DuplicatedMessage(2300, 5)
+        ));
         Ok(())
     })
 }
@@ -880,14 +883,12 @@ async fn is_session_id_equal(
         .load_session(bob_address, None)
         .await?
         .unwrap()
-        .alice_base_key()
-        .clone()
+        .alice_base_key()?
         == bob_store
             .load_session(alice_address, None)
             .await?
             .unwrap()
-            .alice_base_key()
-            .clone())
+            .alice_base_key()?)
 }
 
 #[test]

--- a/swift/.swiftlint.yml
+++ b/swift/.swiftlint.yml
@@ -5,6 +5,7 @@ disabled_rules:
 - function_parameter_count
 - identifier_name
 - line_length
+- redundant_optional_initialization
 - trailing_comma
 - type_body_length
 opt_in_rules:

--- a/swift/Sources/SignalClient/PublicKey.swift
+++ b/swift/Sources/SignalClient/PublicKey.swift
@@ -53,7 +53,7 @@ public class PublicKey: ClonableHandleOwner {
         var result: Bool = false
         try message.withUnsafeBytes { messageBytes in
             try signature.withUnsafeBytes { signatureBytes in
-                try checkError(signal_publickey_verify(nativeHandle, &result, messageBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), messageBytes.count, signatureBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), signatureBytes.count))
+                try checkError(signal_publickey_verify(&result, nativeHandle, messageBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), messageBytes.count, signatureBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), signatureBytes.count))
             }
         }
         return result

--- a/swift/Sources/SignalClient/messages/PreKeySignalMessage.swift
+++ b/swift/Sources/SignalClient/messages/PreKeySignalMessage.swift
@@ -29,12 +29,10 @@ public class PreKeySignalMessage {
                 identityKey: PublicKey,
                 message: SignalMessage) throws {
 
-        var preKeyId = preKeyId ?? 0xFFFFFFFF
-
         try checkError(signal_pre_key_signal_message_new(&handle,
                                                          version,
                                                          registrationId,
-                                                         &preKeyId,
+                                                         preKeyId ?? .max,
                                                          signedPreKeyId,
                                                          baseKey.nativeHandle,
                                                          identityKey.nativeHandle,

--- a/swift/Sources/SignalFfi/signal_ffi.h
+++ b/swift/Sources/SignalFfi/signal_ffi.h
@@ -196,25 +196,10 @@ SignalFfiError *signal_hkdf_derive(unsigned char *output,
                                    const unsigned char *info,
                                    size_t info_len);
 
-SignalFfiError *signal_address_new(SignalProtocolAddress **address,
-                                   const char *name,
-                                   unsigned int device_id);
-
 SignalFfiError *signal_address_get_device_id(const SignalProtocolAddress *obj, unsigned int *out);
 
 SignalFfiError *signal_address_clone(SignalProtocolAddress **new_obj,
                                      const SignalProtocolAddress *obj);
-
-SignalFfiError *signal_publickey_compare(int32_t *result,
-                                         const SignalPublicKey *key1,
-                                         const SignalPublicKey *key2);
-
-SignalFfiError *signal_publickey_verify(const SignalPublicKey *key,
-                                        bool *result,
-                                        const unsigned char *message,
-                                        size_t message_len,
-                                        const unsigned char *signature,
-                                        size_t signature_len);
 
 SignalFfiError *signal_publickey_clone(SignalPublicKey **new_obj, const SignalPublicKey *obj);
 
@@ -254,12 +239,6 @@ SignalFfiError *signal_session_record_archive_current_state(SignalSessionRecord 
 SignalFfiError *signal_session_record_clone(SignalSessionRecord **new_obj,
                                             const SignalSessionRecord *obj);
 
-SignalFfiError *signal_fingerprint_format(const char **fprint,
-                                          const unsigned char *local,
-                                          size_t local_len,
-                                          const unsigned char *remote,
-                                          size_t remote_len);
-
 SignalFfiError *signal_fingerprint_new(SignalFingerprint **obj,
                                        unsigned int iterations,
                                        unsigned int version,
@@ -272,24 +251,6 @@ SignalFfiError *signal_fingerprint_new(SignalFingerprint **obj,
 
 SignalFfiError *signal_fingerprint_clone(SignalFingerprint **new_obj, const SignalFingerprint *obj);
 
-SignalFfiError *signal_fingerprint_compare(bool *result,
-                                           const unsigned char *fprint1,
-                                           size_t fprint1_len,
-                                           const unsigned char *fprint2,
-                                           size_t fprint2_len);
-
-SignalFfiError *signal_message_new(SignalMessage **obj,
-                                   unsigned char message_version,
-                                   const unsigned char *mac_key,
-                                   size_t mac_key_len,
-                                   const SignalPublicKey *sender_ratchet_key,
-                                   unsigned int counter,
-                                   unsigned int previous_counter,
-                                   const unsigned char *ciphertext,
-                                   size_t ciphertext_len,
-                                   const SignalPublicKey *sender_identity_key,
-                                   const SignalPublicKey *receiver_identity_key);
-
 SignalFfiError *signal_message_clone(SignalMessage **new_obj, const SignalMessage *obj);
 
 SignalFfiError *signal_message_get_sender_ratchet_key(SignalPublicKey **new_obj,
@@ -298,22 +259,6 @@ SignalFfiError *signal_message_get_sender_ratchet_key(SignalPublicKey **new_obj,
 SignalFfiError *signal_message_get_message_version(const SignalMessage *obj, unsigned int *out);
 
 SignalFfiError *signal_message_get_counter(const SignalMessage *obj, unsigned int *out);
-
-SignalFfiError *signal_message_verify_mac(bool *result,
-                                          const SignalMessage *handle,
-                                          const SignalPublicKey *sender_identity_key,
-                                          const SignalPublicKey *receiver_identity_key,
-                                          const unsigned char *mac_key,
-                                          size_t mac_key_len);
-
-SignalFfiError *signal_pre_key_signal_message_new(SignalPreKeySignalMessage **obj,
-                                                  unsigned char message_version,
-                                                  unsigned int registration_id,
-                                                  const unsigned int *pre_key_id,
-                                                  unsigned int signed_pre_key_id,
-                                                  const SignalPublicKey *base_key,
-                                                  const SignalPublicKey *identity_key,
-                                                  const SignalMessage *signal_message);
 
 SignalFfiError *signal_pre_key_signal_message_clone(SignalPreKeySignalMessage **new_obj,
                                                     const SignalPreKeySignalMessage *obj);
@@ -639,6 +584,10 @@ SignalFfiError *signal_address_destroy(SignalProtocolAddress *p);
 
 SignalFfiError *signal_address_get_name(const SignalProtocolAddress *obj, const char **out);
 
+SignalFfiError *signal_address_new(SignalProtocolAddress **out,
+                                   const char *name,
+                                   uint32_t device_id);
+
 SignalFfiError *signal_publickey_destroy(SignalPublicKey *p);
 
 SignalFfiError *signal_publickey_deserialize(SignalPublicKey **p,
@@ -652,6 +601,17 @@ SignalFfiError *signal_publickey_serialize(const SignalPublicKey *obj,
 SignalFfiError *signal_publickey_get_public_key_bytes(const SignalPublicKey *obj,
                                                       const unsigned char **out,
                                                       size_t *out_len);
+
+SignalFfiError *signal_publickey_compare(int32_t *out,
+                                         const SignalPublicKey *key1,
+                                         const SignalPublicKey *key2);
+
+SignalFfiError *signal_publickey_verify(bool *out,
+                                        const SignalPublicKey *key,
+                                        const unsigned char *message,
+                                        size_t message_len,
+                                        const unsigned char *signature,
+                                        size_t signature_len);
 
 SignalFfiError *signal_privatekey_destroy(SignalPrivateKey *p);
 
@@ -671,6 +631,18 @@ SignalFfiError *signal_fingerprint_scannable_encoding(const SignalFingerprint *o
 
 SignalFfiError *signal_fingerprint_display_string(const SignalFingerprint *obj, const char **out);
 
+SignalFfiError *signal_fingerprint_format(const char **out,
+                                          const unsigned char *local,
+                                          size_t local_len,
+                                          const unsigned char *remote,
+                                          size_t remote_len);
+
+SignalFfiError *signal_fingerprint_compare(bool *out,
+                                           const unsigned char *fprint1,
+                                           size_t fprint1_len,
+                                           const unsigned char *fprint2,
+                                           size_t fprint2_len);
+
 SignalFfiError *signal_message_destroy(SignalMessage *p);
 
 SignalFfiError *signal_message_deserialize(SignalMessage **p,
@@ -684,6 +656,34 @@ SignalFfiError *signal_message_get_body(const SignalMessage *obj,
 SignalFfiError *signal_message_get_serialized(const SignalMessage *obj,
                                               const unsigned char **out,
                                               size_t *out_len);
+
+SignalFfiError *signal_message_new(SignalMessage **out,
+                                   uint8_t message_version,
+                                   const unsigned char *mac_key,
+                                   size_t mac_key_len,
+                                   const SignalPublicKey *sender_ratchet_key,
+                                   uint32_t counter,
+                                   uint32_t previous_counter,
+                                   const unsigned char *ciphertext,
+                                   size_t ciphertext_len,
+                                   const SignalPublicKey *sender_identity_key,
+                                   const SignalPublicKey *receiver_identity_key);
+
+SignalFfiError *signal_message_verify_mac(bool *out,
+                                          const SignalMessage *msg,
+                                          const SignalPublicKey *sender_identity_key,
+                                          const SignalPublicKey *receiver_identity_key,
+                                          const unsigned char *mac_key,
+                                          size_t mac_key_len);
+
+SignalFfiError *signal_pre_key_signal_message_new(SignalPreKeySignalMessage **out,
+                                                  uint8_t message_version,
+                                                  uint32_t registration_id,
+                                                  uint32_t pre_key_id,
+                                                  uint32_t signed_pre_key_id,
+                                                  const SignalPublicKey *base_key,
+                                                  const SignalPublicKey *identity_key,
+                                                  const SignalMessage *signal_message);
 
 SignalFfiError *signal_pre_key_signal_message_destroy(SignalPreKeySignalMessage *p);
 

--- a/swift/Tests/SignalClientTests/TestUtils.swift
+++ b/swift/Tests/SignalClientTests/TestUtils.swift
@@ -1,0 +1,15 @@
+//
+// Copyright 2020 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+@testable import SignalClient
+
+class BadStore: InMemorySignalProtocolStore {
+    enum Error: Swift.Error {
+        case badness
+    }
+    override func loadPreKey(id: UInt32, context: StoreContext) throws -> PreKeyRecord {
+        throw Error.badness
+    }
+}


### PR DESCRIPTION
Details of implementation in commit message and commit comments.

# Library

[`thiserror`](https://lib.rs/crates/thiserror) is an error handling helper library that uses procedural macros to derive `std::error::Error` and `Display`, as well as any needed `From` impls.

# Benefits

This approach is beneficial because error descriptions and variable interpolations are located directly next to enum variant definitions, making the code more readable and understandable.

# Limitations

This cleaner code comes at the price of compile time. On my machine (`AMD Ryzen 7 4700U with Radeon Graphics (8) @ 2.000GHz`, 8GB memory), this branch takes about 4 seconds longer to compile than the master branch.

| Command | Mean [s] | Min [s] | Max [s] |
|:---|---:|---:|---:|
| `master` | 21.120 ± 0.263 | 20.750 | 21.630 |
| `thiserror` | 25.156 ± 0.306 | 24.454 | 25.576 |

# Licensing

`thiserror` [uses the MIT License](https://github.com/dtolnay/thiserror/blob/master/LICENSE-MIT), so it should be compatible with this repository's license. It can also licensed under Apache, if that's easier. I'm not super familiar with licensing, so I'm not sure if this is a challenge.