### PR TITLE
Don't stuff long logs into error/exception messages

### DIFF
--- a/rust/bridge/ffi/src/util.rs
+++ b/rust/bridge/ffi/src/util.rs
@@ -134,7 +134,6 @@ impl From<&SignalFfiError> for SignalErrorCode {
             }
 
             SignalFfiError::Signal(SignalProtocolError::InvalidMessage(_))
-            | SignalFfiError::Signal(SignalProtocolError::MessageDecryptionFailed(_))
             | SignalFfiError::Signal(SignalProtocolError::InvalidProtobufEncoding)
             | SignalFfiError::Signal(SignalProtocolError::InvalidSealedSenderMessage(_)) => {
                 SignalErrorCode::InvalidMessage

--- a/rust/bridge/shared/src/jni/mod.rs
+++ b/rust/bridge/shared/src/jni/mod.rs
@@ -139,7 +139,6 @@ fn throw_error(env: &JNIEnv, error: SignalJniError) {
         }
 
         SignalJniError::Signal(SignalProtocolError::InvalidMessage(_))
-        | SignalJniError::Signal(SignalProtocolError::MessageDecryptionFailed(_))
         | SignalJniError::Signal(SignalProtocolError::CiphertextMessageTooShort(_))
         | SignalJniError::Signal(SignalProtocolError::InvalidCiphertext)
         | SignalJniError::Signal(SignalProtocolError::InvalidProtobufEncoding)

--- a/rust/protocol/src/error.rs
+++ b/rust/protocol/src/error.rs
@@ -55,7 +55,6 @@ pub enum SignalProtocolError {
 
     DuplicatedMessage(u32, u32),
     InvalidMessage(&'static str),
-    MessageDecryptionFailed(String),
     InternalError(&'static str),
     FfiBindingError(String),
     ApplicationCallbackError(&'static str, Box<dyn Error + Send + UnwindSafe + 'static>),
@@ -184,9 +183,6 @@ impl fmt::Display for SignalProtocolError {
             }
             SignalProtocolError::SealedSenderSelfSend => {
                 write!(f, "self send of a sealed sender message")
-            }
-            SignalProtocolError::MessageDecryptionFailed(info) => {
-                write!(f, "{}", info)
             }
         }
     }

--- a/rust/protocol/src/session_cipher.rs
+++ b/rust/protocol/src/session_cipher.rs
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Signal Messenger, LLC.
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
@@ -425,8 +425,12 @@ fn decrypt_message_with_record<R: Rng + CryptoRng>(
                 previous_state_count(),
             );
         }
-        Err(SignalProtocolError::MessageDecryptionFailed(
-            create_decryption_failure_log(remote_address, &errs, record, ciphertext)?,
+        log::error!(
+            "{}",
+            create_decryption_failure_log(remote_address, &errs, record, ciphertext)?
+        );
+        Err(SignalProtocolError::InvalidMessage(
+            "Message decryption failed",
         ))
     }
 }


### PR DESCRIPTION
Instead use the log integration

(We just had no log integration at the point that the decryption failure logging was needed)