### PR TITLE
Add node multi-arch/cross-compilation support

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -207,10 +207,10 @@ jobs:
     - run: yarn tsc
 
     - run: yarn lint
-      if: matrix.arch == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-latest'
 
     - run: yarn format -c
-      if: matrix.arch == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-latest'
 
     - name: Run yarn test
       uses: GabrielBB/xvfb-action@v1.4

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -172,7 +172,11 @@ jobs:
   node:
     name: Node
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     needs: changes
 
@@ -186,8 +190,14 @@ jobs:
       with:
         profile: minimal
 
-    - run: nvm install && nvm use
-      shell: bash -l {0}
+    - name: Get Node version from .nvmrc
+      id: get-nvm-version
+      shell: bash
+      run: echo "::set-output name=node-version::$(cat .nvmrc)"
+
+    - uses: actions/setup-node@v2
+      with:
+        node-version: ${{ steps.get-nvm-version.outputs.node-version }}
 
     - name: Verify that the Node bindings are up to date
       run: rust/bridge/node/bin/gen_ts_decl.py --verify
@@ -197,8 +207,10 @@ jobs:
     - run: yarn tsc
 
     - run: yarn lint
+      if: matrix.arch == 'ubuntu-latest'
 
     - run: yarn format -c
+      if: matrix.arch == 'ubuntu-latest'
 
     - name: Run yarn test
       uses: GabrielBB/xvfb-action@v1.4

--- a/binding.gyp
+++ b/binding.gyp
@@ -5,13 +5,17 @@
 
 {
     'conditions': [
-        ['OS=="mac"', {'variables': {'NODE_OS_NAME': 'darwin'}},
-         'OS=="win"', {'variables': {'NODE_OS_NAME': 'win32'}},
+        ['OS=="mac"', {'variables': {'NODE_OS_NAME': 'darwin', 'CARGO_TARGET_SUFFIX': 'apple-darwin'}},
+         'OS=="win"', {'variables': {'NODE_OS_NAME': 'win32', 'CARGO_TARGET_SUFFIX': 'pc-windows-msvc'}},
+         'OS=="linux"', {'variables': {'NODE_OS_NAME': 'linux', 'CARGO_TARGET_SUFFIX': 'unknown-linux-gnu'}},
          {'variables': {'NODE_OS_NAME': '<(OS)'}}],
+        ['target_arch=="ia32"', {'variables': {'CARGO_ARCH': 'i686'}},
+         'target_arch=="x64"', {'variables': {'CARGO_ARCH': 'x86_64'}},
+         'target_arch=="arm64"', {'variables': {'CARGO_ARCH': 'aarch64'}}]
     ],
     'targets': [
         {
-            'target_name': 'libsignal_client_<(NODE_OS_NAME).node',
+            'target_name': 'libsignal_client_<(NODE_OS_NAME)_<(target_arch).node',
             'type': 'none',
             'actions': [
                 {
@@ -22,7 +26,9 @@
                         '--out-dir', '<(PRODUCT_DIR)/',
                         '--os-name', '<(NODE_OS_NAME)',
                         '--configuration', '<(CONFIGURATION_NAME)',
-                        '--cargo-build-dir', '<(INTERMEDIATE_DIR)/rust'
+                        '--cargo-build-dir', '<(INTERMEDIATE_DIR)/rust',
+                        '--cargo-target', '<(CARGO_ARCH)-<(CARGO_TARGET_SUFFIX)',
+                        '--node-arch', '<(target_arch)'
                         ],
                     'inputs': [],
                     'outputs': [

--- a/node/index.ts
+++ b/node/index.ts
@@ -7,7 +7,9 @@ import * as os from 'os';
 import bindings = require('bindings'); // eslint-disable-line @typescript-eslint/no-require-imports
 import * as SignalClient from './libsignal_client';
 
-const SC = bindings('libsignal_client_' + os.platform()) as typeof SignalClient;
+const SC = bindings(
+  'libsignal_client_' + os.platform() + '_' + process.arch
+) as typeof SignalClient;
 
 export const { initLogger, LogLevel, CiphertextMessageType } = SC;
 


### PR DESCRIPTION
Needed for Apple Silicon/Windows arm64/Windows ia32

Ref https://github.com/signalapp/Signal-Desktop/issues/3745#issuecomment-777837619
Ref https://github.com/signalapp/Signal-Desktop/issues/1636#issuecomment-778153694
Ref https://github.com/signalapp/Signal-Desktop/issues/4461

**How to test**:

`npm_config_arch` is only needed when you're cross-compiling from a x64 host, e.g. x64 to ia32.

Branch with generated binaries: https://github.com/dennisameling/libsignal-client-node/tree/cross-compilation-compat/build

```
export npm_config_arch=ia32
yarn install
yarn tsc
```

Tested on:
- [x] Windows ia32
- [x] Windows x64
- [x] Windows arm64
- [x] MacOS arm64 (Apple Silicon)
- [x] MacOS x64
- [x] Linux x64