### PR TITLE
Fix the session encrypt/decrypt benchmark code

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -107,6 +107,9 @@ jobs:
     - name: Run tests
       run: cargo test --all --verbose
 
+    - name: Build benches
+      run: cargo build --benches --verbose
+
     - name: Clippy
       run: cargo clippy --all -- -D warnings
 

--- a/rust/protocol/benches/session.rs
+++ b/rust/protocol/benches/session.rs
@@ -22,27 +22,54 @@ pub fn session_encrypt_result(c: &mut Criterion) -> Result<(), SignalProtocolErr
     block_on(alice_store.store_session(&bob_address, &alice_session_record, None))?;
     block_on(bob_store.store_session(&alice_address, &bob_session_record, None))?;
 
-    let message_to_decrypt = block_on(support::encrypt(&mut alice_store, &bob_address, "a short message"))?;
+    let message_to_decrypt = block_on(support::encrypt(
+        &mut alice_store,
+        &bob_address,
+        "a short message",
+    ))?;
 
     c.bench_function("session decrypt first message", |b| {
         b.iter(|| {
             let mut bob_store = bob_store.clone();
-            block_on(support::decrypt(&mut bob_store, &alice_address, &message_to_decrypt)).expect("success");
+            block_on(support::decrypt(
+                &mut bob_store,
+                &alice_address,
+                &message_to_decrypt,
+            ))
+            .expect("success");
         })
     });
 
-    let _ = block_on(support::decrypt(&mut bob_store, &alice_address, &message_to_decrypt))?;
-    let message_to_decrypt = block_on(support::encrypt(&mut alice_store, &bob_address, "a short message"))?;
+    let _ = block_on(support::decrypt(
+        &mut bob_store,
+        &alice_address,
+        &message_to_decrypt,
+    ))?;
+    let message_to_decrypt = block_on(support::encrypt(
+        &mut alice_store,
+        &bob_address,
+        "a short message",
+    ))?;
 
     c.bench_function("session encrypt", |b| {
         b.iter(|| {
-            block_on(support::encrypt(&mut alice_store, &bob_address, "a short message")).expect("success");
+            block_on(support::encrypt(
+                &mut alice_store,
+                &bob_address,
+                "a short message",
+            ))
+            .expect("success");
         })
     });
     c.bench_function("session decrypt", |b| {
         b.iter(|| {
             let mut bob_store = bob_store.clone();
-            block_on(support::decrypt(&mut bob_store, &alice_address, &message_to_decrypt)).expect("success");
+            block_on(support::decrypt(
+                &mut bob_store,
+                &alice_address,
+                &message_to_decrypt,
+            ))
+            .expect("success");
         })
     });
 
@@ -63,21 +90,36 @@ pub fn session_encrypt_decrypt_result(c: &mut Criterion) -> Result<(), SignalPro
 
     c.bench_function("session encrypt+decrypt 1 way", |b| {
         b.iter(|| {
-            let ctext = block_on(support::encrypt(&mut alice_store, &bob_address, "a short message"))
+            let ctext = block_on(support::encrypt(
+                &mut alice_store,
+                &bob_address,
+                "a short message",
+            ))
+            .expect("success");
+            let _ptext = block_on(support::decrypt(&mut bob_store, &alice_address, &ctext))
                 .expect("success");
-            let _ptext = block_on(support::decrypt(&mut bob_store, &alice_address, &ctext)).expect("success");
         })
     });
 
     c.bench_function("session encrypt+decrypt ping pong", |b| {
         b.iter(|| {
-            let ctext = block_on(support::encrypt(&mut alice_store, &bob_address, "a short message"))
+            let ctext = block_on(support::encrypt(
+                &mut alice_store,
+                &bob_address,
+                "a short message",
+            ))
+            .expect("success");
+            let _ptext = block_on(support::decrypt(&mut bob_store, &alice_address, &ctext))
                 .expect("success");
-            let _ptext = block_on(support::decrypt(&mut bob_store, &alice_address, &ctext)).expect("success");
 
-            let ctext = block_on(support::encrypt(&mut bob_store, &alice_address, "a short message"))
+            let ctext = block_on(support::encrypt(
+                &mut bob_store,
+                &alice_address,
+                "a short message",
+            ))
+            .expect("success");
+            let _ptext = block_on(support::decrypt(&mut alice_store, &bob_address, &ctext))
                 .expect("success");
-            let _ptext = block_on(support::decrypt(&mut alice_store, &bob_address, &ctext)).expect("success");
         })
     });
 

--- a/rust/protocol/benches/session.rs
+++ b/rust/protocol/benches/session.rs
@@ -1,18 +1,17 @@
 //
-// Copyright 2020 Signal Messenger, LLC.
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
 use criterion::{criterion_group, criterion_main, Criterion};
+use futures::executor::block_on;
 use libsignal_protocol_rust::*;
 
 #[path = "../tests/support/mod.rs"]
 mod support;
 
 pub fn session_encrypt_result(c: &mut Criterion) -> Result<(), SignalProtocolError> {
-    let (alice_session, bob_session) = support::initialize_sessions_v3()?;
-    let alice_session_record = SessionRecord::new(alice_session);
-    let bob_session_record = SessionRecord::new(bob_session);
+    let (alice_session_record, bob_session_record) = support::initialize_sessions_v3()?;
 
     let alice_address = ProtocolAddress::new("+14159999999".to_owned(), 1);
     let bob_address = ProtocolAddress::new("+14158888888".to_owned(), 1);
@@ -20,30 +19,30 @@ pub fn session_encrypt_result(c: &mut Criterion) -> Result<(), SignalProtocolErr
     let mut alice_store = support::test_in_memory_protocol_store();
     let mut bob_store = support::test_in_memory_protocol_store();
 
-    alice_store.store_session(&bob_address, &alice_session_record)?;
-    bob_store.store_session(&alice_address, &bob_session_record)?;
+    block_on(alice_store.store_session(&bob_address, &alice_session_record, None))?;
+    block_on(bob_store.store_session(&alice_address, &bob_session_record, None))?;
 
-    let message_to_decrypt = support::encrypt(&mut alice_store, &bob_address, "a short message")?;
+    let message_to_decrypt = block_on(support::encrypt(&mut alice_store, &bob_address, "a short message"))?;
 
     c.bench_function("session decrypt first message", |b| {
         b.iter(|| {
             let mut bob_store = bob_store.clone();
-            support::decrypt(&mut bob_store, &alice_address, &message_to_decrypt).expect("success");
+            block_on(support::decrypt(&mut bob_store, &alice_address, &message_to_decrypt)).expect("success");
         })
     });
 
-    let _ = support::decrypt(&mut bob_store, &alice_address, &message_to_decrypt)?;
-    let message_to_decrypt = support::encrypt(&mut alice_store, &bob_address, "a short message")?;
+    let _ = block_on(support::decrypt(&mut bob_store, &alice_address, &message_to_decrypt))?;
+    let message_to_decrypt = block_on(support::encrypt(&mut alice_store, &bob_address, "a short message"))?;
 
     c.bench_function("session encrypt", |b| {
         b.iter(|| {
-            support::encrypt(&mut alice_store, &bob_address, "a short message").expect("success");
+            block_on(support::encrypt(&mut alice_store, &bob_address, "a short message")).expect("success");
         })
     });
     c.bench_function("session decrypt", |b| {
         b.iter(|| {
             let mut bob_store = bob_store.clone();
-            support::decrypt(&mut bob_store, &alice_address, &message_to_decrypt).expect("success");
+            block_on(support::decrypt(&mut bob_store, &alice_address, &message_to_decrypt)).expect("success");
         })
     });
 
@@ -51,9 +50,7 @@ pub fn session_encrypt_result(c: &mut Criterion) -> Result<(), SignalProtocolErr
 }
 
 pub fn session_encrypt_decrypt_result(c: &mut Criterion) -> Result<(), SignalProtocolError> {
-    let (alice_session, bob_session) = support::initialize_sessions_v3()?;
-    let alice_session_record = SessionRecord::new(alice_session);
-    let bob_session_record = SessionRecord::new(bob_session);
+    let (alice_session_record, bob_session_record) = support::initialize_sessions_v3()?;
 
     let alice_address = ProtocolAddress::new("+14159999999".to_owned(), 1);
     let bob_address = ProtocolAddress::new("+14158888888".to_owned(), 1);
@@ -61,26 +58,26 @@ pub fn session_encrypt_decrypt_result(c: &mut Criterion) -> Result<(), SignalPro
     let mut alice_store = support::test_in_memory_protocol_store();
     let mut bob_store = support::test_in_memory_protocol_store();
 
-    alice_store.store_session(&bob_address, &alice_session_record)?;
-    bob_store.store_session(&alice_address, &bob_session_record)?;
+    block_on(alice_store.store_session(&bob_address, &alice_session_record, None))?;
+    block_on(bob_store.store_session(&alice_address, &bob_session_record, None))?;
 
     c.bench_function("session encrypt+decrypt 1 way", |b| {
         b.iter(|| {
-            let ctext = support::encrypt(&mut alice_store, &bob_address, "a short message")
+            let ctext = block_on(support::encrypt(&mut alice_store, &bob_address, "a short message"))
                 .expect("success");
-            let _ptext = support::decrypt(&mut bob_store, &alice_address, &ctext).expect("success");
+            let _ptext = block_on(support::decrypt(&mut bob_store, &alice_address, &ctext)).expect("success");
         })
     });
 
     c.bench_function("session encrypt+decrypt ping pong", |b| {
         b.iter(|| {
-            let ctext = support::encrypt(&mut alice_store, &bob_address, "a short message")
+            let ctext = block_on(support::encrypt(&mut alice_store, &bob_address, "a short message"))
                 .expect("success");
-            let _ptext = support::decrypt(&mut bob_store, &alice_address, &ctext).expect("success");
+            let _ptext = block_on(support::decrypt(&mut bob_store, &alice_address, &ctext)).expect("success");
 
-            let ctext = support::encrypt(&mut bob_store, &alice_address, "a short message")
+            let ctext = block_on(support::encrypt(&mut bob_store, &alice_address, "a short message"))
                 .expect("success");
-            let _ptext = support::decrypt(&mut alice_store, &bob_address, &ctext).expect("success");
+            let _ptext = block_on(support::decrypt(&mut alice_store, &bob_address, &ctext)).expect("success");
         })
     });
 


### PR DESCRIPTION
I considered adding `cargo bench --no-run` to the GH actions build but that would add a whole second (release-mode) build to CI which I'm not sure is worth it.