### PR TITLE
Log more information when decryption fails

### DIFF
--- a/rust/bridge/ffi/src/util.rs
+++ b/rust/bridge/ffi/src/util.rs
@@ -111,6 +111,7 @@ impl From<&SignalFfiError> for SignalErrorCode {
             }
 
             SignalFfiError::Signal(SignalProtocolError::InvalidMessage(_))
+            | SignalFfiError::Signal(SignalProtocolError::MessageDecryptionFailed(_))
             | SignalFfiError::Signal(SignalProtocolError::InvalidProtobufEncoding)
             | SignalFfiError::Signal(SignalProtocolError::InvalidSealedSenderMessage(_)) => {
                 SignalErrorCode::InvalidMessage

--- a/rust/bridge/shared/src/jni/mod.rs
+++ b/rust/bridge/shared/src/jni/mod.rs
@@ -94,6 +94,7 @@ fn throw_error(env: &JNIEnv, error: SignalJniError) {
         }
 
         SignalJniError::Signal(SignalProtocolError::InvalidMessage(_))
+        | SignalJniError::Signal(SignalProtocolError::MessageDecryptionFailed(_))
         | SignalJniError::Signal(SignalProtocolError::CiphertextMessageTooShort(_))
         | SignalJniError::Signal(SignalProtocolError::UnrecognizedCiphertextVersion(_))
         | SignalJniError::Signal(SignalProtocolError::UnrecognizedMessageVersion(_))

--- a/rust/protocol/Cargo.toml
+++ b/rust/protocol/Cargo.toml
@@ -27,6 +27,7 @@ rand = "0.7.3"
 sha2 = "0.9"
 subtle = "2.2.3"
 x25519-dalek = "1.0"
+hex = "0.4"
 
 [features]
 default = ["u64_backend"]
@@ -36,7 +37,6 @@ simd_backend = ["curve25519-dalek/simd_backend"]
 nightly = ["curve25519-dalek/nightly"]
 
 [dev-dependencies]
-hex = "0.4"
 criterion = "0.3"
 futures = "0.3.7"
 

--- a/rust/protocol/src/error.rs
+++ b/rust/protocol/src/error.rs
@@ -59,6 +59,7 @@ pub enum SignalProtocolError {
 
     DuplicatedMessage(u32, u32),
     InvalidMessage(&'static str),
+    MessageDecryptionFailed(String),
     InternalError(&'static str),
     FfiBindingError(String),
     ApplicationCallbackError(&'static str, Box<dyn Error + 'static>),
@@ -193,6 +194,9 @@ impl fmt::Display for SignalProtocolError {
             }
             SignalProtocolError::SealedSenderSelfSend => {
                 write!(f, "self send of a sealed sender message")
+            }
+            SignalProtocolError::MessageDecryptionFailed(info) => {
+                write!(f, "{}", info)
             }
         }
     }

--- a/rust/protocol/src/state/session.rs
+++ b/rust/protocol/src/state/session.rs
@@ -134,6 +134,21 @@ impl SessionState {
         Ok(self.session.sender_chain.is_some())
     }
 
+    pub(crate) fn all_receiver_chain_logging_info(&self) -> Result<Vec<(Vec<u8>, Option<u32>)>> {
+        let mut results = vec![];
+        for chain in self.session.receiver_chains.iter() {
+            let sender_ratchet_public = chain.sender_ratchet_key.clone();
+
+            let chain_key_idx = match &chain.chain_key {
+                Some(chain_key) => Some(chain_key.index),
+                None => None,
+            };
+
+            results.push((sender_ratchet_public, chain_key_idx))
+        }
+        Ok(results)
+    }
+
     pub(crate) fn get_receiver_chain(
         &self,
         sender: &curve::PublicKey,


### PR DESCRIPTION
Error log looks like this

```
Message from +14151111111:1 failed to decrypt; sender ratchet public key 01d5bbc17518fc09e3aa0cc7f43b627d5bce860f7bb2b1adc4676300569cbd30 message counter 1
Candidate session 0 failed with 'invalid ciphertext message', had 1 receiver chains
Receiver chain with sender ratchet public key 0501d5bbc17518fc09e3aa0cc7f43b627d5bce860f7bb2b1adc4676300569cbd30
Candidate session 1 failed with 'invalid ciphertext message', had 4 receiver chains
Receiver chain with sender ratchet public key 057b8c777abe702f861d6e77bf9d3b0a93a361ac24a2aa07cdbf52e413a4e61576
Receiver chain with sender ratchet public key 0571eab62e9ca2827962b7a41593bd76d2a7976762844af15d6ac1529af456ac0c
Receiver chain with sender ratchet public key 052dca6940acfb4a02da93bd649d400cfedf16156cff65fe0d6f4105b42956be2b
Receiver chain with sender ratchet public key 05d7a0b76243102318ed92a981640dde5ca10d7e3d2179d4ac51f35a55ebe28229
```