### PR TITLE
Support &mut arguments and Result<(), Error> results

### DIFF
--- a/java/java/src/main/java/org/signal/internal/Native.java
+++ b/java/java/src/main/java/org/signal/internal/Native.java
@@ -210,7 +210,7 @@ public final class Native {
   public static native byte[] SessionCipher_DecryptSignalMessage(long message, long protocolAddress, SessionStore sessionStore, IdentityKeyStore identityKeyStore);
   public static native CiphertextMessage SessionCipher_EncryptMessage(byte[] message, long protocolAddress, SessionStore sessionStore, IdentityKeyStore identityKeyStore);
 
-  public static native void SessionRecord_ArchiveCurrentState(long handle);
+  public static native void SessionRecord_ArchiveCurrentState(long sessionRecord);
   public static native long SessionRecord_Deserialize(byte[] data);
   public static native void SessionRecord_Destroy(long handle);
   public static native long SessionRecord_FromSingleSessionState(byte[] sessionState);

--- a/node/libsignal_client.d.ts
+++ b/node/libsignal_client.d.ts
@@ -90,6 +90,7 @@ export function ServerCertificate_GetKeyId(obj: ServerCertificate): number;
 export function ServerCertificate_GetSerialized(obj: ServerCertificate): Buffer;
 export function ServerCertificate_GetSignature(obj: ServerCertificate): Buffer;
 export function ServerCertificate_New(keyId: number, serverKey: PublicKey, trustRoot: PrivateKey): ServerCertificate;
+export function SessionRecord_ArchiveCurrentState(sessionRecord: SessionRecord): void;
 export function SessionRecord_Deserialize(buffer: Buffer): SessionRecord;
 export function SessionRecord_GetLocalRegistrationId(obj: SessionRecord): number;
 export function SessionRecord_GetRemoteRegistrationId(obj: SessionRecord): number;

--- a/rust/bridge/ffi/src/lib.rs
+++ b/rust/bridge/ffi/src/lib.rs
@@ -125,17 +125,6 @@ pub unsafe extern "C" fn signal_identitykeypair_deserialize(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn signal_session_record_archive_current_state(
-    session_record: *mut SessionRecord,
-) -> *mut SignalFfiError {
-    run_ffi_safe(|| {
-        let session_record = native_handle_cast_mut::<SessionRecord>(session_record)?;
-        session_record.archive_current_state()?;
-        Ok(())
-    })
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn signal_session_record_has_current_state(
     result: *mut bool,
     session_record: *const SessionRecord,

--- a/rust/bridge/ffi/src/util.rs
+++ b/rust/bridge/ffi/src/util.rs
@@ -194,14 +194,6 @@ pub unsafe fn as_slice_mut<'a>(
     Ok(std::slice::from_raw_parts_mut(input, input_len as usize))
 }
 
-pub unsafe fn native_handle_cast_mut<T>(handle: *mut T) -> Result<&'static mut T, SignalFfiError> {
-    if handle.is_null() {
-        return Err(SignalFfiError::NullPointer);
-    }
-
-    Ok(&mut *handle)
-}
-
 pub unsafe fn read_optional_c_string(
     cstr: *const c_char,
 ) -> Result<Option<String>, SignalFfiError> {

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -951,19 +951,6 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_GroupCipher_1Dec
 
 // SessionRecord
 #[no_mangle]
-pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SessionRecord_1ArchiveCurrentState(
-    env: JNIEnv,
-    _class: JClass,
-    handle: ObjectHandle,
-) {
-    run_ffi_safe(&env, || {
-        let session_record = native_handle_cast::<SessionRecord>(handle)?;
-        session_record.archive_current_state()?;
-        Ok(())
-    })
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn Java_org_signal_client_internal_Native_SessionRecord_1NewFresh(
     env: JNIEnv,
     _class: JClass,

--- a/rust/bridge/node/bin/gen_ts_decl.py
+++ b/rust/bridge/node/bin/gen_ts_decl.py
@@ -37,6 +37,9 @@ def translate_to_ts(typ):
     if typ in type_map:
         return type_map[typ]
 
+    if typ.startswith('&mut'):
+        return typ[4:]
+
     if typ.startswith('&'):
         return typ[1:]
 

--- a/rust/bridge/shared/src/ffi/convert.rs
+++ b/rust/bridge/shared/src/ffi/convert.rs
@@ -152,6 +152,13 @@ macro_rules! ffi_bridge_handle {
                 }
             }
         }
+        impl ffi::ArgTypeInfo for &'static mut $typ {
+            type ArgType = *mut $typ;
+            #[allow(clippy::not_unsafe_ptr_arg_deref)]
+            fn convert_from(foreign: *mut $typ) -> Result<Self, ffi::SignalFfiError> {
+                unsafe { ffi::native_handle_cast_mut(foreign) }
+            }
+        }
         impl ffi::ResultTypeInfo for $typ {
             type ResultType = *mut $typ;
             fn convert_into(self) -> Result<Self::ResultType, ffi::SignalFfiError> {
@@ -225,6 +232,7 @@ macro_rules! ffi_arg_type {
     (String) => (*const libc::c_char);
     (Option<String>) => (*const libc::c_char);
     (& $typ:ty) => (*const $typ);
+    (&mut $typ:ty) => (*mut $typ);
     (Option<& $typ:ty>) => (*const $typ);
 }
 

--- a/rust/bridge/shared/src/ffi/mod.rs
+++ b/rust/bridge/shared/src/ffi/mod.rs
@@ -58,6 +58,14 @@ pub unsafe fn native_handle_cast<T>(handle: *const T) -> Result<&'static T, Sign
     Ok(&*(handle))
 }
 
+pub unsafe fn native_handle_cast_mut<T>(handle: *mut T) -> Result<&'static mut T, SignalFfiError> {
+    if handle.is_null() {
+        return Err(SignalFfiError::NullPointer);
+    }
+
+    Ok(&mut *handle)
+}
+
 pub unsafe fn write_bytearray_to<T: Into<Box<[u8]>>>(
     out: *mut *const c_uchar,
     out_len: *mut size_t,

--- a/rust/bridge/shared/src/jni/convert.rs
+++ b/rust/bridge/shared/src/jni/convert.rs
@@ -222,6 +222,15 @@ macro_rules! jni_bridge_handle {
                 }
             }
         }
+        impl<'a> jni::SimpleArgTypeInfo<'a> for &mut $typ {
+            type ArgType = jni::ObjectHandle;
+            fn convert_from(
+                _env: &jni::JNIEnv,
+                foreign: Self::ArgType,
+            ) -> Result<Self, jni::SignalJniError> {
+                Ok(unsafe { jni::native_handle_cast(foreign) }?)
+            }
+        }
         impl jni::ResultTypeInfo for $typ {
             type ResultType = jni::ObjectHandle;
             fn convert_into(
@@ -271,6 +280,7 @@ macro_rules! trivial {
 
 trivial!(i32);
 trivial!(jbyteArray);
+trivial!(());
 
 macro_rules! jni_arg_type {
     (u8) => {
@@ -295,6 +305,9 @@ macro_rules! jni_arg_type {
         jni::jbyteArray
     };
     (& $typ:ty) => {
+        jni::ObjectHandle
+    };
+    (&mut $typ:ty) => {
         jni::ObjectHandle
     };
     (Option<& $typ:ty>) => {

--- a/rust/bridge/shared/src/lib.rs
+++ b/rust/bridge/shared/src/lib.rs
@@ -577,6 +577,13 @@ fn SessionRecord_GetSessionVersion(s: &SessionRecord) -> Result<u32, SignalProto
     }
 }
 
+#[bridge_fn_void]
+fn SessionRecord_ArchiveCurrentState(
+    session_record: &mut SessionRecord,
+) -> Result<(), SignalProtocolError> {
+    session_record.archive_current_state()
+}
+
 bridge_deserialize!(SessionRecord::deserialize);
 bridge_get_bytearray!(Serialize(SessionRecord) => SessionRecord::serialize);
 bridge_get_bytearray!(GetAliceBaseKey(SessionRecord), ffi = false, node = false =>

--- a/rust/bridge/shared/src/lib.rs
+++ b/rust/bridge/shared/src/lib.rs
@@ -44,7 +44,7 @@ bridge_handle!(SenderKeyMessage);
 bridge_handle!(SenderKeyName);
 bridge_handle!(SenderKeyRecord);
 bridge_handle!(ServerCertificate);
-bridge_handle!(SessionRecord);
+bridge_handle!(SessionRecord, mut = true);
 bridge_handle!(SignalMessage, ffi = message);
 bridge_handle!(SignedPreKeyRecord);
 bridge_handle!(UnidentifiedSenderMessage, ffi = false, node = false);

--- a/rust/bridge/shared/src/node/convert.rs
+++ b/rust/bridge/shared/src/node/convert.rs
@@ -269,6 +269,10 @@ impl<'a, T: Value> ResultTypeInfo<'a> for Handle<'a, T> {
     }
 }
 
+pub(crate) unsafe fn extend_lifetime_to_static<T>(some_ref: &T) -> &'static T {
+    std::mem::transmute::<&'_ T, &'static T>(some_ref)
+}
+
 macro_rules! node_bridge_handle {
     ( $typ:ty as false ) => {};
     ( $typ:ty as $node_name:ident ) => {
@@ -302,9 +306,47 @@ macro_rules! node_bridge_handle {
             }
         }
     };
-    ( $typ:ty ) => {
+    ( $typ:ty as $node_name:ident, mut = true ) => {
+        impl<'a> node::ArgTypeInfo<'a> for &'a $typ {
+            type ArgType = node::DefaultJsBox<std::cell::RefCell<$typ>>;
+            // The lifetime of the boxed RefCell is necessarily longer than the lifetime of any handles referring to it.
+            // However, Deref'ing a Handle can only give us a Ref whose lifetime matches a *particular* handle.
+            // Since we can't introduce a new lifetime "just longer than 'a", we erase it to 'static instead, and store a Handle alongside it to prove that the value is still alive.
+            // (Handle isn't actually responsible for this, as a Copy type, but even so.)
+            // We know the RefCell can't move because we can't know how many JS references there are referring to the JsBox.
+            type StoredType = (node::Handle<'a, Self::ArgType>, std::cell::Ref<'static, $typ>);
+            fn borrow(
+                _cx: &mut node::FunctionContext,
+                foreign: node::Handle<'a, Self::ArgType>,
+            ) -> node::NeonResult<Self::StoredType> {
+                let cell: &std::cell::RefCell<_> = &***foreign;
+                let cell_with_extended_lifetime = unsafe { node::extend_lifetime_to_static(cell) };
+                Ok((foreign, cell_with_extended_lifetime.borrow()))
+            }
+            fn load_from(
+                _cx: &mut node::FunctionContext,
+                stored: &'a mut Self::StoredType,
+            ) -> node::NeonResult<Self> {
+                Ok(&*stored.1)
+            }
+        }
+
         paste! {
-            node_bridge_handle!($typ as $typ);
+            #[doc = "ts: interface " $typ " { readonly __type: unique symbol; }"]
+            impl<'a> node::ResultTypeInfo<'a> for $typ {
+                type ResultType = node::JsValue;
+                fn convert_into(
+                    self,
+                    cx: &mut node::FunctionContext<'a>,
+                ) -> node::NeonResult<node::Handle<'a, Self::ResultType>> {
+                    node::return_boxed_object(cx, Ok(std::cell::RefCell::new(self)))
+                }
+            }
+        }
+    };
+    ( $typ:ty $(, mut = $_:tt)?) => {
+        paste! {
+            node_bridge_handle!($typ as $typ $(, mut = $_)?);
         }
     };
 }

--- a/rust/bridge/shared/src/node/mod.rs
+++ b/rust/bridge/shared/src/node/mod.rs
@@ -144,8 +144,10 @@ macro_rules! node_bridge_get_bytearray {
                 expr_as_fn!(inner_get<'a>(
                     obj: &'a $typ
                 ) -> Result<impl AsRef<[u8]> + 'a, SignalProtocolError> => $body);
-                let obj = cx.argument::<node::DefaultJsBox<$typ>>(0)?;
-                let bytes = inner_get(&obj);
+                let obj_arg = cx.argument::<<&$typ as node::ArgTypeInfo>::ArgType>(0)?;
+                let mut obj_borrow = <&$typ as node::ArgTypeInfo>::borrow(&mut cx, obj_arg)?;
+                let obj = <&$typ as node::ArgTypeInfo>::load_from(&mut cx, &mut obj_borrow)?;
+                let bytes = inner_get(obj);
                 node::return_binary_data(&mut cx, bytes.map(Some))
             }
 
@@ -171,8 +173,10 @@ macro_rules! node_bridge_get_optional_bytearray {
                 expr_as_fn!(inner_get<'a>(
                     obj: &'a $typ
                 ) -> Result<Option<impl AsRef<[u8]> + 'a>, SignalProtocolError> => $body);
-                let obj = cx.argument::<node::DefaultJsBox<$typ>>(0)?;
-                let bytes = inner_get(&obj);
+                let obj_arg = cx.argument::<<&$typ as node::ArgTypeInfo>::ArgType>(0)?;
+                let mut obj_borrow = <&$typ as node::ArgTypeInfo>::borrow(&mut cx, obj_arg)?;
+                let obj = <&$typ as node::ArgTypeInfo>::load_from(&mut cx, &mut obj_borrow)?;
+                let bytes = inner_get(obj);
                 node::return_binary_data(&mut cx, bytes)
             }
 

--- a/rust/bridge/shared/src/support/mod.rs
+++ b/rust/bridge/shared/src/support/mod.rs
@@ -45,13 +45,13 @@ macro_rules! expr_as_fn {
 }
 
 macro_rules! bridge_handle {
-    ($typ:ty $(, clone = $_:tt)? $(, ffi = $ffi_name:ident)? $(, jni = $jni_name:ident)? $(, node = $node_name:ident)?) => {
+    ($typ:ty $(, clone = $_clone:tt)? $(, mut = $_mut:tt)? $(, ffi = $ffi_name:ident)? $(, jni = $jni_name:ident)? $(, node = $node_name:ident)?) => {
         #[cfg(feature = "ffi")]
-        ffi_bridge_handle!($typ $(as $ffi_name)? $(, clone = $_)?);
+        ffi_bridge_handle!($typ $(as $ffi_name)? $(, clone = $_clone)?);
         #[cfg(feature = "jni")]
         jni_bridge_handle!($typ $(as $jni_name)?);
         #[cfg(feature = "node")]
-        node_bridge_handle!($typ $(as $node_name)?);
+        node_bridge_handle!($typ $(as $node_name)? $(, mut = $_mut)?);
     };
 }
 

--- a/swift/Sources/SignalFfi/signal_ffi.h
+++ b/swift/Sources/SignalFfi/signal_ffi.h
@@ -203,8 +203,6 @@ SignalFfiError *signal_identitykeypair_deserialize(SignalPrivateKey **private_ke
                                                    const unsigned char *input,
                                                    size_t input_len);
 
-SignalFfiError *signal_session_record_archive_current_state(SignalSessionRecord *session_record);
-
 SignalFfiError *signal_session_record_has_current_state(bool *result,
                                                         const SignalSessionRecord *session_record);
 
@@ -813,6 +811,8 @@ SignalFfiError *signal_unidentified_sender_message_content_get_contents(const un
 
 SignalFfiError *signal_unidentified_sender_message_content_get_sender_cert(SignalSenderCertificate **out,
                                                                            const SignalUnidentifiedSenderMessageContent *m);
+
+SignalFfiError *signal_session_record_archive_current_state(SignalSessionRecord *session_record);
 
 SignalFfiError *signal_session_record_deserialize(SignalSessionRecord **p,
                                                   const unsigned char *data,


### PR DESCRIPTION
Neon enforces boxed values to be immutable, so I had to jump through some hoops with RefCell. FFI also expects an out-pointer for any declared results, but error-only results shouldn't get one. The easiest way to detect that was to add another macro variant, `bridge_fn_void`.