### PR TITLE
Node: Add an entry point for logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,6 +802,7 @@ version = "0.1.0"
 dependencies = [
  "libsignal-bridge",
  "libsignal-protocol-rust",
+ "log",
  "neon",
  "neon-build 0.5.3",
  "rand",

--- a/node/index.ts
+++ b/node/index.ts
@@ -9,6 +9,8 @@ import * as SignalClient from './libsignal_client';
 
 const SC = bindings('libsignal_client_' + os.platform()) as typeof SignalClient;
 
+export const { initLogger, LogLevel } = SC;
+
 export class PublicKey {
   private readonly nativeHandle: SignalClient.PublicKey;
 

--- a/node/libsignal_client.d.ts
+++ b/node/libsignal_client.d.ts
@@ -30,3 +30,22 @@ export function PrivateKey_serialize(key: PrivateKey): Buffer;
 export function PrivateKey_sign(key: PrivateKey, msg: Buffer): Buffer;
 export function PrivateKey_agree(key: PrivateKey, other_key: PublicKey): Buffer;
 export function PrivateKey_getPublicKey(key: PrivateKey): PublicKey;
+
+export const enum LogLevel {
+  Error = 1,
+  Warn,
+  Info,
+  Debug,
+  Trace,
+}
+
+export function initLogger(
+  maxLevel: LogLevel,
+  callback: (
+    level: LogLevel,
+    target: string,
+    file: string | null,
+    line: number | null,
+    message: string
+  ) => void
+): void;

--- a/node/test/PublicAPITest.ts
+++ b/node/test/PublicAPITest.ts
@@ -1,10 +1,21 @@
 //
-// Copyright 2020 Signal Messenger, LLC.
+// Copyright 2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
 import { assert } from 'chai';
 import * as SignalClient from '../index';
+
+SignalClient.initLogger(
+  SignalClient.LogLevel.Trace,
+  (level, target, fileOrNull, lineOrNull, message) => {
+    const targetPrefix = target ? '[' + target + '] ' : '';
+    const file = fileOrNull ?? '<unknown>';
+    const line = lineOrNull ?? 0;
+    // eslint-disable-next-line no-console
+    console.log(targetPrefix + file + ':' + line + ': ' + message);
+  }
+);
 
 describe('SignalClient', () => {
   it('ECC signatures work', () => {

--- a/rust/bridge/node/Cargo.toml
+++ b/rust/bridge/node/Cargo.toml
@@ -20,5 +20,6 @@ neon-build = "0.5.0"
 [dependencies]
 libsignal-protocol-rust = { path = "../../protocol" }
 libsignal-bridge = { path = "../shared", features = ["node"] }
-neon = { version = "0.7", default-features = false, features = ["napi-1"] }
+neon = { version = "0.7", default-features = false, features = ["napi-1", "event-queue-api"] }
 rand = "0.7.3"
+log = "0.4.11"

--- a/rust/bridge/node/src/lib.rs
+++ b/rust/bridge/node/src/lib.rs
@@ -5,8 +5,11 @@
 
 use neon::prelude::*;
 
+pub mod logging;
+
 #[neon::main]
 fn main(mut cx: ModuleContext) -> NeonResult<()> {
     libsignal_bridge::node::register(&mut cx)?;
+    cx.export_function("initLogger", logging::init_logger)?;
     Ok(())
 }

--- a/rust/bridge/node/src/logging.rs
+++ b/rust/bridge/node/src/logging.rs
@@ -1,0 +1,147 @@
+//
+// Copyright 2021 Signal Messenger, LLC.
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+use libsignal_bridge::node::ArgTypeInfo;
+use neon::prelude::*;
+
+// Keep this in sync with libsignal_client.d.ts, as well as the list below.
+#[derive(Clone, Copy)]
+enum LogLevel {
+    Error = 1,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl From<log::Level> for LogLevel {
+    fn from(level: log::Level) -> Self {
+        use log::Level::*;
+        match level {
+            Error => Self::Error,
+            Warn => Self::Warn,
+            Info => Self::Info,
+            Debug => Self::Debug,
+            Trace => Self::Trace,
+        }
+    }
+}
+
+impl From<LogLevel> for log::Level {
+    fn from(level: LogLevel) -> Self {
+        use LogLevel::*;
+        match level {
+            Error => Self::Error,
+            Warn => Self::Warn,
+            Info => Self::Info,
+            Debug => Self::Debug,
+            Trace => Self::Trace,
+        }
+    }
+}
+
+impl From<LogLevel> for u32 {
+    fn from(level: LogLevel) -> Self {
+        level as u32
+    }
+}
+
+struct NodeLogger {
+    queue: EventQueue,
+}
+
+impl NodeLogger {
+    fn new(cx: &mut FunctionContext) -> Self {
+        let mut queue = cx.queue();
+        queue.unref(cx);
+        Self { queue }
+    }
+}
+
+const GLOBAL_LOG_FN_KEY: &str = "__libsignal_log_fn";
+
+impl log::Log for NodeLogger {
+    fn enabled(&self, _metadata: &log::Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &log::Record) {
+        let target = record.target().to_string();
+        let file = record.file().map(|s| s.to_string());
+        let line = record.line();
+        let message = record.args().to_string();
+        let level = record.level();
+        self.queue
+            .try_send(move |mut cx| {
+                let level_arg: Handle<JsValue> =
+                    cx.number(u32::from(LogLevel::from(level))).upcast();
+                let target_arg: Handle<JsValue> = cx.string(target).upcast();
+                let file_arg: Handle<JsValue> = match file {
+                    Some(file) => cx.string(file).upcast(),
+                    None => cx.null().upcast(),
+                };
+                let line_arg: Handle<JsValue> = match line {
+                    Some(line) => cx.number(line as f64).upcast(),
+                    None => cx.null().upcast(),
+                };
+                let message_arg: Handle<JsValue> = cx.string(message).upcast();
+
+                let global_obj = cx.global();
+                let log_fn = global_obj
+                    .get(&mut cx, GLOBAL_LOG_FN_KEY)?
+                    .downcast_or_throw::<JsFunction, _>(&mut cx)?;
+                let undef = cx.undefined();
+                log_fn.call(
+                    &mut cx,
+                    undef,
+                    vec![level_arg, target_arg, file_arg, line_arg, message_arg],
+                )?;
+                Ok(())
+            })
+            .unwrap_or_else(|_| {
+                // Drop the error; it's not like we can log it!
+                // Most likely the Node event loop has already shut down.
+            });
+    }
+
+    fn flush(&self) {}
+}
+
+fn set_max_level_from_js_level(max_level: u32) {
+    // Keep this in sync with libsignal_client.d.ts.
+    let level = match max_level {
+        1 => LogLevel::Error,
+        2 => LogLevel::Warn,
+        3 => LogLevel::Info,
+        4 => LogLevel::Debug,
+        5 => LogLevel::Trace,
+        _ => panic!("invalid log level"),
+    };
+    assert!(u32::from(level) == max_level);
+
+    log::set_max_level(log::Level::from(level).to_level_filter());
+}
+
+pub(crate) fn init_logger(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    let max_level_arg = cx.argument::<JsNumber>(0)?;
+    let max_level = u32::convert_from(&mut cx, max_level_arg)?;
+    let callback = cx.argument::<JsFunction>(1)?;
+
+    let global = cx.global();
+    global.set(&mut cx, GLOBAL_LOG_FN_KEY, callback)?;
+
+    let logger = NodeLogger::new(&mut cx);
+    match log::set_logger(Box::leak(Box::new(logger))) {
+        Ok(_) => {
+            set_max_level_from_js_level(max_level);
+            log::debug!("logging initialized for libsignal-client");
+        }
+        Err(_) => {
+            log::warn!("logging already initialized for libsignal-client; ignoring later call");
+        }
+    }
+
+    Ok(cx.undefined())
+}

--- a/rust/bridge/shared/src/node/convert.rs
+++ b/rust/bridge/shared/src/node/convert.rs
@@ -8,7 +8,7 @@ use std::borrow::Cow;
 use std::convert::TryInto;
 use std::ops::{Deref, RangeInclusive};
 
-pub(crate) trait ArgTypeInfo<'a>: Sized {
+pub trait ArgTypeInfo<'a>: Sized {
     type ArgType: neon::types::Value;
     fn convert_from(
         cx: &mut FunctionContext<'a>,

--- a/rust/bridge/shared/src/node/mod.rs
+++ b/rust/bridge/shared/src/node/mod.rs
@@ -12,6 +12,7 @@ pub use neon::prelude::*;
 
 #[macro_use]
 mod convert;
+pub use convert::ArgTypeInfo;
 pub(crate) use convert::*;
 
 pub type JsFn = for<'a> fn(FunctionContext<'a>) -> JsResult<'a, JsValue>;


### PR DESCRIPTION
Sketch out a logging callback for Node clients, like #150 for Java and #90 for Swift.