### PR TITLE
Log the SignalClient version when the logger is initialized

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -101,6 +101,9 @@ jobs:
     - name: Rustfmt check
       run: cargo fmt --all -- --check
 
+    - name: Check bridge versioning
+      run: ./bin/verify_crate_versions.py
+
     - name: Build
       run: cargo build --all --verbose
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "libsignal-ffi"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "aes-gcm-siv",
  "async-trait",
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "libsignal-jni"
-version = "0.1.0"
+version = "0.2.3"
 dependencies = [
  "aes-gcm-siv",
  "async-trait",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "libsignal-node"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "libsignal-bridge",
  "libsignal-protocol",

--- a/bin/verify_crate_versions.py
+++ b/bin/verify_crate_versions.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+#
+# Copyright 2021 Signal Messenger, LLC.
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+
+# Verify crate versions and lib package versions are in accord
+
+import sys
+import re
+import json
+import os
+
+def swift_version():
+    version_re = re.compile(".*\.version\s+=\s+'(.*)'")
+    for line in open('SignalClient.podspec'):
+        match = version_re.match(line)
+        if match:
+            return match.group(1)
+    raise Exception("Could not determine version from SignalClient.podspec")
+
+def java_version():
+    version_re = re.compile("\s+ext\.version_number\s+=\s+\"(.*)\"")
+    for line in open('java/build.gradle'):
+        match = version_re.match(line)
+        if match:
+            return match.group(1)
+    raise Exception("Could not determine version from java/build.gradle")
+
+def node_version():
+    package_json = json.load(open('package.json'))
+    return package_json['version']
+
+def bridge_version(bridge):
+    version_re = re.compile('^version = "(.*)"')
+    bridge_cargo_toml = os.path.join('rust/bridge/', bridge, 'Cargo.toml')
+    for line in open(bridge_cargo_toml):
+        match = version_re.match(line)
+        if match:
+            return match.group(1)
+    raise Exception("Could not determine version from ", bridge_cargo_toml)
+
+def main():
+
+    package_versions = {
+        'swift': swift_version(),
+        'java': java_version(),
+        'node': node_version()
+    }
+
+    bridge_versions = {
+        'swift': bridge_version('ffi'),
+        'java': bridge_version('jni'),
+        'node': bridge_version('node'),
+    }
+
+    rc = 0
+    for bridge in ['swift', 'java', 'node']:
+        if bridge_versions[bridge] != package_versions[bridge]:
+            print("ERROR: Bridge %s has package version %s but crate version is %s" % (
+                bridge, package_versions[bridge], bridge_versions[bridge]))
+            rc = 1
+
+    return rc
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/bin/verify_crate_versions.py
+++ b/bin/verify_crate_versions.py
@@ -12,25 +12,29 @@ import re
 import json
 import os
 
+
 def swift_version():
-    version_re = re.compile(".*\.version\s+=\s+'(.*)'")
+    version_re = re.compile(r".*\.version\s+=\s+'(.*)'")
     for line in open('SignalClient.podspec'):
         match = version_re.match(line)
         if match:
             return match.group(1)
     raise Exception("Could not determine version from SignalClient.podspec")
 
+
 def java_version():
-    version_re = re.compile("\s+ext\.version_number\s+=\s+\"(.*)\"")
+    version_re = re.compile(r"\s+ext\.version_number\s+=\s+\"(.*)\"")
     for line in open('java/build.gradle'):
         match = version_re.match(line)
         if match:
             return match.group(1)
     raise Exception("Could not determine version from java/build.gradle")
 
+
 def node_version():
     package_json = json.load(open('package.json'))
     return package_json['version']
+
 
 def bridge_version(bridge):
     version_re = re.compile('^version = "(.*)"')
@@ -40,6 +44,7 @@ def bridge_version(bridge):
         if match:
             return match.group(1)
     raise Exception("Could not determine version from ", bridge_cargo_toml)
+
 
 def main():
 
@@ -63,6 +68,7 @@ def main():
             rc = 1
 
     return rc
+
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/rust/bridge/ffi/Cargo.toml
+++ b/rust/bridge/ffi/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "libsignal-ffi"
-version = "0.1.0"
+version = "0.1.2"
 authors = ["Jack Lloyd <jack@signal.org>"]
 edition = "2018"
 license = "AGPL-3.0-only"

--- a/rust/bridge/ffi/src/logging.rs
+++ b/rust/bridge/ffi/src/logging.rs
@@ -96,7 +96,10 @@ pub unsafe extern "C" fn signal_init_logger(max_level: LogLevel, logger: FfiLogg
     match log::set_logger(Box::leak(Box::new(logger))) {
         Ok(_) => {
             log::set_max_level(log::Level::from(max_level).to_level_filter());
-            log::info!("Initializing libsignal-client version:{}", env!("CARGO_PKG_VERSION"));
+            log::info!(
+                "Initializing libsignal-client version:{}",
+                env!("CARGO_PKG_VERSION")
+            );
         }
         Err(_) => {
             log::warn!("logging already initialized for libsignal-client; ignoring later call");

--- a/rust/bridge/ffi/src/logging.rs
+++ b/rust/bridge/ffi/src/logging.rs
@@ -96,7 +96,7 @@ pub unsafe extern "C" fn signal_init_logger(max_level: LogLevel, logger: FfiLogg
     match log::set_logger(Box::leak(Box::new(logger))) {
         Ok(_) => {
             log::set_max_level(log::Level::from(max_level).to_level_filter());
-            log::debug!("logging initialized for libsignal-client");
+            log::info!("Initializing libsignal-client version:{}", env!("CARGO_PKG_VERSION"));
         }
         Err(_) => {
             log::warn!("logging already initialized for libsignal-client; ignoring later call");

--- a/rust/bridge/jni/Cargo.toml
+++ b/rust/bridge/jni/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "libsignal-jni"
-version = "0.1.0"
+version = "0.2.3"
 authors = ["Jack Lloyd <jack@signal.org>"]
 edition = "2018"
 license = "AGPL-3.0-only"

--- a/rust/bridge/jni/src/logging.rs
+++ b/rust/bridge/jni/src/logging.rs
@@ -169,7 +169,10 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_Logger_1Initiali
         match log::set_logger(Box::leak(Box::new(logger))) {
             Ok(_) => {
                 set_max_level_from_java_level(max_level);
-                log::info!("Initializing libsignal-client version:{}", env!("CARGO_PKG_VERSION"));
+                log::info!(
+                    "Initializing libsignal-client version:{}",
+                    env!("CARGO_PKG_VERSION")
+                );
             }
             Err(_) => {
                 log::warn!("logging already initialized for libsignal-client; ignoring later call");

--- a/rust/bridge/jni/src/logging.rs
+++ b/rust/bridge/jni/src/logging.rs
@@ -169,7 +169,7 @@ pub unsafe extern "C" fn Java_org_signal_client_internal_Native_Logger_1Initiali
         match log::set_logger(Box::leak(Box::new(logger))) {
             Ok(_) => {
                 set_max_level_from_java_level(max_level);
-                log::debug!("logging initialized for libsignal-client");
+                log::info!("Initializing libsignal-client version:{}", env!("CARGO_PKG_VERSION"));
             }
             Err(_) => {
                 log::warn!("logging already initialized for libsignal-client; ignoring later call");

--- a/rust/bridge/node/Cargo.toml
+++ b/rust/bridge/node/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "libsignal-node"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Jordan Rose <jrose@signal.org>", "Jack Lloyd <jack@signal.org>"]
 license = "AGPL-3.0-only"
 edition = "2018"

--- a/rust/bridge/node/src/logging.rs
+++ b/rust/bridge/node/src/logging.rs
@@ -136,7 +136,7 @@ pub(crate) fn init_logger(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     match log::set_logger(Box::leak(Box::new(logger))) {
         Ok(_) => {
             set_max_level_from_js_level(max_level);
-            log::debug!("logging initialized for libsignal-client");
+            log::info!("Initializing libsignal-client version:{}", env!("CARGO_PKG_VERSION"));
         }
         Err(_) => {
             log::warn!("logging already initialized for libsignal-client; ignoring later call");

--- a/rust/bridge/node/src/logging.rs
+++ b/rust/bridge/node/src/logging.rs
@@ -136,7 +136,10 @@ pub(crate) fn init_logger(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     match log::set_logger(Box::leak(Box::new(logger))) {
         Ok(_) => {
             set_max_level_from_js_level(max_level);
-            log::info!("Initializing libsignal-client version:{}", env!("CARGO_PKG_VERSION"));
+            log::info!(
+                "Initializing libsignal-client version:{}",
+                env!("CARGO_PKG_VERSION")
+            );
         }
         Err(_) => {
             log::warn!("logging already initialized for libsignal-client; ignoring later call");


### PR DESCRIPTION
Re the discussion on Android/libsignal-client group where the version of the lib being used wasn't clear to the Android team. Just log the version, then there is no ambiguity.

This requires we keep the crate version in sync with the release version but that doesn't seem terribly onerous.

Considered also logging the git hash and commit date using https://docs.rs/vergen/3.2.0/vergen/index.html but probably just a version is sufficient.