### PR TITLE
Migrate a big chunk of FFI/JNI to bridge_fn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,6 +852,7 @@ dependencies = [
  "libsignal-protocol-rust",
  "log",
  "paste",
+ "rand",
 ]
 
 [[package]]

--- a/java/java/src/main/java/org/signal/internal/Native.java
+++ b/java/java/src/main/java/org/signal/internal/Native.java
@@ -66,20 +66,20 @@ public final class Native {
 
   private Native() {}
 
-  public static native byte[] Aes256GcmSiv_Decrypt(long aesGcmSiv, byte[] msg, byte[] nonce, byte[] associatedData);
+  public static native byte[] Aes256GcmSiv_Decrypt(long aesGcmSiv, byte[] ctext, byte[] nonce, byte[] associatedData);
   public static native void Aes256GcmSiv_Destroy(long handle);
-  public static native byte[] Aes256GcmSiv_Encrypt(long aesGcmSiv, byte[] msg, byte[] nonce, byte[] associatedData);
+  public static native byte[] Aes256GcmSiv_Encrypt(long aesGcmSiv, byte[] ptext, byte[] nonce, byte[] associatedData);
   public static native long Aes256GcmSiv_New(byte[] key);
 
   public static native String DisplayableFingerprint_Format(byte[] local, byte[] remote);
 
-  public static native byte[] ECPrivateKey_Agree(long privateKeyHandle, long publicKeyHandle);
+  public static native byte[] ECPrivateKey_Agree(long privateKey, long publicKey);
   public static native long ECPrivateKey_Deserialize(byte[] data);
   public static native void ECPrivateKey_Destroy(long handle);
   public static native long ECPrivateKey_Generate();
-  public static native long ECPrivateKey_GetPublicKey(long handle);
+  public static native long ECPrivateKey_GetPublicKey(long k);
   public static native byte[] ECPrivateKey_Serialize(long handle);
-  public static native byte[] ECPrivateKey_Sign(long handle, byte[] message);
+  public static native byte[] ECPrivateKey_Sign(long key, byte[] message);
 
   public static native int ECPublicKey_Compare(long key1, long key2);
   public static native long ECPublicKey_Deserialize(byte[] data, int offset);
@@ -97,7 +97,7 @@ public final class Native {
   public static native byte[] HKDF_DeriveSecrets(int version, byte[] inputKeyMaterial, byte[] salt, byte[] info, int outputLength);
 
   public static native long[] IdentityKeyPair_Deserialize(byte[] data);
-  public static native byte[] IdentityKeyPair_Serialize(long publicKeyHandle, long privateKeyHandle);
+  public static native byte[] IdentityKeyPair_Serialize(long publicKey, long privateKey);
 
   public static native void NumericFingerprintGenerator_Destroy(long handle);
   public static native String NumericFingerprintGenerator_GetDisplayString(long handle);
@@ -121,7 +121,7 @@ public final class Native {
   public static native long PreKeyRecord_GetPrivateKey(long handle);
   public static native long PreKeyRecord_GetPublicKey(long handle);
   public static native byte[] PreKeyRecord_GetSerialized(long handle);
-  public static native long PreKeyRecord_New(int id, long pubKeyHandle, long privKeyHandle);
+  public static native long PreKeyRecord_New(int id, long pubKey, long privKey);
 
   public static native long PreKeySignalMessage_Deserialize(byte[] data);
   public static native void PreKeySignalMessage_Destroy(long handle);
@@ -167,7 +167,7 @@ public final class Native {
   public static native int SenderKeyDistributionMessage_GetIteration(long handle);
   public static native byte[] SenderKeyDistributionMessage_GetSerialized(long handle);
   public static native byte[] SenderKeyDistributionMessage_GetSignatureKey(long handle);
-  public static native long SenderKeyDistributionMessage_New(int keyId, int iteration, byte[] chainkey, long pkHandle);
+  public static native long SenderKeyDistributionMessage_New(int keyId, int iteration, byte[] chainkey, long pk);
 
   public static native long SenderKeyMessage_Deserialize(byte[] data);
   public static native void SenderKeyMessage_Destroy(long handle);
@@ -175,8 +175,8 @@ public final class Native {
   public static native int SenderKeyMessage_GetIteration(long handle);
   public static native int SenderKeyMessage_GetKeyId(long handle);
   public static native byte[] SenderKeyMessage_GetSerialized(long handle);
-  public static native long SenderKeyMessage_New(int keyId, int iteration, byte[] ciphertext, long pkHandle);
-  public static native boolean SenderKeyMessage_VerifySignature(long handle, long pubkeyHandle);
+  public static native long SenderKeyMessage_New(int keyId, int iteration, byte[] ciphertext, long pk);
+  public static native boolean SenderKeyMessage_VerifySignature(long skm, long pubkey);
 
   public static native void SenderKeyName_Destroy(long handle);
   public static native String SenderKeyName_GetGroupId(long handle);
@@ -240,7 +240,7 @@ public final class Native {
   public static native byte[] SignedPreKeyRecord_GetSerialized(long handle);
   public static native byte[] SignedPreKeyRecord_GetSignature(long handle);
   public static native long SignedPreKeyRecord_GetTimestamp(long handle);
-  public static native long SignedPreKeyRecord_New(int id, long timestamp, long pubKeyHandle, long privKeyHandle, byte[] signature);
+  public static native long SignedPreKeyRecord_New(int id, long timestamp, long pubKey, long privKey, byte[] signature);
 
   public static native long UnidentifiedSenderMessageContent_Deserialize(byte[] data);
   public static native void UnidentifiedSenderMessageContent_Destroy(long handle);

--- a/rust/bridge/ffi/src/lib.rs
+++ b/rust/bridge/ffi/src/lib.rs
@@ -118,38 +118,6 @@ ffi_fn_clone!(signal_address_clone clones ProtocolAddress);
 
 ffi_fn_clone!(signal_publickey_clone clones PublicKey);
 
-#[no_mangle]
-pub unsafe extern "C" fn signal_privatekey_sign(
-    signature: *mut *const c_uchar,
-    signature_len: *mut size_t,
-    key: *const PrivateKey,
-    message: *const c_uchar,
-    message_len: size_t,
-) -> *mut SignalFfiError {
-    run_ffi_safe(|| {
-        let message = as_slice(message, message_len)?;
-        let key = native_handle_cast::<PrivateKey>(key)?;
-        let mut rng = rand::rngs::OsRng;
-        let sig = key.calculate_signature(&message, &mut rng);
-        write_bytearray_to(signature, signature_len, sig)
-    })
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn signal_privatekey_agree(
-    shared_secret: *mut *const c_uchar,
-    shared_secret_len: *mut size_t,
-    private_key: *const PrivateKey,
-    public_key: *const PublicKey,
-) -> *mut SignalFfiError {
-    run_ffi_safe(|| {
-        let private_key = native_handle_cast::<PrivateKey>(private_key)?;
-        let public_key = native_handle_cast::<PublicKey>(public_key)?;
-        let dh_secret = private_key.calculate_agreement(&public_key);
-        write_bytearray_to(shared_secret, shared_secret_len, dh_secret)
-    })
-}
-
 ffi_fn_clone!(signal_privatekey_clone clones PrivateKey);
 
 #[no_mangle]

--- a/rust/bridge/ffi/src/lib.rs
+++ b/rust/bridge/ffi/src/lib.rs
@@ -119,20 +119,6 @@ ffi_fn_clone!(signal_address_clone clones ProtocolAddress);
 ffi_fn_clone!(signal_publickey_clone clones PublicKey);
 
 #[no_mangle]
-pub unsafe extern "C" fn signal_privatekey_generate(
-    key: *mut *mut PrivateKey,
-) -> *mut SignalFfiError {
-    run_ffi_safe(|| {
-        let mut rng = rand::rngs::OsRng;
-        let keypair = KeyPair::generate(&mut rng);
-        box_object::<PrivateKey>(key, Ok(keypair.private_key))
-    })
-}
-
-ffi_fn_get_new_boxed_obj!(signal_privatekey_get_public_key(PublicKey) from PrivateKey,
-                          |k: &PrivateKey| k.public_key());
-
-#[no_mangle]
 pub unsafe extern "C" fn signal_privatekey_sign(
     signature: *mut *const c_uchar,
     signature_len: *mut size_t,

--- a/rust/bridge/ffi/src/lib.rs
+++ b/rust/bridge/ffi/src/lib.rs
@@ -1161,40 +1161,6 @@ ffi_fn_get_new_boxed_obj!(signal_sender_certificate_get_key(PublicKey) from Send
 ffi_fn_get_new_boxed_obj!(signal_sender_certificate_get_server_certificate(ServerCertificate) from SenderCertificate,
                           |s: &SenderCertificate| Ok(s.signer()?.clone()));
 
-#[no_mangle]
-pub unsafe extern "C" fn signal_sender_certificate_new(
-    out: *mut *mut SenderCertificate,
-    sender_uuid: *const c_char,
-    sender_e164: *const c_char,
-    sender_device_id: u32,
-    sender_key: *const PublicKey,
-    expiration: u64,
-    signer_cert: *const ServerCertificate,
-    signer_key: *const PrivateKey,
-) -> *mut SignalFfiError {
-    run_ffi_safe(|| {
-        let sender_uuid = read_optional_c_string(sender_uuid)?;
-        let sender_e164 = read_optional_c_string(sender_e164)?;
-        let sender_key = native_handle_cast::<PublicKey>(sender_key)?;
-        let signer_cert = native_handle_cast::<ServerCertificate>(signer_cert)?;
-        let signer_key = native_handle_cast::<PrivateKey>(signer_key)?;
-
-        let mut rng = rand::rngs::OsRng;
-
-        let sc = SenderCertificate::new(
-            sender_uuid,
-            sender_e164,
-            *sender_key,
-            sender_device_id,
-            expiration,
-            signer_cert.clone(),
-            signer_key,
-            &mut rng,
-        );
-        box_object(out, sc)
-    })
-}
-
 // UnidentifiedSenderMessageContent
 #[no_mangle]
 pub unsafe extern "C" fn signal_unidentified_sender_message_content_get_msg_type(

--- a/rust/bridge/ffi/src/util.rs
+++ b/rust/bridge/ffi/src/util.rs
@@ -225,17 +225,6 @@ pub unsafe fn get_optional_uint32(p: *const c_uint) -> Option<u32> {
     Some(*p)
 }
 
-pub unsafe fn read_c_string(cstr: *const c_char) -> Result<String, SignalFfiError> {
-    if cstr.is_null() {
-        return Err(SignalFfiError::NullPointer);
-    }
-
-    match CStr::from_ptr(cstr).to_str() {
-        Ok(s) => Ok(s.to_owned()),
-        Err(_) => Err(SignalFfiError::InvalidUtf8String),
-    }
-}
-
 pub unsafe fn read_optional_c_string(
     cstr: *const c_char,
 ) -> Result<Option<String>, SignalFfiError> {

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -45,21 +45,6 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ECPublicKey_1Des
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ECPrivateKey_1Generate(
-    env: JNIEnv,
-    _class: JClass,
-) -> ObjectHandle {
-    run_ffi_safe(&env, || {
-        let mut rng = rand::rngs::OsRng;
-        let keypair = KeyPair::generate(&mut rng);
-        box_object::<PrivateKey>(Ok(keypair.private_key))
-    })
-}
-
-jni_fn_get_new_boxed_obj!(Java_org_signal_client_internal_Native_ECPrivateKey_1GetPublicKey(PublicKey) from PrivateKey,
-                          PrivateKey::public_key);
-
-#[no_mangle]
 pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ECPrivateKey_1Sign(
     env: JNIEnv,
     _class: JClass,

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -6,7 +6,7 @@
 #![allow(clippy::missing_safety_doc)]
 
 use async_trait::async_trait;
-use jni::objects::{JClass, JObject, JString, JValue};
+use jni::objects::{JClass, JObject, JValue};
 use jni::sys::{jboolean, jbyteArray, jint, jlong, jlongArray, jobject};
 use jni::JNIEnv;
 use std::convert::TryFrom;
@@ -1292,55 +1292,6 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SenderCertificat
 
         let address = expect_ready(cert.preferred_address(&session_store, None))?;
         box_object::<ProtocolAddress>(Ok(address))
-    })
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SenderCertificate_1New(
-    env: JNIEnv,
-    _class: JClass,
-    sender_uuid: JString,
-    sender_e164: JString,
-    sender_device_id: jint,
-    sender_key: ObjectHandle,
-    expiration: jlong,
-    signer_cert: ObjectHandle,
-    signer_key: ObjectHandle,
-) -> ObjectHandle {
-    run_ffi_safe(&env, || {
-        let sender_uuid: Option<String> = if sender_uuid.is_null() {
-            None
-        } else {
-            Some(env.get_string(sender_uuid)?.into())
-        };
-
-        let sender_e164: Option<String> = if sender_e164.is_null() {
-            None
-        } else {
-            Some(env.get_string(sender_e164)?.into())
-        };
-
-        let sender_device_id = jint_to_u32(sender_device_id)?;
-        let sender_key = native_handle_cast::<PublicKey>(sender_key)?;
-
-        let expiration = jlong_to_u64(expiration)?;
-        let signer_cert = native_handle_cast::<ServerCertificate>(signer_cert)?;
-        let signer_key = native_handle_cast::<PrivateKey>(signer_key)?;
-
-        let mut rng = rand::rngs::OsRng;
-
-        let sc = SenderCertificate::new(
-            sender_uuid,
-            sender_e164,
-            *sender_key,
-            sender_device_id,
-            expiration,
-            signer_cert.clone(),
-            signer_key,
-            &mut rng,
-        )?;
-
-        box_object::<SenderCertificate>(Ok(sc))
     })
 }
 

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -11,7 +11,6 @@ use jni::sys::{jboolean, jbyteArray, jint, jlong, jlongArray, jobject};
 use jni::JNIEnv;
 use std::convert::TryFrom;
 
-use aes_gcm_siv::Aes256GcmSiv;
 use libsignal_bridge::jni::*;
 use libsignal_protocol_rust::*;
 
@@ -1401,58 +1400,5 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SealedSessionCip
         ))?;
 
         box_object::<UnidentifiedSenderMessageContent>(Ok(usmc))
-    })
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn Java_org_signal_client_internal_Native_Aes256GcmSiv_1New(
-    env: JNIEnv,
-    _class: JClass,
-    key: jbyteArray,
-) -> ObjectHandle {
-    run_ffi_safe(&env, || {
-        let key = env.convert_byte_array(key)?;
-        let aes_gcm_siv = aes_gcm_siv::Aes256GcmSiv::new(&key)?;
-        box_object::<Aes256GcmSiv>(Ok(aes_gcm_siv))
-    })
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn Java_org_signal_client_internal_Native_Aes256GcmSiv_1Encrypt(
-    env: JNIEnv,
-    _class: JClass,
-    aes_gcm_siv: ObjectHandle,
-    msg: jbyteArray,
-    nonce: jbyteArray,
-    associated_data: jbyteArray,
-) -> jbyteArray {
-    run_ffi_safe(&env, || {
-        let aes_gcm_siv = native_handle_cast::<Aes256GcmSiv>(aes_gcm_siv)?;
-        let mut msg = env.convert_byte_array(msg)?;
-        let nonce = env.convert_byte_array(nonce)?;
-        let associated_data = env.convert_byte_array(associated_data)?;
-        let tag = aes_gcm_siv.encrypt(&mut msg, &nonce, &associated_data)?;
-        msg.extend_from_slice(&tag);
-        to_jbytearray(&env, Ok(msg))
-    })
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn Java_org_signal_client_internal_Native_Aes256GcmSiv_1Decrypt(
-    env: JNIEnv,
-    _class: JClass,
-    aes_gcm_siv: ObjectHandle,
-    msg: jbyteArray,
-    nonce: jbyteArray,
-    associated_data: jbyteArray,
-) -> jbyteArray {
-    run_ffi_safe(&env, || {
-        let aes_gcm_siv = native_handle_cast::<Aes256GcmSiv>(aes_gcm_siv)?;
-        let mut msg = env.convert_byte_array(msg)?;
-        let nonce = env.convert_byte_array(nonce)?;
-        let associated_data = env.convert_byte_array(associated_data)?;
-
-        aes_gcm_siv.decrypt_with_appended_tag(&mut msg, &nonce, &associated_data)?;
-        to_jbytearray(&env, Ok(msg))
     })
 }

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -45,37 +45,6 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ECPublicKey_1Des
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ECPrivateKey_1Sign(
-    env: JNIEnv,
-    _class: JClass,
-    handle: ObjectHandle,
-    message: jbyteArray,
-) -> jbyteArray {
-    run_ffi_safe(&env, || {
-        let message = env.convert_byte_array(message)?;
-        let key = native_handle_cast::<PrivateKey>(handle)?;
-        let mut rng = rand::rngs::OsRng;
-        let sig = key.calculate_signature(&message, &mut rng)?;
-        to_jbytearray(&env, Ok(sig))
-    })
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn Java_org_signal_client_internal_Native_ECPrivateKey_1Agree(
-    env: JNIEnv,
-    _class: JClass,
-    private_key_handle: ObjectHandle,
-    public_key_handle: ObjectHandle,
-) -> jbyteArray {
-    run_ffi_safe(&env, || {
-        let private_key = native_handle_cast::<PrivateKey>(private_key_handle)?;
-        let public_key = native_handle_cast::<PublicKey>(public_key_handle)?;
-        let shared_secret = private_key.calculate_agreement(&public_key)?;
-        to_jbytearray(&env, Ok(shared_secret))
-    })
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn Java_org_signal_client_internal_Native_IdentityKeyPair_1Serialize(
     env: JNIEnv,
     _class: JClass,

--- a/rust/bridge/jni/src/util.rs
+++ b/rust/bridge/jni/src/util.rs
@@ -20,13 +20,6 @@ pub unsafe fn native_handle_cast_optional<T>(
     Ok(Some(&mut *(handle as *mut T)))
 }
 
-pub fn jlong_to_u64(v: jlong) -> Result<u64, SignalJniError> {
-    if v < 0 {
-        return Err(SignalJniError::IntegerOverflow(format!("{} to u64", v)));
-    }
-    Ok(v as u64)
-}
-
 pub fn jint_from_u32(value: Result<u32, SignalProtocolError>) -> Result<jint, SignalJniError> {
     match value {
         Ok(value) => {

--- a/rust/bridge/shared/Cargo.toml
+++ b/rust/bridge/shared/Cargo.toml
@@ -17,6 +17,7 @@ libsignal-bridge-macros = { path = "macros" }
 futures = "0.3.7"
 log = "0.4.11"
 paste = "1.0"
+rand = "0.7.3"
 
 libc = { version = "0.2", optional = true }
 jni = { version = "0.17", optional = true }

--- a/rust/bridge/shared/macros/src/lib.rs
+++ b/rust/bridge/shared/macros/src/lib.rs
@@ -56,7 +56,7 @@ fn ffi_bridge_fn(name: String, sig: &Signature, result_kind: ResultKind) -> Toke
                 out_len: *mut libc::size_t, // note the trailing comma
             ),
             quote!(ffi::Env,), // note the trailing comma
-            quote!(ffi::write_bytearray_to(out, out_len, __result)?),
+            quote!(ffi::write_bytearray_to(out, out_len, __result?)?),
         ),
         (ResultKind::Buffer, ReturnType::Default) => {
             return Error::new(

--- a/rust/bridge/shared/src/ffi/convert.rs
+++ b/rust/bridge/shared/src/ffi/convert.rs
@@ -73,6 +73,17 @@ impl ArgTypeInfo for String {
     }
 }
 
+impl ArgTypeInfo for Option<String> {
+    type ArgType = *const c_char;
+    fn convert_from(foreign: *const c_char) -> Result<Self, SignalFfiError> {
+        if foreign.is_null() {
+            Ok(None)
+        } else {
+            String::convert_from(foreign).map(Some)
+        }
+    }
+}
+
 impl<T: ResultTypeInfo> ResultTypeInfo for Result<T, SignalProtocolError> {
     type ResultType = T::ResultType;
     fn convert_into(self) -> Result<Self::ResultType, SignalFfiError> {
@@ -147,6 +158,7 @@ macro_rules! ffi_arg_type {
     (usize) => (libc::size_t);
     (&[u8]) => (*const libc::c_uchar);
     (String) => (*const libc::c_char);
+    (Option<String>) => (*const libc::c_char);
     (& $typ:ty) => (*const $typ);
 }
 

--- a/rust/bridge/shared/src/ffi/convert.rs
+++ b/rust/bridge/shared/src/ffi/convert.rs
@@ -135,12 +135,14 @@ macro_rules! trivial {
 trivial!(i32);
 trivial!(u8);
 trivial!(u32);
+trivial!(u64);
 trivial!(usize);
 trivial!(bool);
 
 macro_rules! ffi_arg_type {
     (u8) => (u8);
     (u32) => (u32);
+    (u64) => (u64);
     (Option<u32>) => (u32);
     (usize) => (libc::size_t);
     (&[u8]) => (*const libc::c_uchar);

--- a/rust/bridge/shared/src/ffi/convert.rs
+++ b/rust/bridge/shared/src/ffi/convert.rs
@@ -91,6 +91,13 @@ impl<T: ResultTypeInfo> ResultTypeInfo for Result<T, SignalProtocolError> {
     }
 }
 
+impl<T: ResultTypeInfo> ResultTypeInfo for Result<T, aes_gcm_siv::Error> {
+    type ResultType = T::ResultType;
+    fn convert_into(self) -> Result<Self::ResultType, SignalFfiError> {
+        T::convert_into(self?)
+    }
+}
+
 impl ResultTypeInfo for String {
     type ResultType = *const libc::c_char;
     fn convert_into(self) -> Result<Self::ResultType, SignalFfiError> {
@@ -163,7 +170,7 @@ macro_rules! ffi_arg_type {
 }
 
 macro_rules! ffi_result_type {
-    (Result<$typ:tt, $_:tt>) => (ffi_result_type!($typ));
+    (Result<$typ:tt, $_:ty>) => (ffi_result_type!($typ));
     (i32) => (i32);
     (bool) => (bool);
     (String) => (*const libc::c_char);

--- a/rust/bridge/shared/src/ffi/convert.rs
+++ b/rust/bridge/shared/src/ffi/convert.rs
@@ -5,6 +5,7 @@
 
 use libc::{c_char, c_uchar};
 use libsignal_protocol_rust::*;
+use std::borrow::Cow;
 use std::ffi::CStr;
 
 use crate::ffi::*;
@@ -84,6 +85,15 @@ impl ResultTypeInfo for String {
     fn convert_into(self) -> Result<Self::ResultType, SignalFfiError> {
         let cstr = CString::new(self).expect("No NULL characters in string being returned to C");
         Ok(cstr.into_raw())
+    }
+}
+
+pub(crate) struct Env;
+
+impl crate::Env for Env {
+    type Buffer = Box<[u8]>;
+    fn buffer<'a, T: Into<Cow<'a, [u8]>>>(&self, input: T) -> Self::Buffer {
+        input.into().into()
     }
 }
 

--- a/rust/bridge/shared/src/jni/convert.rs
+++ b/rust/bridge/shared/src/jni/convert.rs
@@ -49,6 +49,13 @@ impl<'a> ArgTypeInfo<'a> for Option<u32> {
     }
 }
 
+impl<'a> ArgTypeInfo<'a> for u64 {
+    type ArgType = jlong;
+    fn convert_from(_env: &'a JNIEnv, foreign: jlong) -> Result<Self, SignalJniError> {
+        jlong_to_u64(foreign)
+    }
+}
+
 impl<'a> ArgTypeInfo<'a> for u8 {
     type ArgType = jint;
     fn convert_from(_env: &'a JNIEnv, foreign: jint) -> Result<Self, SignalJniError> {
@@ -178,6 +185,9 @@ macro_rules! jni_arg_type {
     };
     (Option<u32>) => {
         jni::jint
+    };
+    (u64) => {
+        jni::jlong
     };
     (String) => {
         jni::JString

--- a/rust/bridge/shared/src/jni/convert.rs
+++ b/rust/bridge/shared/src/jni/convert.rs
@@ -70,6 +70,17 @@ impl<'a> ArgTypeInfo<'a> for String {
     }
 }
 
+impl<'a> ArgTypeInfo<'a> for Option<String> {
+    type ArgType = JString<'a>;
+    fn convert_from(env: &'a JNIEnv, foreign: JString<'a>) -> Result<Self, SignalJniError> {
+        if foreign.is_null() {
+            Ok(None)
+        } else {
+            String::convert_from(env, foreign).map(Some)
+        }
+    }
+}
+
 pub(crate) struct AutoByteSlice<'a> {
     jni_array: AutoByteArray<'a, 'a>,
     len: usize,
@@ -190,6 +201,9 @@ macro_rules! jni_arg_type {
         jni::jlong
     };
     (String) => {
+        jni::JString
+    };
+    (Option<String>) => {
         jni::JString
     };
     (&[u8]) => {

--- a/rust/bridge/shared/src/jni/convert.rs
+++ b/rust/bridge/shared/src/jni/convert.rs
@@ -129,6 +129,13 @@ impl<T: ResultTypeInfo> ResultTypeInfo for Result<T, SignalProtocolError> {
     }
 }
 
+impl<T: ResultTypeInfo> ResultTypeInfo for Result<T, aes_gcm_siv::Error> {
+    type ResultType = T::ResultType;
+    fn convert_into(self, env: &JNIEnv) -> Result<Self::ResultType, SignalJniError> {
+        T::convert_into(self?, env)
+    }
+}
+
 impl<T: ResultTypeInfo> ResultTypeInfo for Result<T, SignalJniError> {
     type ResultType = T::ResultType;
     fn convert_into(self, env: &JNIEnv) -> Result<Self::ResultType, SignalJniError> {
@@ -215,7 +222,7 @@ macro_rules! jni_arg_type {
 }
 
 macro_rules! jni_result_type {
-    (Result<$typ:tt, $_:tt>) => {
+    (Result<$typ:tt, $_:ty>) => {
         jni_result_type!($typ)
     };
     (bool) => {

--- a/rust/bridge/shared/src/jni/mod.rs
+++ b/rust/bridge/shared/src/jni/mod.rs
@@ -4,7 +4,7 @@
 //
 
 use jni::objects::{JObject, JValue};
-use jni::sys::{_jobject, jlong};
+use jni::sys::jobject;
 
 use aes_gcm_siv::Error as AesGcmSivError;
 use libsignal_protocol_rust::*;
@@ -12,7 +12,7 @@ use std::convert::TryFrom;
 
 pub(crate) use jni::objects::{JClass, JString};
 pub(crate) use jni::strings::JNIString;
-pub(crate) use jni::sys::{jboolean, jbyteArray, jint, jstring};
+pub(crate) use jni::sys::{jboolean, jbyteArray, jint, jlong, jstring};
 pub(crate) use jni::JNIEnv;
 
 #[macro_use]
@@ -147,7 +147,7 @@ impl JniDummyValue for jint {
     }
 }
 
-impl JniDummyValue for *mut _jobject {
+impl JniDummyValue for jobject {
     fn dummy_value() -> Self {
         0 as jstring
     }
@@ -217,6 +217,13 @@ pub fn jint_to_u8(v: jint) -> Result<u8, SignalJniError> {
         Err(_) => Err(SignalJniError::IntegerOverflow(format!("{} to u8", v))),
         Ok(v) => Ok(v),
     }
+}
+
+pub fn jlong_to_u64(v: jlong) -> Result<u64, SignalJniError> {
+    if v < 0 {
+        return Err(SignalJniError::IntegerOverflow(format!("{} to u64", v)));
+    }
+    Ok(v as u64)
 }
 
 pub fn to_jbytearray<T: AsRef<[u8]>>(

--- a/rust/bridge/shared/src/lib.rs
+++ b/rust/bridge/shared/src/lib.rs
@@ -25,6 +25,7 @@ pub mod jni;
 mod support;
 use support::*;
 
+bridge_handle!(Aes256GcmSiv);
 bridge_handle!(PreKeyRecord);
 bridge_handle!(PreKeySignalMessage);
 bridge_handle!(PrivateKey);
@@ -448,3 +449,38 @@ bridge_get_bytearray!(get_sender_chain_key_value(SessionRecord), ffi = None =>
 );
 
 bridge_destroy!(Aes256GcmSiv);
+
+#[bridge_fn]
+fn Aes256GcmSiv_New(key: &[u8]) -> Result<Aes256GcmSiv, aes_gcm_siv::Error> {
+    aes_gcm_siv::Aes256GcmSiv::new(&key)
+}
+
+#[bridge_fn_buffer]
+fn Aes256GcmSiv_Encrypt<T: Env>(
+    env: T,
+    aes_gcm_siv: &Aes256GcmSiv,
+    ptext: &[u8],
+    nonce: &[u8],
+    associated_data: &[u8],
+) -> Result<T::Buffer, aes_gcm_siv::Error> {
+    let mut buf = Vec::with_capacity(ptext.len() + 16);
+    buf.extend_from_slice(ptext);
+
+    let gcm_tag = aes_gcm_siv.encrypt(&mut buf, &nonce, &associated_data)?;
+    buf.extend_from_slice(&gcm_tag);
+
+    Ok(env.buffer(buf))
+}
+
+#[bridge_fn_buffer]
+fn Aes256GcmSiv_Decrypt<T: Env>(
+    env: T,
+    aes_gcm_siv: &Aes256GcmSiv,
+    ctext: &[u8],
+    nonce: &[u8],
+    associated_data: &[u8],
+) -> Result<T::Buffer, aes_gcm_siv::Error> {
+    let mut buf = ctext.to_vec();
+    aes_gcm_siv.decrypt_with_appended_tag(&mut buf, &nonce, &associated_data)?;
+    Ok(env.buffer(buf))
+}

--- a/rust/bridge/shared/src/lib.rs
+++ b/rust/bridge/shared/src/lib.rs
@@ -25,6 +25,7 @@ pub mod jni;
 mod support;
 use support::*;
 
+bridge_handle!(PrivateKey);
 bridge_handle!(ProtocolAddress);
 bridge_handle!(PublicKey);
 bridge_handle!(SignalMessage);
@@ -81,6 +82,18 @@ bridge_get_bytearray!(
     jni = ECPrivateKey_1Serialize =>
     |k| Ok(k.serialize())
 );
+
+#[bridge_fn(ffi = "privatekey_generate")]
+fn ECPrivateKey_Generate() -> PrivateKey {
+    let mut rng = rand::rngs::OsRng;
+    let keypair = KeyPair::generate(&mut rng);
+    keypair.private_key
+}
+
+#[bridge_fn(ffi = "privatekey_get_public_key")]
+fn ECPrivateKey_GetPublicKey(k: &PrivateKey) -> Result<PublicKey, SignalProtocolError> {
+    k.public_key()
+}
 
 bridge_destroy!(Fingerprint, jni = NumericFingerprintGenerator);
 bridge_get_bytearray!(

--- a/rust/bridge/shared/src/lib.rs
+++ b/rust/bridge/shared/src/lib.rs
@@ -383,6 +383,30 @@ fn SenderCertificate_Validate(
     cert.validate(key, time)
 }
 
+#[bridge_fn]
+fn SenderCertificate_New(
+    sender_uuid: Option<String>,
+    sender_e164: Option<String>,
+    sender_device_id: u32,
+    sender_key: &PublicKey,
+    expiration: u64,
+    signer_cert: &ServerCertificate,
+    signer_key: &PrivateKey,
+) -> Result<SenderCertificate, SignalProtocolError> {
+    let mut rng = rand::rngs::OsRng;
+
+    SenderCertificate::new(
+        sender_uuid,
+        sender_e164,
+        *sender_key,
+        sender_device_id,
+        expiration,
+        signer_cert.clone(),
+        signer_key,
+        &mut rng,
+    )
+}
+
 bridge_destroy!(UnidentifiedSenderMessageContent);
 bridge_deserialize!(UnidentifiedSenderMessageContent::deserialize);
 bridge_get_bytearray!(

--- a/rust/bridge/shared/src/support.rs
+++ b/rust/bridge/shared/src/support.rs
@@ -5,6 +5,7 @@
 
 use futures::pin_mut;
 use futures::task::noop_waker_ref;
+use std::borrow::Cow;
 use std::future::Future;
 use std::task::{self, Poll};
 
@@ -17,6 +18,12 @@ pub fn expect_ready<F: Future>(future: F) -> F::Output {
         Poll::Ready(result) => result,
         Poll::Pending => panic!("future was not ready"),
     }
+}
+
+/// Used for returning newly-allocated buffers as efficiently as possible.
+pub(crate) trait Env {
+    type Buffer;
+    fn buffer<'a, T: Into<Cow<'a, [u8]>>>(&self, input: T) -> Self::Buffer;
 }
 
 /// Wraps an expression in a function with a given name and type...

--- a/swift/Sources/SignalClient/Aes256GcmSiv.swift
+++ b/swift/Sources/SignalClient/Aes256GcmSiv.swift
@@ -32,9 +32,9 @@ public class Aes256GcmSiv: ClonableHandleOwner {
             try nonce.withUnsafeBytes { nonceBytes in
                 try associated_data.withUnsafeBytes { adBytes in
                     try invokeFnReturningArray {
-                        signal_aes256_gcm_siv_encrypt(nativeHandle,
-                                                      $0,
+                        signal_aes256_gcm_siv_encrypt($0,
                                                       $1,
+                                                      nativeHandle,
                                                       messageBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
                                                       messageBytes.count,
                                                       nonceBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
@@ -59,9 +59,9 @@ public class Aes256GcmSiv: ClonableHandleOwner {
             try nonce.withUnsafeBytes { nonceBytes in
                 try associated_data.withUnsafeBytes { adBytes in
                     try invokeFnReturningArray {
-                        signal_aes256_gcm_siv_decrypt(nativeHandle,
-                                                      $0,
+                        signal_aes256_gcm_siv_decrypt($0,
                                                       $1,
+                                                      nativeHandle,
                                                       messageBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
                                                       messageBytes.count,
                                                       nonceBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),

--- a/swift/Sources/SignalFfi/signal_ffi.h
+++ b/swift/Sources/SignalFfi/signal_ffi.h
@@ -203,28 +203,7 @@ SignalFfiError *signal_address_clone(SignalProtocolAddress **new_obj,
 
 SignalFfiError *signal_publickey_clone(SignalPublicKey **new_obj, const SignalPublicKey *obj);
 
-SignalFfiError *signal_privatekey_generate(SignalPrivateKey **key);
-
-SignalFfiError *signal_privatekey_get_public_key(SignalPublicKey **new_obj,
-                                                 const SignalPrivateKey *obj);
-
-SignalFfiError *signal_privatekey_sign(const unsigned char **signature,
-                                       size_t *signature_len,
-                                       const SignalPrivateKey *key,
-                                       const unsigned char *message,
-                                       size_t message_len);
-
-SignalFfiError *signal_privatekey_agree(const unsigned char **shared_secret,
-                                        size_t *shared_secret_len,
-                                        const SignalPrivateKey *private_key,
-                                        const SignalPublicKey *public_key);
-
 SignalFfiError *signal_privatekey_clone(SignalPrivateKey **new_obj, const SignalPrivateKey *obj);
-
-SignalFfiError *signal_identitykeypair_serialize(const unsigned char **output,
-                                                 size_t *output_len,
-                                                 const SignalPrivateKey *private_key,
-                                                 const SignalPublicKey *public_key);
 
 SignalFfiError *signal_identitykeypair_deserialize(SignalPrivateKey **private_key,
                                                    SignalPublicKey **public_key,
@@ -284,13 +263,6 @@ SignalFfiError *signal_pre_key_signal_message_get_identity_key(SignalPublicKey *
 SignalFfiError *signal_pre_key_signal_message_get_signal_message(SignalMessage **new_obj,
                                                                  const SignalPreKeySignalMessage *obj);
 
-SignalFfiError *signal_sender_key_message_new(SignalSenderKeyMessage **obj,
-                                              unsigned int key_id,
-                                              unsigned int iteration,
-                                              const unsigned char *ciphertext,
-                                              size_t ciphertext_len,
-                                              const SignalPrivateKey *pk);
-
 SignalFfiError *signal_sender_key_message_clone(SignalSenderKeyMessage **new_obj,
                                                 const SignalSenderKeyMessage *obj);
 
@@ -299,17 +271,6 @@ SignalFfiError *signal_sender_key_message_get_key_id(const SignalSenderKeyMessag
 
 SignalFfiError *signal_sender_key_message_get_iteration(const SignalSenderKeyMessage *obj,
                                                         unsigned int *out);
-
-SignalFfiError *signal_sender_key_message_verify_signature(bool *result,
-                                                           const SignalSenderKeyMessage *skm,
-                                                           const SignalPublicKey *pubkey);
-
-SignalFfiError *signal_sender_key_distribution_message_new(SignalSenderKeyDistributionMessage **obj,
-                                                           unsigned int key_id,
-                                                           unsigned int iteration,
-                                                           const unsigned char *chainkey,
-                                                           size_t chainkey_len,
-                                                           const SignalPublicKey *pk);
 
 SignalFfiError *signal_sender_key_distribution_message_clone(SignalSenderKeyDistributionMessage **new_obj,
                                                              const SignalSenderKeyDistributionMessage *obj);
@@ -358,14 +319,6 @@ SignalFfiError *signal_pre_key_bundle_get_signed_pre_key_public(SignalPublicKey 
 SignalFfiError *signal_pre_key_bundle_get_identity_key(SignalPublicKey **new_obj,
                                                        const SignalPreKeyBundle *obj);
 
-SignalFfiError *signal_signed_pre_key_record_new(SignalSignedPreKeyRecord **obj,
-                                                 unsigned int id,
-                                                 unsigned long long timestamp,
-                                                 const SignalPublicKey *pub_key,
-                                                 const SignalPrivateKey *priv_key,
-                                                 const unsigned char *signature,
-                                                 size_t signature_len);
-
 SignalFfiError *signal_signed_pre_key_record_get_id(const SignalSignedPreKeyRecord *obj,
                                                     unsigned int *out);
 
@@ -381,11 +334,6 @@ SignalFfiError *signal_signed_pre_key_record_get_private_key(SignalPrivateKey **
 SignalFfiError *signal_signed_pre_key_record_clone(SignalSignedPreKeyRecord **new_obj,
                                                    const SignalSignedPreKeyRecord *obj);
 
-SignalFfiError *signal_pre_key_record_new(SignalPreKeyRecord **obj,
-                                          unsigned int id,
-                                          const SignalPublicKey *pub_key,
-                                          const SignalPrivateKey *priv_key);
-
 SignalFfiError *signal_pre_key_record_get_id(const SignalPreKeyRecord *obj, unsigned int *out);
 
 SignalFfiError *signal_pre_key_record_get_public_key(SignalPublicKey **new_obj,
@@ -397,18 +345,11 @@ SignalFfiError *signal_pre_key_record_get_private_key(SignalPrivateKey **new_obj
 SignalFfiError *signal_pre_key_record_clone(SignalPreKeyRecord **new_obj,
                                             const SignalPreKeyRecord *obj);
 
-SignalFfiError *signal_sender_key_name_new(SignalSenderKeyName **obj,
-                                           const char *group_id,
-                                           const char *sender_name,
-                                           unsigned int sender_device_id);
-
 SignalFfiError *signal_sender_key_name_clone(SignalSenderKeyName **new_obj,
                                              const SignalSenderKeyName *obj);
 
 SignalFfiError *signal_sender_key_name_get_sender_device_id(const SignalSenderKeyName *obj,
                                                             unsigned int *out);
-
-SignalFfiError *signal_sender_key_record_new_fresh(SignalSenderKeyRecord **obj);
 
 SignalFfiError *signal_sender_key_record_clone(SignalSenderKeyRecord **new_obj,
                                                const SignalSenderKeyRecord *obj);
@@ -483,11 +424,6 @@ SignalFfiError *signal_server_certificate_get_key_id(const SignalServerCertifica
 SignalFfiError *signal_server_certificate_get_key(SignalPublicKey **new_obj,
                                                   const SignalServerCertificate *obj);
 
-SignalFfiError *signal_server_certificate_new(SignalServerCertificate **out,
-                                              unsigned int key_id,
-                                              const SignalPublicKey *server_key,
-                                              const SignalPrivateKey *trust_root);
-
 SignalFfiError *signal_sender_certificate_get_expiration(const SignalSenderCertificate *obj,
                                                          unsigned long long *out);
 
@@ -499,20 +435,6 @@ SignalFfiError *signal_sender_certificate_get_key(SignalPublicKey **new_obj,
 
 SignalFfiError *signal_sender_certificate_get_server_certificate(SignalServerCertificate **new_obj,
                                                                  const SignalSenderCertificate *obj);
-
-SignalFfiError *signal_sender_certificate_validate(bool *valid,
-                                                   const SignalSenderCertificate *cert,
-                                                   const SignalPublicKey *key,
-                                                   uint64_t time);
-
-SignalFfiError *signal_sender_certificate_new(SignalSenderCertificate **out,
-                                              const char *sender_uuid,
-                                              const char *sender_e164,
-                                              uint32_t sender_device_id,
-                                              const SignalPublicKey *sender_key,
-                                              uint64_t expiration,
-                                              const SignalServerCertificate *signer_cert,
-                                              const SignalPrivateKey *signer_key);
 
 SignalFfiError *signal_unidentified_sender_message_content_get_msg_type(uint8_t *out,
                                                                         const SignalUnidentifiedSenderMessageContent *obj);
@@ -553,30 +475,6 @@ SignalFfiError *signal_sealed_session_cipher_decrypt(const unsigned char **out,
                                                      const SignalPreKeyStore *prekey_store,
                                                      const SignalSignedPreKeyStore *signed_prekey_store,
                                                      void *ctx);
-
-SignalFfiError *signal_aes256_gcm_siv_new(SignalAes256GcmSiv **obj,
-                                          const unsigned char *key,
-                                          size_t key_len);
-
-SignalFfiError *signal_aes256_gcm_siv_encrypt(const SignalAes256GcmSiv *aes_gcm_siv,
-                                              const unsigned char **ctext,
-                                              size_t *ctext_len,
-                                              const unsigned char *ptext,
-                                              size_t ptext_len,
-                                              const unsigned char *nonce,
-                                              size_t nonce_len,
-                                              const unsigned char *associated_data,
-                                              size_t associated_data_len);
-
-SignalFfiError *signal_aes256_gcm_siv_decrypt(const SignalAes256GcmSiv *aes_gcm_siv,
-                                              const unsigned char **ptext,
-                                              size_t *ptext_len,
-                                              const unsigned char *ctext,
-                                              size_t ctext_len,
-                                              const unsigned char *nonce,
-                                              size_t nonce_len,
-                                              const unsigned char *associated_data,
-                                              size_t associated_data_len);
 
 void signal_init_logger(SignalLogLevel max_level, SignalFfiLogger logger);
 
@@ -622,6 +520,26 @@ SignalFfiError *signal_privatekey_deserialize(SignalPrivateKey **p,
 SignalFfiError *signal_privatekey_serialize(const SignalPrivateKey *obj,
                                             const unsigned char **out,
                                             size_t *out_len);
+
+SignalFfiError *signal_privatekey_generate(SignalPrivateKey **out);
+
+SignalFfiError *signal_privatekey_get_public_key(SignalPublicKey **out, const SignalPrivateKey *k);
+
+SignalFfiError *signal_privatekey_sign(const unsigned char **out,
+                                       size_t *out_len,
+                                       const SignalPrivateKey *key,
+                                       const unsigned char *message,
+                                       size_t message_len);
+
+SignalFfiError *signal_privatekey_agree(const unsigned char **out,
+                                        size_t *out_len,
+                                        const SignalPrivateKey *private_key,
+                                        const SignalPublicKey *public_key);
+
+SignalFfiError *signal_identitykeypair_serialize(const unsigned char **out,
+                                                 size_t *out_len,
+                                                 const SignalPublicKey *public_key,
+                                                 const SignalPrivateKey *private_key);
 
 SignalFfiError *signal_fingerprint_destroy(SignalFingerprint *p);
 
@@ -709,6 +627,17 @@ SignalFfiError *signal_sender_key_message_serialize(const SignalSenderKeyMessage
                                                     const unsigned char **out,
                                                     size_t *out_len);
 
+SignalFfiError *signal_sender_key_message_new(SignalSenderKeyMessage **out,
+                                              uint32_t key_id,
+                                              uint32_t iteration,
+                                              const unsigned char *ciphertext,
+                                              size_t ciphertext_len,
+                                              const SignalPrivateKey *pk);
+
+SignalFfiError *signal_sender_key_message_verify_signature(bool *out,
+                                                           const SignalSenderKeyMessage *skm,
+                                                           const SignalPublicKey *pubkey);
+
 SignalFfiError *signal_sender_key_distribution_message_destroy(SignalSenderKeyDistributionMessage *p);
 
 SignalFfiError *signal_sender_key_distribution_message_deserialize(SignalSenderKeyDistributionMessage **p,
@@ -722,6 +651,13 @@ SignalFfiError *signal_sender_key_distribution_message_get_chain_key(const Signa
 SignalFfiError *signal_sender_key_distribution_message_serialize(const SignalSenderKeyDistributionMessage *obj,
                                                                  const unsigned char **out,
                                                                  size_t *out_len);
+
+SignalFfiError *signal_sender_key_distribution_message_new(SignalSenderKeyDistributionMessage **out,
+                                                           uint32_t key_id,
+                                                           uint32_t iteration,
+                                                           const unsigned char *chainkey,
+                                                           size_t chainkey_len,
+                                                           const SignalPublicKey *pk);
 
 SignalFfiError *signal_pre_key_bundle_destroy(SignalPreKeyBundle *p);
 
@@ -743,6 +679,14 @@ SignalFfiError *signal_signed_pre_key_record_serialize(const SignalSignedPreKeyR
                                                        const unsigned char **out,
                                                        size_t *out_len);
 
+SignalFfiError *signal_signed_pre_key_record_new(SignalSignedPreKeyRecord **out,
+                                                 uint32_t id,
+                                                 uint64_t timestamp,
+                                                 const SignalPublicKey *pub_key,
+                                                 const SignalPrivateKey *priv_key,
+                                                 const unsigned char *signature,
+                                                 size_t signature_len);
+
 SignalFfiError *signal_pre_key_record_destroy(SignalPreKeyRecord *p);
 
 SignalFfiError *signal_pre_key_record_deserialize(SignalPreKeyRecord **p,
@@ -753,6 +697,11 @@ SignalFfiError *signal_pre_key_record_serialize(const SignalPreKeyRecord *obj,
                                                 const unsigned char **out,
                                                 size_t *out_len);
 
+SignalFfiError *signal_pre_key_record_new(SignalPreKeyRecord **out,
+                                          uint32_t id,
+                                          const SignalPublicKey *pub_key,
+                                          const SignalPrivateKey *priv_key);
+
 SignalFfiError *signal_sender_key_name_destroy(SignalSenderKeyName *p);
 
 SignalFfiError *signal_sender_key_name_get_group_id(const SignalSenderKeyName *obj,
@@ -760,6 +709,11 @@ SignalFfiError *signal_sender_key_name_get_group_id(const SignalSenderKeyName *o
 
 SignalFfiError *signal_sender_key_name_get_sender_name(const SignalSenderKeyName *obj,
                                                        const char **out);
+
+SignalFfiError *signal_sender_key_name_new(SignalSenderKeyName **out,
+                                           const char *group_id,
+                                           const char *sender_name,
+                                           uint32_t sender_device_id);
 
 SignalFfiError *signal_sender_key_record_destroy(SignalSenderKeyRecord *p);
 
@@ -770,6 +724,8 @@ SignalFfiError *signal_sender_key_record_deserialize(SignalSenderKeyRecord **p,
 SignalFfiError *signal_sender_key_record_serialize(const SignalSenderKeyRecord *obj,
                                                    const unsigned char **out,
                                                    size_t *out_len);
+
+SignalFfiError *signal_sender_key_record_new_fresh(SignalSenderKeyRecord **out);
 
 SignalFfiError *signal_ciphertext_message_destroy(SignalCiphertextMessage *p);
 
@@ -790,6 +746,11 @@ SignalFfiError *signal_server_certificate_get_certificate(const SignalServerCert
 SignalFfiError *signal_server_certificate_get_signature(const SignalServerCertificate *obj,
                                                         const unsigned char **out,
                                                         size_t *out_len);
+
+SignalFfiError *signal_server_certificate_new(SignalServerCertificate **out,
+                                              uint32_t key_id,
+                                              const SignalPublicKey *server_key,
+                                              const SignalPrivateKey *trust_root);
 
 SignalFfiError *signal_sender_certificate_destroy(SignalSenderCertificate *p);
 
@@ -814,6 +775,20 @@ SignalFfiError *signal_sender_certificate_get_sender_uuid(const SignalSenderCert
 
 SignalFfiError *signal_sender_certificate_get_sender_e164(const SignalSenderCertificate *obj,
                                                           const char **out);
+
+SignalFfiError *signal_sender_certificate_validate(bool *out,
+                                                   const SignalSenderCertificate *cert,
+                                                   const SignalPublicKey *key,
+                                                   uint64_t time);
+
+SignalFfiError *signal_sender_certificate_new(SignalSenderCertificate **out,
+                                              const char *sender_uuid,
+                                              const char *sender_e164,
+                                              uint32_t sender_device_id,
+                                              const SignalPublicKey *sender_key,
+                                              uint64_t expiration,
+                                              const SignalServerCertificate *signer_cert,
+                                              const SignalPrivateKey *signer_key);
 
 SignalFfiError *signal_unidentified_sender_message_content_destroy(SignalUnidentifiedSenderMessageContent *p);
 
@@ -840,5 +815,29 @@ SignalFfiError *signal_session_record_serialize(const SignalSessionRecord *obj,
                                                 size_t *out_len);
 
 SignalFfiError *signal_aes256_gcm_siv_destroy(SignalAes256GcmSiv *p);
+
+SignalFfiError *signal_aes256_gcm_siv_new(SignalAes256GcmSiv **out,
+                                          const unsigned char *key,
+                                          size_t key_len);
+
+SignalFfiError *signal_aes256_gcm_siv_encrypt(const unsigned char **out,
+                                              size_t *out_len,
+                                              const SignalAes256GcmSiv *aes_gcm_siv,
+                                              const unsigned char *ptext,
+                                              size_t ptext_len,
+                                              const unsigned char *nonce,
+                                              size_t nonce_len,
+                                              const unsigned char *associated_data,
+                                              size_t associated_data_len);
+
+SignalFfiError *signal_aes256_gcm_siv_decrypt(const unsigned char **out,
+                                              size_t *out_len,
+                                              const SignalAes256GcmSiv *aes_gcm_siv,
+                                              const unsigned char *ctext,
+                                              size_t ctext_len,
+                                              const unsigned char *nonce,
+                                              size_t nonce_len,
+                                              const unsigned char *associated_data,
+                                              size_t associated_data_len);
 
 #endif /* SIGNAL_FFI_H_ */


### PR DESCRIPTION
I suggest reviewing commit-by-commit. In particular the commit that adds `bridge_fn_buffer` has much more going on than the others. It's a little unfortunate that that doesn't fall nicely out of the rest of the `bridge_fn` infrastructure, but the double output parameters for C and avoiding an extra copy for Java make it worth it in the end. Still, you can see it starting to pay off with the diff size.