### PR TITLE
Node: statically link the C runtime on Windows

### DIFF
--- a/node/build_node_bridge.py
+++ b/node/build_node_bridge.py
@@ -80,6 +80,11 @@ def main(args=None):
     # https://github.com/rust-lang/rfcs/issues/2771
     cargo_env['CARGO_PROFILE_RELEASE_LTO'] = 'thin'
 
+    if node_os_name == 'win32':
+        # By default, Rust on Windows depends on an MSVC component for the C runtime.
+        # Link it statically to avoid propagating that dependency.
+        cargo_env['RUSTFLAGS'] = '-C target-feature=+crt-static'
+
     cmd = subprocess.Popen(cmdline, env=cargo_env)
     cmd.wait()
 


### PR DESCRIPTION
On Windows, the C runtime doesn't come preinstalled, so we need to link it to avoid passing a dependency on to our users.