### PR TITLE
Move the burden of SessionCipher locking to the client.

### DIFF
--- a/java/java/src/main/java/org/whispersystems/libsignal/SessionBuilder.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/SessionBuilder.java
@@ -30,6 +30,8 @@ import org.whispersystems.libsignal.state.SignedPreKeyStore;
  * Sessions are constructed per recipientId + deviceId tuple.  Remote logical users are identified
  * by their recipientId, and each logical recipientId can have multiple physical devices.
  *
+ * This class is not thread-safe.
+ *
  * @author Moxie Marlinspike
  */
 public class SessionBuilder {
@@ -83,12 +85,9 @@ public class SessionBuilder {
    *                                                                  trusted.
    */
   public void process(PreKeyBundle preKey) throws InvalidKeyException, UntrustedIdentityException {
-    synchronized (SessionCipher.SESSION_LOCK) {
-      Native.SessionBuilder_ProcessPreKeyBundle(preKey.nativeHandle(),
-                          remoteAddress.nativeHandle(),
-                          sessionStore,
-                          identityKeyStore);
-    }
+    Native.SessionBuilder_ProcessPreKeyBundle(preKey.nativeHandle(),
+                        remoteAddress.nativeHandle(),
+                        sessionStore,
+                        identityKeyStore);
   }
-
 }

--- a/java/java/src/main/java/org/whispersystems/libsignal/SessionCipher.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/SessionCipher.java
@@ -28,10 +28,11 @@ import java.security.NoSuchAlgorithmException;
  * this class can be used for all encrypt/decrypt operations within
  * that session.
  *
+ * This class is not thread-safe.
+ *
  * @author Moxie Marlinspike
  */
 public class SessionCipher {
-  public static final Object SESSION_LOCK = new Object();
 
   private final SessionStore          sessionStore;
   private final IdentityKeyStore      identityKeyStore;
@@ -69,12 +70,10 @@ public class SessionCipher {
    * @return A ciphertext message encrypted to the recipient+device tuple.
    */
   public CiphertextMessage encrypt(byte[] paddedMessage) throws UntrustedIdentityException {
-    synchronized (SESSION_LOCK) {
-       return Native.SessionCipher_EncryptMessage(paddedMessage,
-                             this.remoteAddress.nativeHandle(),
-                             sessionStore,
-                             identityKeyStore);
-    }
+     return Native.SessionCipher_EncryptMessage(paddedMessage,
+                           this.remoteAddress.nativeHandle(),
+                           sessionStore,
+                           identityKeyStore);
   }
 
   /**
@@ -96,14 +95,12 @@ public class SessionCipher {
       throws DuplicateMessageException, LegacyMessageException, InvalidMessageException,
              InvalidKeyIdException, InvalidKeyException, UntrustedIdentityException
   {
-    synchronized (SESSION_LOCK) {
-      return Native.SessionCipher_DecryptPreKeySignalMessage(ciphertext.nativeHandle(),
-                                        remoteAddress.nativeHandle(),
-                                        sessionStore,
-                                        identityKeyStore,
-                                        preKeyStore,
-                                        signedPreKeyStore);
-    }
+    return Native.SessionCipher_DecryptPreKeySignalMessage(ciphertext.nativeHandle(),
+                                      remoteAddress.nativeHandle(),
+                                      sessionStore,
+                                      identityKeyStore,
+                                      preKeyStore,
+                                      signedPreKeyStore);
   }
 
   /**
@@ -122,29 +119,23 @@ public class SessionCipher {
       throws InvalidMessageException, DuplicateMessageException, LegacyMessageException,
       NoSessionException, UntrustedIdentityException
   {
-    synchronized (SESSION_LOCK) {
-       return Native.SessionCipher_DecryptSignalMessage(ciphertext.nativeHandle(),
-                                   remoteAddress.nativeHandle(),
-                                   sessionStore,
-                                   identityKeyStore);
-    }
+     return Native.SessionCipher_DecryptSignalMessage(ciphertext.nativeHandle(),
+                                 remoteAddress.nativeHandle(),
+                                 sessionStore,
+                                 identityKeyStore);
   }
 
   public int getRemoteRegistrationId() {
-    synchronized (SESSION_LOCK) {
-      SessionRecord record = sessionStore.loadSession(remoteAddress);
-      return record.getSessionState().getRemoteRegistrationId();
-    }
+    SessionRecord record = sessionStore.loadSession(remoteAddress);
+    return record.getSessionState().getRemoteRegistrationId();
   }
 
   public int getSessionVersion() {
-    synchronized (SESSION_LOCK) {
-      if (!sessionStore.containsSession(remoteAddress)) {
-        throw new IllegalStateException(String.format("No session for (%s)!", remoteAddress));
-      }
-
-      SessionRecord record = sessionStore.loadSession(remoteAddress);
-      return record.getSessionState().getSessionVersion();
+    if (!sessionStore.containsSession(remoteAddress)) {
+      throw new IllegalStateException(String.format("No session for (%s)!", remoteAddress));
     }
+
+    SessionRecord record = sessionStore.loadSession(remoteAddress);
+    return record.getSessionState().getSessionVersion();
   }
 }


### PR DESCRIPTION
The lock inside of `SessionCipher` is causing a lot of pain due to the threading model of the Android app. Let's just move the entire responsibility of locking to the client.