### PR TITLE
Remove DisplayableFingerprint_Format from bridge

### DIFF
--- a/java/java/src/main/java/org/signal/internal/Native.java
+++ b/java/java/src/main/java/org/signal/internal/Native.java
@@ -74,8 +74,6 @@ public final class Native {
   public static native byte[] Aes256GcmSiv_Encrypt(long aesGcmSiv, byte[] ptext, byte[] nonce, byte[] associatedData);
   public static native long Aes256GcmSiv_New(byte[] key);
 
-  public static native String DisplayableFingerprint_Format(byte[] local, byte[] remote);
-
   public static native byte[] ECPrivateKey_Agree(long privateKey, long publicKey);
   public static native long ECPrivateKey_Deserialize(byte[] data);
   public static native void ECPrivateKey_Destroy(long handle);

--- a/java/java/src/main/java/org/whispersystems/libsignal/fingerprint/DisplayableFingerprint.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/fingerprint/DisplayableFingerprint.java
@@ -10,10 +10,6 @@ import org.signal.client.internal.Native;
 public class DisplayableFingerprint {
   private String displayString;
 
-  DisplayableFingerprint(byte[] localFingerprint, byte[] remoteFingerprint) {
-    this.displayString = Native.DisplayableFingerprint_Format(localFingerprint, remoteFingerprint);
-  }
-
   DisplayableFingerprint(String displayString) {
     this.displayString = displayString;
   }

--- a/node/libsignal_client.d.ts
+++ b/node/libsignal_client.d.ts
@@ -12,7 +12,6 @@ export function Aes256GcmSiv_Encrypt(aesGcmSiv: Aes256GcmSiv, ptext: Buffer, non
 export function Aes256GcmSiv_New(key: Buffer): Aes256GcmSiv;
 export function CiphertextMessage_Serialize(obj: CiphertextMessage): Buffer;
 export function CiphertextMessage_Type(msg: CiphertextMessage): number;
-export function DisplayableFingerprint_Format(local: Buffer, remote: Buffer): string;
 export function Fingerprint_DisplayString(obj: Fingerprint): string;
 export function Fingerprint_New(iterations: number, version: number, localIdentifier: Buffer, localKey: PublicKey, remoteIdentifier: Buffer, remoteKey: PublicKey): Fingerprint;
 export function Fingerprint_ScannableEncoding(obj: Fingerprint): Buffer;

--- a/rust/bridge/shared/src/lib.rs
+++ b/rust/bridge/shared/src/lib.rs
@@ -236,13 +236,6 @@ bridge_get!(
     jni = "NumericFingerprintGenerator_1GetDisplayString"
 );
 
-#[bridge_fn(ffi = "fingerprint_format")]
-fn DisplayableFingerprint_Format(
-    local: &[u8],
-    remote: &[u8],
-) -> Result<String, SignalProtocolError> {
-    DisplayableFingerprint::new(&local, &remote).map(|f| f.to_string())
-}
 #[bridge_fn(ffi = "fingerprint_compare")]
 fn ScannableFingerprint_Compare(
     fprint1: &[u8],

--- a/swift/Sources/SignalFfi/signal_ffi.h
+++ b/swift/Sources/SignalFfi/signal_ffi.h
@@ -457,12 +457,6 @@ SignalFfiError *signal_fingerprint_scannable_encoding(const unsigned char **out,
 
 SignalFfiError *signal_fingerprint_display_string(const char **out, const SignalFingerprint *obj);
 
-SignalFfiError *signal_fingerprint_format(const char **out,
-                                          const unsigned char *local,
-                                          size_t local_len,
-                                          const unsigned char *remote,
-                                          size_t remote_len);
-
 SignalFfiError *signal_fingerprint_compare(bool *out,
                                            const unsigned char *fprint1,
                                            size_t fprint1_len,


### PR DESCRIPTION
Was exposed in Java but never called by Android. Was included in the C ABI but no Swift binding.

Doesn't make any sense to use this because it just string formats the binary fingerprint but to generate that you need the fingerprint generator. We instead always use the formatted string from `NumericFingerprintGenerator_GetDisplayString`.