### PR TITLE
Node: remove "prepare" script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "clean": "rimraf node/dist build",
     "test": "electron-mocha --recursive node/dist/test",
     "lint": "cd node && eslint . --ext .js,.jsx,.ts,.tsx",
-    "format": "p() { prettier ${@:- --write} package.json '*.js' 'node/**/*.{css,js,json,md,scss,ts,tsx}'; }; p",
-    "prepare": "yarn tsc"
+    "format": "p() { prettier ${@:- --write} package.json '*.js' 'node/**/*.{css,js,json,md,scss,ts,tsx}'; }; p"
   },
   "dependencies": {
     "bindings": "^1.5.0"


### PR DESCRIPTION
This only made sense for using libsignal-client *directly* as a dependency; when used through a prebuilt "artifact repo" (see node/scripts/copy_repo.sh), there's no TypeScript to compile.