### PR TITLE
Compatibility with cocoapods-binary

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -255,12 +255,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Check out SignalCoreKit
-        uses: actions/checkout@v2
-        with:
-          repository: signalapp/SignalCoreKit
-          path: SignalCoreKit
-
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -269,7 +263,7 @@ jobs:
 
       - name: Run pod lint
         # No import validation because it tries to build unsupported platforms (like 32-bit iOS).
-        run: pod lib lint --verbose --platforms=ios --include-podspecs=SignalCoreKit/SignalCoreKit.podspec --skip-import-validation
+        run: pod lib lint --verbose --platforms=ios --skip-import-validation
         env:
           XCODE_XCCONFIG_FILE: swift/PodLibLint.xcconfig
 

--- a/SignalClient.podspec
+++ b/SignalClient.podspec
@@ -18,7 +18,13 @@ Pod::Spec.new do |s|
 
   s.dependency 'CocoaLumberjack/Swift'
 
-  s.source_files = ['swift/Sources/**/*.swift', 'swift/Sources/**/*.m']
+  s.source_files = [
+    'swift/Sources/**/*.swift',
+    'swift/Sources/**/*.m',
+    # FIXME: We'd like to hide this from downstream clients at some point.
+    # (Making this header accessible to both CocoaPods and SwiftPM is hard.)
+    'swift/Sources/SignalFfi/signal_ffi.h'
+  ]
   s.preserve_paths = [
     'bin/*',
     'Cargo.toml',
@@ -26,17 +32,12 @@ Pod::Spec.new do |s|
     'rust-toolchain',
     'rust/*',
     'swift/*.sh',
-    'swift/Sources/SignalFfi',
   ]
 
   s.pod_target_xcconfig = {
       'CARGO_BUILD_TARGET_DIR' => '$(DERIVED_FILE_DIR)/libsignal-ffi',
       'CARGO_PROFILE_RELEASE_DEBUG' => '1', # enable line tables
       'LIBSIGNAL_FFI_DIR' => '$(CARGO_BUILD_TARGET_DIR)/$(CARGO_BUILD_TARGET)/release',
-
-      'HEADER_SEARCH_PATHS' => '$(PODS_TARGET_SRCROOT)/swift/Sources/SignalFfi',
-      # Duplicate this here to make sure the search path is passed on to Swift dependencies.
-      'SWIFT_INCLUDE_PATHS' => '$(HEADER_SEARCH_PATHS)',
 
       # Make sure we link the static library, not a dynamic one.
       # Use an extra level of indirection because CocoaPods messes with OTHER_LDFLAGS too.

--- a/SignalClient.podspec
+++ b/SignalClient.podspec
@@ -53,9 +53,9 @@ Pod::Spec.new do |s|
   }
 
   s.script_phases = [
-    { :name => 'Build libsignal-ffi',
+    { :name => 'Build libsignal-ffi (if not prebuilt)',
       :execution_position => :before_compile,
-      :script => '"${PODS_TARGET_SRCROOT}/swift/build_ffi.sh"',
+      :script => 'if [[ -n "${PRODUCT_TYPE}" ]]; then "${PODS_TARGET_SRCROOT}/swift/build_ffi.sh"; fi',
     }
   ]
 

--- a/SignalClient.podspec
+++ b/SignalClient.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.swift_version    = '5'
   s.platform = :ios, '10'
 
-  s.dependency 'SignalCoreKit'
+  s.dependency 'CocoaLumberjack/Swift'
 
   s.source_files = ['swift/Sources/**/*.swift', 'swift/Sources/**/*.m']
   s.preserve_paths = [

--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -8,6 +8,11 @@
 import PackageDescription
 
 let rustBuildDir = "../target/debug/"
+let autoImportSignalFfi = [
+    // Use an undocumented, unstable flag to avoid mentioning SignalFfi in source files.
+    // (Making this header accessible to both CocoaPods and SwiftPM is hard.)
+    "-Xfrontend", "-import-module", "-Xfrontend", "SignalFfi"
+]
 
 let package = Package(
     name: "SignalClient",
@@ -23,11 +28,13 @@ let package = Package(
         .target(
             name: "SignalClient",
             dependencies: ["SignalFfi"],
-            exclude: ["Logging.m"]
+            exclude: ["Logging.m"],
+            swiftSettings: [.unsafeFlags(autoImportSignalFfi)]
         ),
         .testTarget(
             name: "SignalClientTests",
             dependencies: ["SignalClient"],
+            swiftSettings: [.unsafeFlags(autoImportSignalFfi)],
             linkerSettings: [.unsafeFlags(["\(rustBuildDir)/libsignal_ffi.a"])]
         )
     ]

--- a/swift/Sources/SignalClient/Address.swift
+++ b/swift/Sources/SignalClient/Address.swift
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-import SignalFfi
-
 public class ProtocolAddress: ClonableHandleOwner {
     public init(name: String, deviceId: UInt32) throws {
         var handle: OpaquePointer?

--- a/swift/Sources/SignalClient/Aes256GcmSiv.swift
+++ b/swift/Sources/SignalClient/Aes256GcmSiv.swift
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-import SignalFfi
 import Foundation
 
 public class Aes256GcmSiv: ClonableHandleOwner {

--- a/swift/Sources/SignalClient/DataStoreProtocols.swift
+++ b/swift/Sources/SignalClient/DataStoreProtocols.swift
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-import SignalFfi
-
 public enum Direction {
     case sending
     case receiving

--- a/swift/Sources/SignalClient/Error.swift
+++ b/swift/Sources/SignalClient/Error.swift
@@ -1,12 +1,12 @@
 //
-// Copyright 2020 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
 import SignalFfi
 
-#if canImport(SignalCoreKit)
-import SignalCoreKit
+#if canImport(CocoaLumberjack)
+import CocoaLumberjack
 #endif
 
 public enum SignalError: Error {
@@ -103,16 +103,23 @@ internal func checkError(_ error: SignalFfiErrorRef?) throws {
     }
 }
 
-internal func failOnError(_ error: SignalFfiErrorRef?) {
-    failOnError { try checkError(error) }
+internal func failOnError(_ error: SignalFfiErrorRef?,
+                          file: StaticString = #file,
+                          function: StaticString = #function,
+                          line: UInt = #line) {
+    failOnError(file: file, function: function, line: line) { try checkError(error) }
 }
 
-internal func failOnError<Result>(_ fn: () throws -> Result) -> Result {
-#if canImport(SignalCoreKit)
+internal func failOnError<Result>(file: StaticString = #file,
+                                  function: StaticString = #function,
+                                  line: UInt = #line,
+                                  _ fn: () throws -> Result) -> Result {
+#if canImport(CocoaLumberjack)
     do {
         return try fn()
     } catch {
-        owsFail("unexpected error: \(error)")
+        DDLogError("❤️ \(error)", file: file, function: function, line: line)
+        fatalError("\(error)")
     }
 #else
     return try! fn()

--- a/swift/Sources/SignalClient/Error.swift
+++ b/swift/Sources/SignalClient/Error.swift
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-import SignalFfi
-
 #if canImport(CocoaLumberjack)
 import CocoaLumberjack
 #endif

--- a/swift/Sources/SignalClient/Fingerprint.swift
+++ b/swift/Sources/SignalClient/Fingerprint.swift
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-import SignalFfi
 import Foundation
 
 public struct DisplayableFingerprint {

--- a/swift/Sources/SignalClient/IdentityKey.swift
+++ b/swift/Sources/SignalClient/IdentityKey.swift
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-import SignalFfi
 import Foundation
 
 public struct IdentityKey: Equatable {

--- a/swift/Sources/SignalClient/Kdf.swift
+++ b/swift/Sources/SignalClient/Kdf.swift
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-import SignalFfi
 import Foundation
 
 public func hkdf<InputBytes, SaltBytes, InfoBytes>(outputLength: Int,

--- a/swift/Sources/SignalClient/Logging.m
+++ b/swift/Sources/SignalClient/Logging.m
@@ -1,27 +1,55 @@
 //
-// Copyright 2020 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
 #import "signal_ffi.h"
-#import <SignalCoreKit/OWSLogs.h>
+#import <CocoaLumberjack/CocoaLumberjack.h>
+
+#ifdef DEBUG
+static const NSUInteger ddLogLevel = DDLogLevelAll;
+#else
+static const NSUInteger ddLogLevel = DDLogLevelInfo;
+#endif
+
+// Matches the behavior of SignalCoreKit.
+static const char *getPrefix(SignalLogLevel level)
+{
+    switch (level) {
+        case SignalLogLevel_Trace:
+            return u8"💙";
+        case SignalLogLevel_Debug:
+            return u8"💚";
+        case SignalLogLevel_Info:
+            return u8"💛";
+        case SignalLogLevel_Warn:
+            return u8"🧡";
+        case SignalLogLevel_Error:
+        default:
+            return u8"❤️";
+    }
+}
+
+static DDLogFlag getDDLogFlag(SignalLogLevel level)
+{
+    switch (level) {
+        case SignalLogLevel_Trace:
+            return DDLogFlagVerbose;
+        case SignalLogLevel_Debug:
+            return DDLogFlagDebug;
+        case SignalLogLevel_Info:
+            return DDLogFlagInfo;
+        case SignalLogLevel_Warn:
+            return DDLogFlagWarning;
+        case SignalLogLevel_Error:
+        default:
+            return DDLogFlagError;
+    }
+}
 
 static bool isEnabled(const char *_Nonnull target, SignalLogLevel level)
 {
-    switch (level) {
-        case SignalLogLevel_Error:
-            return ShouldLogError();
-        case SignalLogLevel_Warn:
-            return ShouldLogWarning();
-        case SignalLogLevel_Info:
-            return ShouldLogInfo();
-        case SignalLogLevel_Debug:
-            return ShouldLogDebug();
-        case SignalLogLevel_Trace:
-            return ShouldLogVerbose();
-        default:
-            return ShouldLogError();
-    }
+    return ddLogLevel >= getDDLogFlag(level);
 }
 
 static void logMessage(const char *_Nonnull target,
@@ -34,43 +62,33 @@ static void logMessage(const char *_Nonnull target,
         return;
     }
 
-    // We're not using OWSLog* directly because we don't want log() to be the source of the log.
-    NSString *formattedMessage;
+    const char *prefix = getPrefix(level);
+
+    NSString *format;
     if (file) {
-        formattedMessage = [NSString stringWithFormat:@"[%s:%u] %s", file, line, message];
+        format = @"%1$s [%3$s:%4$u] %2$s";
     } else {
-        formattedMessage = [NSString stringWithUTF8String:message];
+        format = @"%1$s %2$s";
     }
 
-    switch (level) {
-        case SignalLogLevel_Error:
-            [OWSLogger error:formattedMessage];
-            break;
-        case SignalLogLevel_Warn:
-            [OWSLogger warn:formattedMessage];
-            break;
-        case SignalLogLevel_Info:
-            [OWSLogger info:formattedMessage];
-            break;
-        case SignalLogLevel_Debug:
-            [OWSLogger debug:formattedMessage];
-            break;
-        case SignalLogLevel_Trace:
-            [OWSLogger verbose:formattedMessage];
-            break;
-        default:
-            [OWSLogger error:formattedMessage];
-            break;
-    }
+    [DDLog log:(level != SignalLogLevel_Error)
+         level:ddLogLevel
+          flag:getDDLogFlag(level)
+       context:0
+          file:file ? file : "<SignalClient>"
+      function:NULL
+          line:line
+           tag:nil
+        format:format, prefix, message, file, line];
 }
 
 static void flush()
 {
-    OWSLogFlush();
+    [DDLog flushLog];
 }
 
 __attribute__((constructor)) static void initLogging()
 {
-    SignalLogLevel logLevel = ShouldLogDebug() ? SignalLogLevel_Trace : SignalLogLevel_Info;
+    SignalLogLevel logLevel = isEnabled("", SignalLogLevel_Trace) ? SignalLogLevel_Trace : SignalLogLevel_Info;
     signal_init_logger(logLevel, (SignalFfiLogger) { .enabled = isEnabled, .log = logMessage, .flush = flush });
 }

--- a/swift/Sources/SignalClient/PrivateKey.swift
+++ b/swift/Sources/SignalClient/PrivateKey.swift
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-import SignalFfi
 import Foundation
 
 public class PrivateKey: ClonableHandleOwner {

--- a/swift/Sources/SignalClient/Protocol.swift
+++ b/swift/Sources/SignalClient/Protocol.swift
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-import SignalFfi
 import Foundation
 
 /*

--- a/swift/Sources/SignalClient/PublicKey.swift
+++ b/swift/Sources/SignalClient/PublicKey.swift
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-import SignalFfi
 import Foundation
 
 public class PublicKey: ClonableHandleOwner {

--- a/swift/Sources/SignalClient/SealedSender.swift
+++ b/swift/Sources/SignalClient/SealedSender.swift
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-import SignalFfi
 import Foundation
 
 public class ServerCertificate: ClonableHandleOwner {

--- a/swift/Sources/SignalClient/SenderKeyName.swift
+++ b/swift/Sources/SignalClient/SenderKeyName.swift
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-import SignalFfi
-
 public class SenderKeyName: ClonableHandleOwner {
     internal override class func destroyNativeHandle(_ handle: OpaquePointer) -> SignalFfiErrorRef? {
         return signal_sender_key_name_destroy(handle)

--- a/swift/Sources/SignalClient/Utils.swift
+++ b/swift/Sources/SignalClient/Utils.swift
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-import SignalFfi
-
 internal func invokeFnReturningString(fn: (UnsafeMutablePointer<UnsafePointer<CChar>?>?) -> SignalFfiErrorRef?) throws -> String {
     var output: UnsafePointer<Int8>?
     try checkError(fn(&output))

--- a/swift/Sources/SignalClient/messages/CiphertextMessage.swift
+++ b/swift/Sources/SignalClient/messages/CiphertextMessage.swift
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-import SignalFfi
-
 public class CiphertextMessage {
     private var handle: OpaquePointer?
 

--- a/swift/Sources/SignalClient/messages/PreKeySignalMessage.swift
+++ b/swift/Sources/SignalClient/messages/PreKeySignalMessage.swift
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-import SignalFfi
 import Foundation
 
 public class PreKeySignalMessage {

--- a/swift/Sources/SignalClient/messages/SenderKeyDistributionMessage.swift
+++ b/swift/Sources/SignalClient/messages/SenderKeyDistributionMessage.swift
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-import SignalFfi
 import Foundation
 
 public class SenderKeyDistributionMessage {

--- a/swift/Sources/SignalClient/messages/SenderKeyMessage.swift
+++ b/swift/Sources/SignalClient/messages/SenderKeyMessage.swift
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-import SignalFfi
 import Foundation
 
 public class SenderKeyMessage {

--- a/swift/Sources/SignalClient/messages/SignalMessage.swift
+++ b/swift/Sources/SignalClient/messages/SignalMessage.swift
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-import SignalFfi
 import Foundation
 
 public class SignalMessage {

--- a/swift/Sources/SignalClient/state/PreKeyBundle.swift
+++ b/swift/Sources/SignalClient/state/PreKeyBundle.swift
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-import SignalFfi
 import Foundation
 
 public class PreKeyBundle {

--- a/swift/Sources/SignalClient/state/PreKeyRecord.swift
+++ b/swift/Sources/SignalClient/state/PreKeyRecord.swift
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-import SignalFfi
 import Foundation
 
 public class PreKeyRecord: ClonableHandleOwner {

--- a/swift/Sources/SignalClient/state/SenderKeyRecord.swift
+++ b/swift/Sources/SignalClient/state/SenderKeyRecord.swift
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-import SignalFfi
 import Foundation
 
 public class SenderKeyRecord: ClonableHandleOwner {

--- a/swift/Sources/SignalClient/state/SessionRecord.swift
+++ b/swift/Sources/SignalClient/state/SessionRecord.swift
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-import SignalFfi
 import Foundation
 
 public class SessionRecord: ClonableHandleOwner {

--- a/swift/Sources/SignalClient/state/SignedPreKeyRecord.swift
+++ b/swift/Sources/SignalClient/state/SignedPreKeyRecord.swift
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-import SignalFfi
 import Foundation
 
 public class SignedPreKeyRecord: ClonableHandleOwner {

--- a/swift/Sources/SignalFfi/module.modulemap
+++ b/swift/Sources/SignalFfi/module.modulemap
@@ -4,5 +4,4 @@
 //
 module SignalFfi {
 	header "signal_ffi.h"
-	link "signal_ffi"
 }

--- a/swift/Tests/SignalClientTests/TestCaseBase.swift
+++ b/swift/Tests/SignalClientTests/TestCaseBase.swift
@@ -6,14 +6,14 @@
 import XCTest
 import SignalFfi
 
-#if canImport(SignalCoreKit)
-import SignalCoreKit
+#if canImport(CocoaLumberjack)
+import CocoaLumberjack
 #endif
 
 class TestCaseBase: XCTestCase {
     // Use a static stored property for one-time initialization.
     static let loggingInitialized: Bool = {
-#if canImport(SignalCoreKit)
+#if canImport(CocoaLumberjack)
         DDLog.add(DDOSLogger.sharedInstance)
 #else
         signal_init_logger(SignalLogLevel_Trace, .init(

--- a/swift/Tests/SignalClientTests/TestCaseBase.swift
+++ b/swift/Tests/SignalClientTests/TestCaseBase.swift
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+import SignalClient
 import XCTest
-import SignalFfi
 
 #if canImport(CocoaLumberjack)
 import CocoaLumberjack


### PR DESCRIPTION
Three changes that allow libsignal-client to be prebuilt for iOS clients using [cocoapods-binary](https://github.com/leavez/cocoapods-binary):
- Use CocoaLumberjack directly instead of SignalCoreKit's OWSLog
- Move signal_ffi.h into SignalClient.framework (and add a hacky unstable compiler flag to keep the SwiftPM build working)
- Skip build_ffi.sh when the pod is prebuilt 