### PR TITLE
Swift: fix IdentityKeyPair.init(bytes:)

### DIFF
--- a/swift/Sources/SignalClient/IdentityKey.swift
+++ b/swift/Sources/SignalClient/IdentityKey.swift
@@ -35,7 +35,7 @@ public struct IdentityKeyPair {
         var pubkeyPtr: OpaquePointer?
         var privkeyPtr: OpaquePointer?
         try bytes.withUnsafeBytes {
-            try checkError(signal_identitykeypair_deserialize(&pubkeyPtr, &privkeyPtr, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count))
+            try checkError(signal_identitykeypair_deserialize(&privkeyPtr, &pubkeyPtr, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count))
         }
 
         publicKey = PublicKey(owned: pubkeyPtr!)


### PR DESCRIPTION
It called the underlying Rust entrypoint with the arguments in the wrong order. Fixes #155.