### PR TITLE
Add support for Node to libsignal-bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,6 +751,7 @@ dependencies = [
  "libsignal-bridge-macros",
  "libsignal-protocol-rust",
  "log",
+ "neon",
  "paste",
  "rand",
 ]
@@ -798,6 +799,7 @@ dependencies = [
 name = "libsignal-node"
 version = "0.1.0"
 dependencies = [
+ "libsignal-bridge",
  "libsignal-protocol-rust",
  "neon",
  "neon-build 0.5.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,6 +750,7 @@ dependencies = [
  "libc",
  "libsignal-bridge-macros",
  "libsignal-protocol-rust",
+ "linkme",
  "log",
  "neon",
  "paste",
@@ -827,6 +828,26 @@ dependencies = [
  "sha2",
  "subtle",
  "x25519-dalek",
+]
+
+[[package]]
+name = "linkme"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af8d48c3ea47e553ce0cece93639dbca649955e44e07de98be481f5918e0c555"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84a81a6a2a96ffd36c5fe4904c5173e1d8636ad3156a6dda1c6370387a1f7a4a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/node/build_node_bridge.sh
+++ b/node/build_node_bridge.sh
@@ -71,6 +71,12 @@ fi
 
 OUT_DIR=${OUT_DIR:-build/${CONFIGURATION_NAME}}
 
+# On Linux, cdylibs don't include public symbols from their dependencies,
+# even if those symbols have been re-exported in the Rust source.
+# Using LTO works around this at the cost of a slightly slower build.
+# https://github.com/rust-lang/rfcs/issues/2771
+export CARGO_PROFILE_RELEASE_LTO=thin
+
 check_rust
 
 echo_then_run cargo build -p libsignal-node ${CARGO_PROFILE_ARG}

--- a/rust/bridge/node/Cargo.toml
+++ b/rust/bridge/node/Cargo.toml
@@ -19,5 +19,6 @@ neon-build = "0.5.0"
 
 [dependencies]
 libsignal-protocol-rust = { path = "../../protocol" }
+libsignal-bridge = { path = "../shared", features = ["node"] }
 neon = { version = "0.7", default-features = false, features = ["napi-1"] }
 rand = "0.7.3"

--- a/rust/bridge/node/src/lib.rs
+++ b/rust/bridge/node/src/lib.rs
@@ -3,86 +3,19 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use libsignal_bridge::node::*;
 use libsignal_bridge::*;
-use libsignal_protocol_rust::*;
-use neon::context::Context;
 use neon::prelude::*;
-
-fn return_boolean<'a>(
-    cx: &mut FunctionContext<'a>,
-    value: Result<bool, SignalProtocolError>,
-) -> JsResult<'a, JsValue> {
-    match value {
-        Ok(v) => Ok(cx.boolean(v).upcast()),
-        Err(e) => cx.throw_error(e.to_string()),
-    }
-}
-
-#[allow(non_snake_case)]
-fn PrivateKey_generate(mut cx: FunctionContext) -> JsResult<JsValue> {
-    let mut rng = rand::rngs::OsRng;
-    let keypair = KeyPair::generate(&mut rng);
-    return_boxed_object(&mut cx, Ok(keypair.private_key))
-}
-
-#[allow(non_snake_case)]
-fn PrivateKey_getPublicKey(mut cx: FunctionContext) -> JsResult<JsValue> {
-    let obj = cx.argument::<DefaultJsBox<PrivateKey>>(0)?;
-    let new_obj = obj.public_key();
-    return_boxed_object(&mut cx, new_obj)
-}
-
-#[allow(non_snake_case)]
-fn PrivateKey_sign(mut cx: FunctionContext) -> JsResult<JsValue> {
-    let key = cx.argument::<DefaultJsBox<PrivateKey>>(0)?;
-    let message = cx.argument::<JsBuffer>(1)?;
-
-    let mut rng = rand::rngs::OsRng;
-    let signature = {
-        let guard = cx.lock();
-        let message = message.borrow(&guard);
-        key.calculate_signature(message.as_slice::<u8>(), &mut rng)
-    };
-
-    return_binary_data(&mut cx, signature)
-}
-
-#[allow(non_snake_case)]
-fn PrivateKey_agree(mut cx: FunctionContext) -> JsResult<JsValue> {
-    let key = cx.argument::<DefaultJsBox<PrivateKey>>(0)?;
-    let other_key = cx.argument::<DefaultJsBox<PublicKey>>(1)?;
-
-    let shared_secret = key.calculate_agreement(&other_key);
-    return_binary_data(&mut cx, shared_secret)
-}
-
-#[allow(non_snake_case)]
-fn PublicKey_verify(mut cx: FunctionContext) -> JsResult<JsValue> {
-    let key = cx.argument::<DefaultJsBox<PublicKey>>(0)?;
-    let message = cx.argument::<JsBuffer>(1)?;
-    let signature = cx.argument::<JsBuffer>(2)?;
-
-    let ok = {
-        let guard = cx.lock();
-        let message = message.borrow(&guard);
-        let signature = signature.borrow(&guard);
-        key.verify_signature(message.as_slice::<u8>(), signature.as_slice::<u8>())
-    };
-
-    return_boolean(&mut cx, ok)
-}
 
 #[neon::main]
 fn main(mut cx: ModuleContext) -> NeonResult<()> {
-    cx.export_function("PrivateKey_generate", PrivateKey_generate)?;
+    cx.export_function("PrivateKey_generate", node_PrivateKey_generate)?;
     cx.export_function("PrivateKey_deserialize", node_PrivateKey_deserialize)?;
     cx.export_function("PrivateKey_serialize", node_PrivateKey_serialize)?;
-    cx.export_function("PrivateKey_sign", PrivateKey_sign)?;
-    cx.export_function("PrivateKey_agree", PrivateKey_agree)?;
-    cx.export_function("PrivateKey_getPublicKey", PrivateKey_getPublicKey)?;
+    cx.export_function("PrivateKey_sign", node_PrivateKey_sign)?;
+    cx.export_function("PrivateKey_agree", node_PrivateKey_agree)?;
+    cx.export_function("PrivateKey_getPublicKey", node_PrivateKey_getPublicKey)?;
 
-    cx.export_function("PublicKey_verify", PublicKey_verify)?;
+    cx.export_function("PublicKey_verify", node_PublicKey_verify)?;
     cx.export_function("PublicKey_deserialize", node_PublicKey_deserialize)?;
     cx.export_function("PublicKey_serialize", node_PublicKey_serialize)?;
     Ok(())

--- a/rust/bridge/node/src/lib.rs
+++ b/rust/bridge/node/src/lib.rs
@@ -1,22 +1,12 @@
 //
-// Copyright 2020 Signal Messenger, LLC.
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use libsignal_bridge::*;
 use neon::prelude::*;
 
 #[neon::main]
 fn main(mut cx: ModuleContext) -> NeonResult<()> {
-    cx.export_function("PrivateKey_generate", node_PrivateKey_generate)?;
-    cx.export_function("PrivateKey_deserialize", node_PrivateKey_deserialize)?;
-    cx.export_function("PrivateKey_serialize", node_PrivateKey_serialize)?;
-    cx.export_function("PrivateKey_sign", node_PrivateKey_sign)?;
-    cx.export_function("PrivateKey_agree", node_PrivateKey_agree)?;
-    cx.export_function("PrivateKey_getPublicKey", node_PrivateKey_getPublicKey)?;
-
-    cx.export_function("PublicKey_verify", node_PublicKey_verify)?;
-    cx.export_function("PublicKey_deserialize", node_PublicKey_deserialize)?;
-    cx.export_function("PublicKey_serialize", node_PublicKey_serialize)?;
+    libsignal_bridge::node::register(&mut cx)?;
     Ok(())
 }

--- a/rust/bridge/node/src/lib.rs
+++ b/rust/bridge/node/src/lib.rs
@@ -8,7 +8,6 @@ use libsignal_bridge::*;
 use libsignal_protocol_rust::*;
 use neon::context::Context;
 use neon::prelude::*;
-use std::convert::TryFrom;
 
 fn return_boolean<'a>(
     cx: &mut FunctionContext<'a>,
@@ -20,49 +19,12 @@ fn return_boolean<'a>(
     }
 }
 
-fn return_binary_data<'a, T: AsRef<[u8]>>(
-    cx: &mut FunctionContext<'a>,
-    bytes: Result<T, SignalProtocolError>,
-) -> JsResult<'a, JsValue> {
-    match bytes {
-        Ok(bytes) => {
-            let bytes = bytes.as_ref();
-
-            let bytes_len = match u32::try_from(bytes.len()) {
-                Ok(l) => l,
-                Err(_) => {
-                    return cx.throw_error("Cannot return very large object to JS environment")
-                }
-            };
-            let mut buffer = cx.buffer(bytes_len)?;
-            cx.borrow_mut(&mut buffer, |raw_buffer| {
-                raw_buffer.as_mut_slice().copy_from_slice(&bytes);
-            });
-            Ok(buffer.upcast())
-        }
-        Err(e) => cx.throw_error(e.to_string()),
-    }
-}
-
-macro_rules! node_bridge_serialize {
-    ( $typ:ident::$fn:ident is $node_name:ident ) => {
-        #[allow(non_snake_case)]
-        fn $node_name(mut cx: FunctionContext) -> JsResult<JsValue> {
-            let obj = cx.argument::<DefaultJsBox<$typ>>(0)?;
-            let bytes = obj.$fn();
-            return_binary_data(&mut cx, Ok(bytes))
-        }
-    };
-}
-
 #[allow(non_snake_case)]
 fn PrivateKey_generate(mut cx: FunctionContext) -> JsResult<JsValue> {
     let mut rng = rand::rngs::OsRng;
     let keypair = KeyPair::generate(&mut rng);
     return_boxed_object(&mut cx, Ok(keypair.private_key))
 }
-
-node_bridge_serialize!(PrivateKey::serialize is PrivateKey_serialize);
 
 #[allow(non_snake_case)]
 fn PrivateKey_getPublicKey(mut cx: FunctionContext) -> JsResult<JsValue> {
@@ -95,8 +57,6 @@ fn PrivateKey_agree(mut cx: FunctionContext) -> JsResult<JsValue> {
     return_binary_data(&mut cx, shared_secret)
 }
 
-node_bridge_serialize!(PublicKey::serialize is PublicKey_serialize);
-
 #[allow(non_snake_case)]
 fn PublicKey_verify(mut cx: FunctionContext) -> JsResult<JsValue> {
     let key = cx.argument::<DefaultJsBox<PublicKey>>(0)?;
@@ -117,13 +77,13 @@ fn PublicKey_verify(mut cx: FunctionContext) -> JsResult<JsValue> {
 fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("PrivateKey_generate", PrivateKey_generate)?;
     cx.export_function("PrivateKey_deserialize", node_PrivateKey_deserialize)?;
-    cx.export_function("PrivateKey_serialize", PrivateKey_serialize)?;
+    cx.export_function("PrivateKey_serialize", node_PrivateKey_serialize)?;
     cx.export_function("PrivateKey_sign", PrivateKey_sign)?;
     cx.export_function("PrivateKey_agree", PrivateKey_agree)?;
     cx.export_function("PrivateKey_getPublicKey", PrivateKey_getPublicKey)?;
 
     cx.export_function("PublicKey_verify", PublicKey_verify)?;
     cx.export_function("PublicKey_deserialize", node_PublicKey_deserialize)?;
-    cx.export_function("PublicKey_serialize", PublicKey_serialize)?;
+    cx.export_function("PublicKey_serialize", node_PublicKey_serialize)?;
     Ok(())
 }

--- a/rust/bridge/shared/Cargo.toml
+++ b/rust/bridge/shared/Cargo.toml
@@ -22,7 +22,8 @@ rand = "0.7.3"
 libc = { version = "0.2", optional = true }
 jni = { version = "0.17", optional = true }
 neon = { version = "0.7.0", optional = true, default-features = false, features = ["napi-4"] }
+linkme = { version = "0.2.4", optional = true }
 
 [features]
 ffi = ["libc"]
-node = ["neon"]
+node = ["neon", "linkme"]

--- a/rust/bridge/shared/Cargo.toml
+++ b/rust/bridge/shared/Cargo.toml
@@ -21,6 +21,8 @@ rand = "0.7.3"
 
 libc = { version = "0.2", optional = true }
 jni = { version = "0.17", optional = true }
+neon = { version = "0.7.0", optional = true, default-features = false, features = ["napi-4"] }
 
 [features]
 ffi = ["libc"]
+node = ["neon"]

--- a/rust/bridge/shared/src/ffi/convert.rs
+++ b/rust/bridge/shared/src/ffi/convert.rs
@@ -110,7 +110,7 @@ pub(crate) struct Env;
 
 impl crate::Env for Env {
     type Buffer = Box<[u8]>;
-    fn buffer<'a, T: Into<Cow<'a, [u8]>>>(&self, input: T) -> Self::Buffer {
+    fn buffer<'a, T: Into<Cow<'a, [u8]>>>(self, input: T) -> Self::Buffer {
         input.into().into()
     }
 }

--- a/rust/bridge/shared/src/jni/convert.rs
+++ b/rust/bridge/shared/src/jni/convert.rs
@@ -145,7 +145,7 @@ impl<T: ResultTypeInfo> ResultTypeInfo for Result<T, SignalJniError> {
 
 impl crate::Env for &'_ JNIEnv<'_> {
     type Buffer = Result<jbyteArray, SignalJniError>;
-    fn buffer<'a, T: Into<Cow<'a, [u8]>>>(&self, input: T) -> Self::Buffer {
+    fn buffer<'a, T: Into<Cow<'a, [u8]>>>(self, input: T) -> Self::Buffer {
         to_jbytearray(&self, Ok(input.into()))
     }
 }

--- a/rust/bridge/shared/src/lib.rs
+++ b/rust/bridge/shared/src/lib.rs
@@ -65,7 +65,7 @@ bridge_get_bytearray!(
     PublicKey::public_key_bytes
 );
 
-#[bridge_fn(ffi = "publickey_compare")]
+#[bridge_fn(ffi = "publickey_compare", node = "PublicKey_compare")]
 fn ECPublicKey_Compare(key1: &PublicKey, key2: &PublicKey) -> i32 {
     match key1.cmp(&key2) {
         std::cmp::Ordering::Less => -1,
@@ -74,7 +74,7 @@ fn ECPublicKey_Compare(key1: &PublicKey, key2: &PublicKey) -> i32 {
     }
 }
 
-#[bridge_fn(ffi = "publickey_verify")]
+#[bridge_fn(ffi = "publickey_verify", node = "PublicKey_verify")]
 fn ECPublicKey_Verify(
     key: &PublicKey,
     message: &[u8],
@@ -96,19 +96,19 @@ bridge_get_bytearray!(
     |k| Ok(k.serialize())
 );
 
-#[bridge_fn(ffi = "privatekey_generate")]
+#[bridge_fn(ffi = "privatekey_generate", node = "PrivateKey_generate")]
 fn ECPrivateKey_Generate() -> PrivateKey {
     let mut rng = rand::rngs::OsRng;
     let keypair = KeyPair::generate(&mut rng);
     keypair.private_key
 }
 
-#[bridge_fn(ffi = "privatekey_get_public_key")]
+#[bridge_fn(ffi = "privatekey_get_public_key", node = "PrivateKey_getPublicKey")]
 fn ECPrivateKey_GetPublicKey(k: &PrivateKey) -> Result<PublicKey, SignalProtocolError> {
     k.public_key()
 }
 
-#[bridge_fn_buffer(ffi = "privatekey_sign")]
+#[bridge_fn_buffer(ffi = "privatekey_sign", node = "PrivateKey_sign")]
 fn ECPrivateKey_Sign<T: Env>(
     env: T,
     key: &PrivateKey,
@@ -119,7 +119,7 @@ fn ECPrivateKey_Sign<T: Env>(
     Ok(env.buffer(sig.into_vec()))
 }
 
-#[bridge_fn_buffer(ffi = "privatekey_agree")]
+#[bridge_fn_buffer(ffi = "privatekey_agree", node = "PrivateKey_agree")]
 fn ECPrivateKey_Agree<T: Env>(
     env: T,
     private_key: &PrivateKey,

--- a/rust/bridge/shared/src/lib.rs
+++ b/rust/bridge/shared/src/lib.rs
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Signal Messenger, LLC.
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
@@ -10,8 +10,8 @@ use libsignal_bridge_macros::*;
 use libsignal_protocol_rust::*;
 use std::convert::TryFrom;
 
-#[cfg(not(any(feature = "ffi", feature = "jni")))]
-compile_error!("Either feature \"ffi\" or \"jni\" must be enabled for this crate.");
+#[cfg(not(any(feature = "ffi", feature = "jni", feature = "node")))]
+compile_error!("Feature \"ffi\", \"jni\", or \"node\" must be enabled for this crate.");
 
 #[cfg(feature = "ffi")]
 #[macro_use]
@@ -20,6 +20,10 @@ pub mod ffi;
 #[cfg(feature = "jni")]
 #[macro_use]
 pub mod jni;
+
+#[cfg(feature = "node")]
+#[macro_use]
+pub mod node;
 
 #[macro_use]
 mod support;

--- a/rust/bridge/shared/src/node/convert.rs
+++ b/rust/bridge/shared/src/node/convert.rs
@@ -1,0 +1,252 @@
+//
+// Copyright 2021 Signal Messenger, LLC.
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+use neon::prelude::*;
+use std::borrow::Cow;
+use std::convert::TryInto;
+use std::ops::{Deref, RangeInclusive};
+
+pub(crate) trait ArgTypeInfo<'a>: Sized {
+    type ArgType: neon::types::Value;
+    fn convert_from(
+        cx: &mut FunctionContext<'a>,
+        foreign: Handle<'a, Self::ArgType>,
+    ) -> NeonResult<Self>;
+}
+
+pub(crate) trait RefArgTypeInfo<'a>: Deref {
+    type ArgType: neon::types::Value;
+    type StoredType: Deref<Target = Self::Target> + 'a;
+    fn convert_from(
+        cx: &mut FunctionContext<'a>,
+        foreign: Handle<'a, Self::ArgType>,
+    ) -> NeonResult<Self::StoredType>;
+}
+
+pub(crate) trait ResultTypeInfo<'a>: Sized {
+    type ResultType: neon::types::Value;
+    fn convert_into(self, cx: &mut FunctionContext<'a>)
+        -> NeonResult<Handle<'a, Self::ResultType>>;
+}
+
+fn can_convert_js_number_to_int(value: f64, valid_range: RangeInclusive<f64>) -> bool {
+    value.is_finite() && value.fract() == 0.0 && valid_range.contains(&value)
+}
+
+impl<'a> ArgTypeInfo<'a> for u32 {
+    type ArgType = JsNumber;
+    fn convert_from(
+        cx: &mut FunctionContext<'a>,
+        foreign: Handle<'a, Self::ArgType>,
+    ) -> NeonResult<Self> {
+        let value = foreign.value(cx);
+        if !can_convert_js_number_to_int(value, 0.0..=u32::MAX.into()) {
+            return cx
+                .throw_range_error(format!("integer overflow during conversion of {}", value));
+        }
+        Ok(value as u32)
+    }
+}
+
+impl<'a> ArgTypeInfo<'a> for u8 {
+    type ArgType = JsNumber;
+    fn convert_from(
+        cx: &mut FunctionContext<'a>,
+        foreign: Handle<'a, Self::ArgType>,
+    ) -> NeonResult<Self> {
+        let value = foreign.value(cx);
+        if !can_convert_js_number_to_int(value, 0.0..=u8::MAX.into()) {
+            return cx
+                .throw_range_error(format!("integer overflow during conversion of {}", value));
+        }
+        Ok(value as u8)
+    }
+}
+
+// 2**53 - 1, the maximum "safe" integer representable in an f64.
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
+const MAX_SAFE_JS_INTEGER: f64 = 9007199254740991.0;
+
+impl<'a> ArgTypeInfo<'a> for u64 {
+    type ArgType = JsNumber;
+    fn convert_from(
+        cx: &mut FunctionContext<'a>,
+        foreign: Handle<'a, Self::ArgType>,
+    ) -> NeonResult<Self> {
+        let value = foreign.value(cx);
+        if !can_convert_js_number_to_int(value, 0.0..=MAX_SAFE_JS_INTEGER) {
+            return cx
+                .throw_range_error(format!("integer overflow during conversion of {}", value));
+        }
+        Ok(value as u64)
+    }
+}
+
+impl<'a> ArgTypeInfo<'a> for String {
+    type ArgType = JsString;
+    fn convert_from(
+        cx: &mut FunctionContext<'a>,
+        foreign: Handle<'a, Self::ArgType>,
+    ) -> NeonResult<Self> {
+        Ok(foreign.value(cx))
+    }
+}
+
+impl<'a, T: ArgTypeInfo<'a>> ArgTypeInfo<'a> for Option<T> {
+    type ArgType = JsValue;
+    fn convert_from(
+        cx: &mut FunctionContext<'a>,
+        foreign: Handle<'a, Self::ArgType>,
+    ) -> NeonResult<Self> {
+        if foreign.downcast::<JsNull, _>(cx).is_ok() {
+            return Ok(None);
+        }
+        let non_optional_value = foreign.downcast_or_throw::<T::ArgType, _>(cx)?;
+        T::convert_from(cx, non_optional_value).map(Some)
+    }
+}
+
+impl<'a> RefArgTypeInfo<'a> for &[u8] {
+    type ArgType = JsBuffer;
+    // FIXME: Avoid copying this data.
+    type StoredType = Vec<u8>;
+    fn convert_from(
+        cx: &mut FunctionContext<'a>,
+        foreign: Handle<'a, Self::ArgType>,
+    ) -> NeonResult<Self::StoredType> {
+        Ok(cx.borrow(&foreign, |buf| buf.as_slice().to_vec()))
+    }
+}
+
+impl<'a> ResultTypeInfo<'a> for bool {
+    type ResultType = JsBoolean;
+    fn convert_into(
+        self,
+        cx: &mut FunctionContext<'a>,
+    ) -> NeonResult<Handle<'a, Self::ResultType>> {
+        Ok(cx.boolean(self))
+    }
+}
+
+impl<'a> ResultTypeInfo<'a> for i32 {
+    type ResultType = JsNumber;
+    fn convert_into(
+        self,
+        cx: &mut FunctionContext<'a>,
+    ) -> NeonResult<Handle<'a, Self::ResultType>> {
+        Ok(cx.number(self as f64))
+    }
+}
+
+impl<'a> ResultTypeInfo<'a> for String {
+    type ResultType = JsString;
+    fn convert_into(
+        self,
+        cx: &mut FunctionContext<'a>,
+    ) -> NeonResult<Handle<'a, Self::ResultType>> {
+        Ok(cx.string(self))
+    }
+}
+
+impl<'a, T: ResultTypeInfo<'a>> ResultTypeInfo<'a>
+    for Result<T, libsignal_protocol_rust::SignalProtocolError>
+{
+    type ResultType = T::ResultType;
+    fn convert_into(
+        self,
+        cx: &mut FunctionContext<'a>,
+    ) -> NeonResult<Handle<'a, Self::ResultType>> {
+        match self {
+            Ok(value) => value.convert_into(cx),
+            // FIXME: Use a dedicated Error type?
+            Err(err) => cx.throw_error(err.to_string()),
+        }
+    }
+}
+
+impl<'a, T: ResultTypeInfo<'a>> ResultTypeInfo<'a> for Result<T, aes_gcm_siv::Error> {
+    type ResultType = T::ResultType;
+    fn convert_into(
+        self,
+        cx: &mut FunctionContext<'a>,
+    ) -> NeonResult<Handle<'a, Self::ResultType>> {
+        match self {
+            Ok(value) => value.convert_into(cx),
+            // FIXME: Use a dedicated Error type?
+            Err(err) => cx.throw_error(err.to_string()),
+        }
+    }
+}
+
+impl<'a, T: ResultTypeInfo<'a>> ResultTypeInfo<'a> for NeonResult<T> {
+    type ResultType = T::ResultType;
+    fn convert_into(
+        self,
+        cx: &mut FunctionContext<'a>,
+    ) -> NeonResult<Handle<'a, Self::ResultType>> {
+        self?.convert_into(cx)
+    }
+}
+
+impl<'a, T: Value> ResultTypeInfo<'a> for Handle<'a, T> {
+    type ResultType = T;
+    fn convert_into(
+        self,
+        _cx: &mut FunctionContext<'a>,
+    ) -> NeonResult<Handle<'a, Self::ResultType>> {
+        Ok(self)
+    }
+}
+
+pub(crate) struct RefBoxHandle<'a, T: Send + 'static> {
+    pub(crate) data: Handle<'a, crate::node::DefaultJsBox<T>>,
+}
+
+impl<'a, T: Send + 'static> Deref for RefBoxHandle<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &***self.data
+    }
+}
+
+macro_rules! node_bridge_handle {
+    ($typ:ty) => {
+        impl<'a> node::RefArgTypeInfo<'a> for &$typ {
+            type ArgType = node::DefaultJsBox<$typ>;
+            type StoredType = node::RefBoxHandle<'a, $typ>;
+            fn convert_from(
+                _cx: &mut node::FunctionContext<'a>,
+                foreign: node::Handle<'a, Self::ArgType>,
+            ) -> node::NeonResult<Self::StoredType> {
+                Ok(node::RefBoxHandle { data: foreign })
+            }
+        }
+        impl<'a> node::ResultTypeInfo<'a> for $typ {
+            type ResultType = node::JsValue;
+            fn convert_into(
+                self,
+                cx: &mut node::FunctionContext<'a>,
+            ) -> node::NeonResult<node::Handle<'a, Self::ResultType>> {
+                node::return_boxed_object(cx, Ok(self))
+            }
+        }
+    };
+}
+
+impl<'a> crate::Env for &'_ mut FunctionContext<'a> {
+    type Buffer = JsResult<'a, JsBuffer>;
+    fn buffer<'b, T: Into<Cow<'b, [u8]>>>(self, input: T) -> Self::Buffer {
+        let input = input.into();
+        let len: u32 = input
+            .len()
+            .try_into()
+            .or_else(|_| self.throw_error("buffer too large to return to JavaScript"))?;
+        let mut result = Context::buffer(self, len)?;
+        self.borrow_mut(&mut result, |buf| {
+            buf.as_mut_slice().copy_from_slice(input.as_ref())
+        });
+        Ok(result)
+    }
+}

--- a/rust/bridge/shared/src/node/mod.rs
+++ b/rust/bridge/shared/src/node/mod.rs
@@ -5,6 +5,7 @@
 
 use libsignal_protocol_rust::*;
 use neon::context::Context;
+use std::convert::TryFrom;
 use std::ops::Deref;
 
 pub use neon::prelude::*;
@@ -29,6 +30,30 @@ pub fn return_boxed_object<'a, T: 'static + Send>(
 ) -> JsResult<'a, JsValue> {
     match value {
         Ok(v) => Ok(cx.boxed(DefaultFinalize(v)).upcast()),
+        Err(e) => cx.throw_error(e.to_string()),
+    }
+}
+
+pub fn return_binary_data<'a, T: AsRef<[u8]>>(
+    cx: &mut FunctionContext<'a>,
+    bytes: Result<T, SignalProtocolError>,
+) -> JsResult<'a, JsValue> {
+    match bytes {
+        Ok(bytes) => {
+            let bytes = bytes.as_ref();
+
+            let bytes_len = match u32::try_from(bytes.len()) {
+                Ok(l) => l,
+                Err(_) => {
+                    return cx.throw_error("Cannot return very large object to JS environment")
+                }
+            };
+            let mut buffer = cx.buffer(bytes_len)?;
+            cx.borrow_mut(&mut buffer, |raw_buffer| {
+                raw_buffer.as_mut_slice().copy_from_slice(&bytes);
+            });
+            Ok(buffer.upcast())
+        }
         Err(e) => cx.throw_error(e.to_string()),
     }
 }
@@ -60,5 +85,29 @@ macro_rules! node_bridge_deserialize {
     };
     ( $typ:ident::$fn:path ) => {
         node_bridge_deserialize!($typ::$fn as $typ);
+    };
+}
+
+macro_rules! node_bridge_get_bytearray {
+    ( $name:ident($typ:ty) as None => $body:expr ) => {};
+    ( $name:ident($typ:ty) as $node_name:ident => $body:expr ) => {
+        paste! {
+            #[allow(non_snake_case)]
+            pub fn [<node_ $node_name>](
+                mut cx: node::FunctionContext
+            ) -> node::JsResult<node::JsValue> {
+                expr_as_fn!(inner_get<'a>(
+                    obj: &'a $typ
+                ) -> Result<impl AsRef<[u8]> + 'a, SignalProtocolError> => $body);
+                let obj = cx.argument::<node::DefaultJsBox<$typ>>(0)?;
+                let bytes = inner_get(&obj);
+                node::return_binary_data(&mut cx, bytes)
+            }
+        }
+    };
+    ( $name:ident($typ:ty) => $body:expr ) => {
+        paste! {
+            node_bridge_get_bytearray!($name($typ) as [<$typ _ $name>] => $body);
+        }
     };
 }

--- a/rust/bridge/shared/src/node/mod.rs
+++ b/rust/bridge/shared/src/node/mod.rs
@@ -1,0 +1,64 @@
+//
+// Copyright 2021 Signal Messenger, LLC.
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+use libsignal_protocol_rust::*;
+use neon::context::Context;
+use std::ops::Deref;
+
+pub use neon::prelude::*;
+
+pub struct DefaultFinalize<T>(T);
+
+impl<T> Finalize for DefaultFinalize<T> {}
+
+impl<T> Deref for DefaultFinalize<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub type DefaultJsBox<T> = JsBox<DefaultFinalize<T>>;
+
+pub fn return_boxed_object<'a, T: 'static + Send>(
+    cx: &mut FunctionContext<'a>,
+    value: Result<T, SignalProtocolError>,
+) -> JsResult<'a, JsValue> {
+    match value {
+        Ok(v) => Ok(cx.boxed(DefaultFinalize(v)).upcast()),
+        Err(e) => cx.throw_error(e.to_string()),
+    }
+}
+
+pub(crate) fn with_buffer_contents<R>(
+    cx: &mut FunctionContext,
+    buffer: Handle<JsBuffer>,
+    f: impl for<'a> FnOnce(&'a [u8]) -> R,
+) -> R {
+    let guard = cx.lock();
+    let slice = buffer.borrow(&guard).as_slice::<u8>();
+    f(slice)
+}
+
+macro_rules! node_bridge_deserialize {
+    ( $typ:ident::$fn:path as None ) => {};
+    ( $typ:ident::$fn:path as $node_name:ident ) => {
+        paste! {
+            #[allow(non_snake_case, clippy::redundant_closure)]
+            pub fn [<node_ $node_name _deserialize>](
+                mut cx: node::FunctionContext
+            ) -> node::JsResult<node::JsValue> {
+                let buffer = cx.argument::<node::JsBuffer>(0)?;
+                let obj: Result<$typ, _> =
+                    node::with_buffer_contents(&mut cx, buffer, |buf| $typ::$fn(buf));
+                node::return_boxed_object(&mut cx, obj)
+            }
+        }
+    };
+    ( $typ:ident::$fn:path ) => {
+        node_bridge_deserialize!($typ::$fn as $typ);
+    };
+}

--- a/rust/bridge/shared/src/node/mod.rs
+++ b/rust/bridge/shared/src/node/mod.rs
@@ -4,11 +4,15 @@
 //
 
 use libsignal_protocol_rust::*;
-use neon::context::Context;
 use std::convert::TryFrom;
 use std::ops::Deref;
 
+pub use neon::context::{Context, Lock};
 pub use neon::prelude::*;
+
+#[macro_use]
+mod convert;
+pub(crate) use convert::*;
 
 pub struct DefaultFinalize<T>(T);
 

--- a/rust/bridge/shared/src/support.rs
+++ b/rust/bridge/shared/src/support.rs
@@ -85,11 +85,13 @@ macro_rules! bridge_get_bytearray {
 }
 
 macro_rules! bridge_get_optional_bytearray {
-    ($name:ident($typ:ty) $(, ffi = $ffi_name:ident)? $(, jni = $jni_name:ident)? => $body:expr ) => {
+    ($name:ident($typ:ty) $(, ffi = $ffi_name:ident)? $(, jni = $jni_name:ident)? $(, node = $node_name:ident)? => $body:expr ) => {
         #[cfg(feature = "ffi")]
         ffi_bridge_get_optional_bytearray!($name($typ) $(as $ffi_name)? => $body);
         #[cfg(feature = "jni")]
         jni_bridge_get_optional_bytearray!($name($typ) $(as $jni_name)? => $body);
+        #[cfg(feature = "node")]
+        node_bridge_get_optional_bytearray!($name($typ) $(as $node_name)? => $body);
     }
 }
 

--- a/rust/bridge/shared/src/support.rs
+++ b/rust/bridge/shared/src/support.rs
@@ -71,11 +71,13 @@ macro_rules! bridge_deserialize {
 }
 
 macro_rules! bridge_get_bytearray {
-    ($name:ident($typ:ty) $(, ffi = $ffi_name:ident)? $(, jni = $jni_name:ident)? => $body:expr ) => {
+    ($name:ident($typ:ty) $(, ffi = $ffi_name:ident)? $(, jni = $jni_name:ident)? $(, node = $node_name:ident)? => $body:expr ) => {
         #[cfg(feature = "ffi")]
         ffi_bridge_get_bytearray!($name($typ) $(as $ffi_name)? => $body);
         #[cfg(feature = "jni")]
         jni_bridge_get_bytearray!($name($typ) $(as $jni_name)? => $body);
+        #[cfg(feature = "node")]
+        node_bridge_get_bytearray!($name($typ) $(as $node_name)? => $body);
     }
 }
 

--- a/rust/bridge/shared/src/support.rs
+++ b/rust/bridge/shared/src/support.rs
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Signal Messenger, LLC.
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
@@ -96,19 +96,23 @@ macro_rules! bridge_get_optional_bytearray {
 }
 
 macro_rules! bridge_get_string {
-    ($name:ident($typ:ty) $(, ffi = $ffi_name:ident)? $(, jni = $jni_name:ident)? => $body:expr ) => {
+    ($name:ident($typ:ty) $(, ffi = $ffi_name:ident)? $(, jni = $jni_name:ident)? $(, node = $node_name:ident)? => $body:expr ) => {
         #[cfg(feature = "ffi")]
         ffi_bridge_get_string!($name($typ) $(as $ffi_name)? => $body);
         #[cfg(feature = "jni")]
         jni_bridge_get_string!($name($typ) $(as $jni_name)? => $body);
+        #[cfg(feature = "node")]
+        node_bridge_get_string!($name($typ) $(as $node_name)? => $body);
     }
 }
 
 macro_rules! bridge_get_optional_string {
-    ($name:ident($typ:ty) $(, ffi = $ffi_name:ident)? $(, jni = $jni_name:ident)? => $body:expr ) => {
+    ($name:ident($typ:ty) $(, ffi = $ffi_name:ident)? $(, jni = $jni_name:ident)? $(, node = $node_name:ident)? => $body:expr ) => {
         #[cfg(feature = "ffi")]
         ffi_bridge_get_optional_string!($name($typ) $(as $ffi_name)? => $body);
         #[cfg(feature = "jni")]
         jni_bridge_get_optional_string!($name($typ) $(as $jni_name)? => $body);
+        #[cfg(feature = "node")]
+        node_bridge_get_optional_string!($name($typ) $(as $node_name)? => $body);
     }
 }

--- a/rust/bridge/shared/src/support.rs
+++ b/rust/bridge/shared/src/support.rs
@@ -55,15 +55,18 @@ macro_rules! bridge_destroy {
         ffi_bridge_destroy!($typ $(as $ffi_name)?);
         #[cfg(feature = "jni")]
         jni_bridge_destroy!($typ $(as $jni_name)?);
+        // The Node bridge doesn't need manual destruction.
     }
 }
 
 macro_rules! bridge_deserialize {
-    ($typ:ident::$fn:path $(, ffi = $ffi_name:ident)? $(, jni = $jni_name:ident)? ) => {
+    ($typ:ident::$fn:path $(, ffi = $ffi_name:ident)? $(, jni = $jni_name:ident)? $(, node = $node_name:ident)? ) => {
         #[cfg(feature = "ffi")]
         ffi_bridge_deserialize!($typ::$fn $(as $ffi_name)?);
         #[cfg(feature = "jni")]
         jni_bridge_deserialize!($typ::$fn $(as $jni_name)?);
+        #[cfg(feature = "node")]
+        node_bridge_deserialize!($typ::$fn $(as $node_name)?);
     }
 }
 

--- a/rust/bridge/shared/src/support.rs
+++ b/rust/bridge/shared/src/support.rs
@@ -11,6 +11,7 @@ use std::task::{self, Poll};
 
 pub(crate) use paste::paste;
 
+#[allow(dead_code)] // not used in Node-only builds
 #[track_caller]
 pub fn expect_ready<F: Future>(future: F) -> F::Output {
     pin_mut!(future);
@@ -23,7 +24,7 @@ pub fn expect_ready<F: Future>(future: F) -> F::Output {
 /// Used for returning newly-allocated buffers as efficiently as possible.
 pub(crate) trait Env {
     type Buffer;
-    fn buffer<'a, T: Into<Cow<'a, [u8]>>>(&self, input: T) -> Self::Buffer;
+    fn buffer<'a, T: Into<Cow<'a, [u8]>>>(self, input: T) -> Self::Buffer;
 }
 
 /// Wraps an expression in a function with a given name and type...
@@ -46,6 +47,8 @@ macro_rules! bridge_handle {
         ffi_bridge_handle!($typ);
         #[cfg(feature = "jni")]
         jni_bridge_handle!($typ);
+        #[cfg(feature = "node")]
+        node_bridge_handle!($typ);
     };
 }
 


### PR DESCRIPTION
This should in theory give us *all* of the functions already in libsignal-bridge for free. There are a few complicated bits:

- Borrowing a JsBuffer requires the JS engine to be locked, but returning a new buffer requires using the JS engine. That means having to incur a copy-in (for `&[u8]` parameters) or a copy-out (for `&[u8]` results) unless we make `bridge_fn` signatures more complicated. For now I've gone with a copy-in because it was easier to implement, but a copy-out probably makes more sense in the long run.

- I wanted to avoid Neon's explicit registration list because it was one more thing to keep in sync, so I've used the [`linkme`](https://docs.rs/linkme/0.2.4/linkme/index.html) crate to have the linker build a static list that can be iterated through at runtime. If you think this is too much magic I'll drop it, though.

~~Still a draft because I built it on top of Neon 0.7.0, which I stole from the futures PR. I'll rebase on something else when we're ready to merge if we still don't have that in. (But meanwhile I'd want to port all the Swift-side tests we have to Node.)~~ Tests can come as we expose the various APIs in TypeScript.