### PR TITLE
Node: bridge_fn shouldn't care about refs vs values at the macro level

### DIFF
--- a/rust/bridge/node/src/logging.rs
+++ b/rust/bridge/node/src/logging.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use libsignal_bridge::node::ArgTypeInfo;
+use libsignal_bridge::node::SimpleArgTypeInfo;
 use neon::prelude::*;
 
 /// ts: export const enum LogLevel { Error, Warn, Info, Debug, Trace }

--- a/rust/bridge/shared/macros/src/lib.rs
+++ b/rust/bridge/shared/macros/src/lib.rs
@@ -266,25 +266,13 @@ fn node_bridge_fn(name: String, sig: &Signature, result_kind: ResultKind) -> Tok
                 attrs: _,
                 pat: box Pat::Ident(name),
                 colon_token: _,
-                ty: ty @ box Type::Reference(_),
-            }) => (
-                name.ident.clone(),
-                quote!(
-                    let #name = cx.argument::<<#ty as node::RefArgTypeInfo>::ArgType>(#i)?;
-                    let #name = <#ty as node::RefArgTypeInfo>::convert_from(&mut cx, #name)?;
-                    let #name = &*#name
-                ),
-            ),
-            FnArg::Typed(PatType {
-                attrs: _,
-                pat: box Pat::Ident(name),
-                colon_token: _,
                 ty,
             }) => (
                 name.ident.clone(),
                 quote!(
                     let #name = cx.argument::<<#ty as node::ArgTypeInfo>::ArgType>(#i)?;
-                    let #name = <#ty as node::ArgTypeInfo>::convert_from(&mut cx, #name)?
+                    let mut #name = <#ty as node::ArgTypeInfo>::borrow(&mut cx, #name)?;
+                    let #name = <#ty as node::ArgTypeInfo>::load_from(&mut cx, &mut #name)?;
                 ),
             ),
             FnArg::Typed(PatType { pat, .. }) => (

--- a/rust/bridge/shared/src/node/mod.rs
+++ b/rust/bridge/shared/src/node/mod.rs
@@ -12,7 +12,7 @@ pub use neon::prelude::*;
 
 #[macro_use]
 mod convert;
-pub use convert::ArgTypeInfo;
+pub use convert::SimpleArgTypeInfo;
 pub(crate) use convert::*;
 
 pub type JsFn = for<'a> fn(FunctionContext<'a>) -> JsResult<'a, JsValue>;


### PR DESCRIPTION
Follow-up from the similar change for JNI, #157. This should hopefully be simpler going forward.