### PR TITLE
Drop the "-rust" from the "libsignal-protocol" crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,7 +749,7 @@ dependencies = [
  "jni",
  "libc",
  "libsignal-bridge-macros",
- "libsignal-protocol-rust",
+ "libsignal-protocol",
  "linkme",
  "log",
  "neon",
@@ -778,7 +778,7 @@ dependencies = [
  "async-trait",
  "libc",
  "libsignal-bridge",
- "libsignal-protocol-rust",
+ "libsignal-protocol",
  "log",
  "rand",
 ]
@@ -791,7 +791,7 @@ dependencies = [
  "async-trait",
  "jni",
  "libsignal-bridge",
- "libsignal-protocol-rust",
+ "libsignal-protocol",
  "log",
  "rand",
 ]
@@ -801,7 +801,7 @@ name = "libsignal-node"
 version = "0.1.0"
 dependencies = [
  "libsignal-bridge",
- "libsignal-protocol-rust",
+ "libsignal-protocol",
  "log",
  "neon",
  "neon-build 0.5.3",
@@ -809,7 +809,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "libsignal-protocol-rust"
+name = "libsignal-protocol"
 version = "0.1.0"
 dependencies = [
  "aes",

--- a/rust/bridge/ffi/Cargo.toml
+++ b/rust/bridge/ffi/Cargo.toml
@@ -15,7 +15,7 @@ name = "signal_ffi"
 crate-type = ["staticlib"]
 
 [dependencies]
-libsignal-protocol-rust = { path = "../../protocol" }
+libsignal-protocol = { path = "../../protocol" }
 aes-gcm-siv = { path = "../../aes-gcm-siv" }
 libsignal-bridge = { path = "../shared", features = ["ffi"] }
 async-trait = "0.1.41"

--- a/rust/bridge/ffi/cbindgen.toml
+++ b/rust/bridge/ffi/cbindgen.toml
@@ -40,7 +40,7 @@ sort_by = "None"
 
 [parse]
 parse_deps = true
-include = ["libsignal-protocol-rust", "aes-gcm-siv"]
+include = ["libsignal-protocol", "aes-gcm-siv"]
 extra_bindings = ["libsignal-bridge"]
 
 [parse.expand]

--- a/rust/bridge/ffi/src/lib.rs
+++ b/rust/bridge/ffi/src/lib.rs
@@ -8,7 +8,7 @@
 use async_trait::async_trait;
 use libc::{c_char, c_int, c_uchar, c_uint, size_t};
 use libsignal_bridge::ffi::*;
-use libsignal_protocol_rust::*;
+use libsignal_protocol::*;
 use std::convert::TryFrom;
 use std::ffi::{c_void, CString};
 use std::fmt;

--- a/rust/bridge/ffi/src/util.rs
+++ b/rust/bridge/ffi/src/util.rs
@@ -5,7 +5,7 @@
 
 use libc::{c_char, c_uchar, c_uint, size_t};
 use libsignal_bridge::ffi::*;
-use libsignal_protocol_rust::*;
+use libsignal_protocol::*;
 use std::ffi::CStr;
 
 use aes_gcm_siv::Error as AesGcmSivError;

--- a/rust/bridge/jni/Cargo.toml
+++ b/rust/bridge/jni/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libsignal-protocol-rust = { path = "../../protocol" }
+libsignal-protocol = { path = "../../protocol" }
 aes-gcm-siv = { path = "../../aes-gcm-siv" }
 libsignal-bridge = { path = "../shared", features = ["jni"] }
 async-trait = "0.1.41"

--- a/rust/bridge/jni/src/lib.rs
+++ b/rust/bridge/jni/src/lib.rs
@@ -12,7 +12,7 @@ use jni::JNIEnv;
 use std::convert::TryFrom;
 
 use libsignal_bridge::jni::*;
-use libsignal_protocol_rust::*;
+use libsignal_protocol::*;
 
 pub mod logging;
 mod util;

--- a/rust/bridge/jni/src/util.rs
+++ b/rust/bridge/jni/src/util.rs
@@ -8,7 +8,7 @@ use jni::sys::{jint, jobject};
 use jni::JNIEnv;
 
 use libsignal_bridge::jni::*;
-use libsignal_protocol_rust::SignalProtocolError;
+use libsignal_protocol::SignalProtocolError;
 
 pub fn jint_from_u32(value: Result<u32, SignalProtocolError>) -> Result<jint, SignalJniError> {
     match value {

--- a/rust/bridge/node/Cargo.toml
+++ b/rust/bridge/node/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib"]
 neon-build = "0.5.0"
 
 [dependencies]
-libsignal-protocol-rust = { path = "../../protocol" }
+libsignal-protocol = { path = "../../protocol" }
 libsignal-bridge = { path = "../shared", features = ["node"] }
 neon = { version = "0.7", default-features = false, features = ["napi-4", "event-queue-api"] }
 rand = "0.7.3"

--- a/rust/bridge/shared/Cargo.toml
+++ b/rust/bridge/shared/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 license = "AGPL-3.0-only"
 
 [dependencies]
-libsignal-protocol-rust = { path = "../../protocol" }
+libsignal-protocol = { path = "../../protocol" }
 aes-gcm-siv = { path = "../../aes-gcm-siv" }
 libsignal-bridge-macros = { path = "macros" }
 futures = "0.3.7"

--- a/rust/bridge/shared/src/ffi/convert.rs
+++ b/rust/bridge/shared/src/ffi/convert.rs
@@ -4,7 +4,7 @@
 //
 
 use libc::{c_char, c_uchar};
-use libsignal_protocol_rust::*;
+use libsignal_protocol::*;
 use std::borrow::Cow;
 use std::ffi::CStr;
 

--- a/rust/bridge/shared/src/ffi/error.rs
+++ b/rust/bridge/shared/src/ffi/error.rs
@@ -6,7 +6,7 @@
 use std::fmt;
 
 use aes_gcm_siv::Error as AesGcmSivError;
-use libsignal_protocol_rust::*;
+use libsignal_protocol::*;
 
 #[derive(Debug)]
 pub enum SignalFfiError {

--- a/rust/bridge/shared/src/ffi/mod.rs
+++ b/rust/bridge/shared/src/ffi/mod.rs
@@ -4,7 +4,7 @@
 //
 
 use libc::{c_char, c_uchar, size_t};
-use libsignal_protocol_rust::*;
+use libsignal_protocol::*;
 use std::ffi::CString;
 
 #[macro_use]

--- a/rust/bridge/shared/src/jni/convert.rs
+++ b/rust/bridge/shared/src/jni/convert.rs
@@ -6,7 +6,7 @@
 use jni::objects::{AutoByteArray, JString, ReleaseMode};
 use jni::sys::{JNI_FALSE, JNI_TRUE};
 use jni::JNIEnv;
-use libsignal_protocol_rust::*;
+use libsignal_protocol::*;
 use std::borrow::Cow;
 
 use crate::jni::*;

--- a/rust/bridge/shared/src/jni/error.rs
+++ b/rust/bridge/shared/src/jni/error.rs
@@ -8,7 +8,7 @@ use jni::{JNIEnv, JavaVM};
 use std::fmt;
 
 use aes_gcm_siv::Error as AesGcmSivError;
-use libsignal_protocol_rust::*;
+use libsignal_protocol::*;
 
 use super::*;
 

--- a/rust/bridge/shared/src/jni/mod.rs
+++ b/rust/bridge/shared/src/jni/mod.rs
@@ -7,7 +7,7 @@ use jni::objects::{JObject, JThrowable, JValue};
 use jni::sys::jobject;
 
 use aes_gcm_siv::Error as AesGcmSivError;
-use libsignal_protocol_rust::*;
+use libsignal_protocol::*;
 use std::convert::TryFrom;
 
 pub(crate) use jni::objects::{JClass, JString};

--- a/rust/bridge/shared/src/lib.rs
+++ b/rust/bridge/shared/src/lib.rs
@@ -7,7 +7,7 @@
 
 use aes_gcm_siv::Aes256GcmSiv;
 use libsignal_bridge_macros::*;
-use libsignal_protocol_rust::*;
+use libsignal_protocol::*;
 use static_assertions::const_assert_eq;
 use std::convert::TryFrom;
 

--- a/rust/bridge/shared/src/node/convert.rs
+++ b/rust/bridge/shared/src/node/convert.rs
@@ -188,7 +188,7 @@ impl<'a> ResultTypeInfo<'a> for Vec<u8> {
 }
 
 impl<'a, T: ResultTypeInfo<'a>> ResultTypeInfo<'a>
-    for Result<T, libsignal_protocol_rust::SignalProtocolError>
+    for Result<T, libsignal_protocol::SignalProtocolError>
 {
     type ResultType = T::ResultType;
     fn convert_into(

--- a/rust/bridge/shared/src/node/mod.rs
+++ b/rust/bridge/shared/src/node/mod.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use libsignal_protocol_rust::*;
+use libsignal_protocol::*;
 use std::convert::TryFrom;
 use std::ops::Deref;
 

--- a/rust/bridge/shared/src/support/transform_helper.rs
+++ b/rust/bridge/shared/src/support/transform_helper.rs
@@ -46,7 +46,7 @@ impl<T> TransformHelper<Option<T>> {
 }
 
 pub(crate) trait TransformHelperImpl: Sized {
-    fn ok_if_needed(self) -> Result<Self, libsignal_protocol_rust::SignalProtocolError> {
+    fn ok_if_needed(self) -> Result<Self, libsignal_protocol::SignalProtocolError> {
         Ok(self)
     }
     fn option_map_into(self) -> Self {

--- a/rust/protocol/Cargo.toml
+++ b/rust/protocol/Cargo.toml
@@ -4,7 +4,7 @@
 #
 
 [package]
-name = "libsignal-protocol-rust"
+name = "libsignal-protocol"
 version = "0.1.0"
 authors = ["Ehren Kret <ehren@signal.org>", "Jack Lloyd <jack@signal.org>"]
 edition = "2018"

--- a/rust/protocol/benches/ratchet.rs
+++ b/rust/protocol/benches/ratchet.rs
@@ -5,7 +5,7 @@
 
 use criterion::{criterion_group, criterion_main, Criterion, SamplingMode};
 use futures::executor::block_on;
-use libsignal_protocol_rust::*;
+use libsignal_protocol::*;
 use std::convert::TryFrom;
 
 #[path = "../tests/support/mod.rs"]

--- a/rust/protocol/benches/session.rs
+++ b/rust/protocol/benches/session.rs
@@ -5,7 +5,7 @@
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use futures::executor::block_on;
-use libsignal_protocol_rust::*;
+use libsignal_protocol::*;
 
 #[path = "../tests/support/mod.rs"]
 mod support;

--- a/rust/protocol/tests/groups.rs
+++ b/rust/protocol/tests/groups.rs
@@ -7,7 +7,7 @@ mod support;
 
 use async_trait::async_trait;
 use futures::executor::block_on;
-use libsignal_protocol_rust::*;
+use libsignal_protocol::*;
 use rand::rngs::OsRng;
 use rand::seq::SliceRandom;
 use rand::Rng;

--- a/rust/protocol/tests/ratchet.rs
+++ b/rust/protocol/tests/ratchet.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use libsignal_protocol_rust::*;
+use libsignal_protocol::*;
 
 #[test]
 fn test_ratcheting_session_as_bob() -> Result<(), SignalProtocolError> {

--- a/rust/protocol/tests/sealed_sender.rs
+++ b/rust/protocol/tests/sealed_sender.rs
@@ -6,7 +6,7 @@
 mod support;
 
 use futures::executor::block_on;
-use libsignal_protocol_rust::*;
+use libsignal_protocol::*;
 use rand::rngs::OsRng;
 use support::*;
 

--- a/rust/protocol/tests/session.rs
+++ b/rust/protocol/tests/session.rs
@@ -6,7 +6,7 @@
 mod support;
 
 use futures::executor::block_on;
-use libsignal_protocol_rust::*;
+use libsignal_protocol::*;
 use rand::rngs::OsRng;
 use std::convert::TryFrom;
 use support::*;

--- a/rust/protocol/tests/support/mod.rs
+++ b/rust/protocol/tests/support/mod.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use libsignal_protocol_rust::*;
+use libsignal_protocol::*;
 use rand::{rngs::OsRng, CryptoRng, Rng};
 
 pub fn test_in_memory_protocol_store() -> InMemSignalProtocolStore {


### PR DESCRIPTION
The project corresponds to libsignal-protocol-java and the others, but *within* the language we don't need to tag with the language name.