### PR TITLE
CocoaPods: Build the Rust library as part of installing the CocoaPod

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -272,6 +272,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Check out SignalCoreKit
+        uses: actions/checkout@v2
+        with:
+          repository: signalapp/SignalCoreKit
+          path: SignalCoreKit
+
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -280,7 +286,7 @@ jobs:
 
       - name: Run pod lint
         # No import validation because it tries to build unsupported platforms (like 32-bit iOS).
-        run: pod lib lint --verbose --platforms=ios --skip-import-validation
+        run: pod lib lint --verbose --platforms=ios --include-podspecs=SignalCoreKit/SignalCoreKit.podspec --skip-import-validation
         env:
           XCODE_XCCONFIG_FILE: swift/PodLibLint.xcconfig
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -116,27 +116,6 @@ jobs:
     - name: Clippy
       run: cargo clippy --all -- -D warnings
 
-  rust_ios:
-    name: Build Rust for iOS
-
-    runs-on: macos-latest
-
-    needs: changes
-
-    if: ${{ needs.changes.outputs.rust_ios == 'true' }}
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        target: aarch64-apple-ios
-
-    - name: Build
-      run: cargo build --verbose --target aarch64-apple-ios -p libsignal-ffi
-
   java:
     name: Java
 
@@ -282,7 +261,9 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          target: x86_64-apple-ios
+
+      - name: Add iOS targets
+        run: rustup target add x86_64-apple-ios aarch64-apple-ios
 
       - name: Run pod lint
         # No import validation because it tries to build unsupported platforms (like 32-bit iOS).

--- a/SignalClient.podspec
+++ b/SignalClient.podspec
@@ -16,15 +16,9 @@ Pod::Spec.new do |s|
   s.swift_version    = '5'
   s.platform = :ios, '10'
 
-  s.dependency 'CocoaLumberjack/Swift'
+  s.dependency 'SignalCoreKit'
 
-  s.source_files = [
-    'swift/Sources/**/*.swift',
-    'swift/Sources/**/*.m',
-    # FIXME: We'd like to hide this from downstream clients at some point.
-    # (Making this header accessible to both CocoaPods and SwiftPM is hard.)
-    'swift/Sources/SignalFfi/signal_ffi.h'
-  ]
+  s.source_files = ['swift/Sources/**/*.swift', 'swift/Sources/**/*.m']
   s.preserve_paths = [
     'bin/*',
     'Cargo.toml',
@@ -32,12 +26,17 @@ Pod::Spec.new do |s|
     'rust-toolchain',
     'rust/*',
     'swift/*.sh',
+    'swift/Sources/SignalFfi',
   ]
 
   s.pod_target_xcconfig = {
       'CARGO_BUILD_TARGET_DIR' => '$(DERIVED_FILE_DIR)/libsignal-ffi',
       'CARGO_PROFILE_RELEASE_DEBUG' => '1', # enable line tables
       'LIBSIGNAL_FFI_DIR' => '$(CARGO_BUILD_TARGET_DIR)/$(CARGO_BUILD_TARGET)/release',
+
+      'HEADER_SEARCH_PATHS' => '$(PODS_TARGET_SRCROOT)/swift/Sources/SignalFfi',
+      # Duplicate this here to make sure the search path is passed on to Swift dependencies.
+      'SWIFT_INCLUDE_PATHS' => '$(HEADER_SEARCH_PATHS)',
 
       # Make sure we link the static library, not a dynamic one.
       # Use an extra level of indirection because CocoaPods messes with OTHER_LDFLAGS too.
@@ -53,9 +52,9 @@ Pod::Spec.new do |s|
   }
 
   s.script_phases = [
-    { :name => 'Build libsignal-ffi (if not prebuilt)',
+    { :name => 'Build libsignal-ffi',
       :execution_position => :before_compile,
-      :script => 'if [[ -n "${PRODUCT_TYPE}" ]]; then "${PODS_TARGET_SRCROOT}/swift/build_ffi.sh"; fi',
+      :script => '"${PODS_TARGET_SRCROOT}/swift/build_ffi.sh"',
     }
   ]
 

--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -8,11 +8,6 @@
 import PackageDescription
 
 let rustBuildDir = "../target/debug/"
-let autoImportSignalFfi = [
-    // Use an undocumented, unstable flag to avoid mentioning SignalFfi in source files.
-    // (Making this header accessible to both CocoaPods and SwiftPM is hard.)
-    "-Xfrontend", "-import-module", "-Xfrontend", "SignalFfi"
-]
 
 let package = Package(
     name: "SignalClient",
@@ -28,13 +23,11 @@ let package = Package(
         .target(
             name: "SignalClient",
             dependencies: ["SignalFfi"],
-            exclude: ["Logging.m"],
-            swiftSettings: [.unsafeFlags(autoImportSignalFfi)]
+            exclude: ["Logging.m"]
         ),
         .testTarget(
             name: "SignalClientTests",
             dependencies: ["SignalClient"],
-            swiftSettings: [.unsafeFlags(autoImportSignalFfi)],
             linkerSettings: [.unsafeFlags(["\(rustBuildDir)/libsignal_ffi.a"])]
         )
     ]

--- a/swift/Sources/SignalClient/Address.swift
+++ b/swift/Sources/SignalClient/Address.swift
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+import SignalFfi
+
 public class ProtocolAddress: ClonableHandleOwner {
     public init(name: String, deviceId: UInt32) throws {
         var handle: OpaquePointer?

--- a/swift/Sources/SignalClient/Aes256GcmSiv.swift
+++ b/swift/Sources/SignalClient/Aes256GcmSiv.swift
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+import SignalFfi
 import Foundation
 
 public class Aes256GcmSiv: ClonableHandleOwner {

--- a/swift/Sources/SignalClient/DataStoreProtocols.swift
+++ b/swift/Sources/SignalClient/DataStoreProtocols.swift
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+import SignalFfi
+
 public enum Direction {
     case sending
     case receiving

--- a/swift/Sources/SignalClient/Error.swift
+++ b/swift/Sources/SignalClient/Error.swift
@@ -1,10 +1,12 @@
 //
-// Copyright 2020-2021 Signal Messenger, LLC
+// Copyright 2020 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-#if canImport(CocoaLumberjack)
-import CocoaLumberjack
+import SignalFfi
+
+#if canImport(SignalCoreKit)
+import SignalCoreKit
 #endif
 
 public enum SignalError: Error {
@@ -101,23 +103,16 @@ internal func checkError(_ error: SignalFfiErrorRef?) throws {
     }
 }
 
-internal func failOnError(_ error: SignalFfiErrorRef?,
-                          file: StaticString = #file,
-                          function: StaticString = #function,
-                          line: UInt = #line) {
-    failOnError(file: file, function: function, line: line) { try checkError(error) }
+internal func failOnError(_ error: SignalFfiErrorRef?) {
+    failOnError { try checkError(error) }
 }
 
-internal func failOnError<Result>(file: StaticString = #file,
-                                  function: StaticString = #function,
-                                  line: UInt = #line,
-                                  _ fn: () throws -> Result) -> Result {
-#if canImport(CocoaLumberjack)
+internal func failOnError<Result>(_ fn: () throws -> Result) -> Result {
+#if canImport(SignalCoreKit)
     do {
         return try fn()
     } catch {
-        DDLogError("❤️ \(error)", file: file, function: function, line: line)
-        fatalError("\(error)")
+        owsFail("unexpected error: \(error)")
     }
 #else
     return try! fn()

--- a/swift/Sources/SignalClient/Fingerprint.swift
+++ b/swift/Sources/SignalClient/Fingerprint.swift
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+import SignalFfi
 import Foundation
 
 public struct DisplayableFingerprint {

--- a/swift/Sources/SignalClient/IdentityKey.swift
+++ b/swift/Sources/SignalClient/IdentityKey.swift
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+import SignalFfi
 import Foundation
 
 public struct IdentityKey: Equatable {

--- a/swift/Sources/SignalClient/Kdf.swift
+++ b/swift/Sources/SignalClient/Kdf.swift
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+import SignalFfi
 import Foundation
 
 public func hkdf<InputBytes, SaltBytes, InfoBytes>(outputLength: Int,

--- a/swift/Sources/SignalClient/PrivateKey.swift
+++ b/swift/Sources/SignalClient/PrivateKey.swift
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+import SignalFfi
 import Foundation
 
 public class PrivateKey: ClonableHandleOwner {

--- a/swift/Sources/SignalClient/Protocol.swift
+++ b/swift/Sources/SignalClient/Protocol.swift
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+import SignalFfi
 import Foundation
 
 /*

--- a/swift/Sources/SignalClient/PublicKey.swift
+++ b/swift/Sources/SignalClient/PublicKey.swift
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+import SignalFfi
 import Foundation
 
 public class PublicKey: ClonableHandleOwner {

--- a/swift/Sources/SignalClient/SealedSender.swift
+++ b/swift/Sources/SignalClient/SealedSender.swift
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+import SignalFfi
 import Foundation
 
 public class ServerCertificate: ClonableHandleOwner {

--- a/swift/Sources/SignalClient/SenderKeyName.swift
+++ b/swift/Sources/SignalClient/SenderKeyName.swift
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+import SignalFfi
+
 public class SenderKeyName: ClonableHandleOwner {
     internal override class func destroyNativeHandle(_ handle: OpaquePointer) -> SignalFfiErrorRef? {
         return signal_sender_key_name_destroy(handle)

--- a/swift/Sources/SignalClient/Utils.swift
+++ b/swift/Sources/SignalClient/Utils.swift
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+import SignalFfi
+
 internal func invokeFnReturningString(fn: (UnsafeMutablePointer<UnsafePointer<CChar>?>?) -> SignalFfiErrorRef?) throws -> String {
     var output: UnsafePointer<Int8>?
     try checkError(fn(&output))

--- a/swift/Sources/SignalClient/messages/CiphertextMessage.swift
+++ b/swift/Sources/SignalClient/messages/CiphertextMessage.swift
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+import SignalFfi
+
 public class CiphertextMessage {
     private var handle: OpaquePointer?
 

--- a/swift/Sources/SignalClient/messages/PreKeySignalMessage.swift
+++ b/swift/Sources/SignalClient/messages/PreKeySignalMessage.swift
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+import SignalFfi
 import Foundation
 
 public class PreKeySignalMessage {

--- a/swift/Sources/SignalClient/messages/SenderKeyDistributionMessage.swift
+++ b/swift/Sources/SignalClient/messages/SenderKeyDistributionMessage.swift
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+import SignalFfi
 import Foundation
 
 public class SenderKeyDistributionMessage {

--- a/swift/Sources/SignalClient/messages/SenderKeyMessage.swift
+++ b/swift/Sources/SignalClient/messages/SenderKeyMessage.swift
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+import SignalFfi
 import Foundation
 
 public class SenderKeyMessage {

--- a/swift/Sources/SignalClient/messages/SignalMessage.swift
+++ b/swift/Sources/SignalClient/messages/SignalMessage.swift
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+import SignalFfi
 import Foundation
 
 public class SignalMessage {

--- a/swift/Sources/SignalClient/state/PreKeyBundle.swift
+++ b/swift/Sources/SignalClient/state/PreKeyBundle.swift
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+import SignalFfi
 import Foundation
 
 public class PreKeyBundle {

--- a/swift/Sources/SignalClient/state/PreKeyRecord.swift
+++ b/swift/Sources/SignalClient/state/PreKeyRecord.swift
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+import SignalFfi
 import Foundation
 
 public class PreKeyRecord: ClonableHandleOwner {

--- a/swift/Sources/SignalClient/state/SenderKeyRecord.swift
+++ b/swift/Sources/SignalClient/state/SenderKeyRecord.swift
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+import SignalFfi
 import Foundation
 
 public class SenderKeyRecord: ClonableHandleOwner {

--- a/swift/Sources/SignalClient/state/SessionRecord.swift
+++ b/swift/Sources/SignalClient/state/SessionRecord.swift
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+import SignalFfi
 import Foundation
 
 public class SessionRecord: ClonableHandleOwner {

--- a/swift/Sources/SignalClient/state/SignedPreKeyRecord.swift
+++ b/swift/Sources/SignalClient/state/SignedPreKeyRecord.swift
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+import SignalFfi
 import Foundation
 
 public class SignedPreKeyRecord: ClonableHandleOwner {

--- a/swift/Sources/SignalFfi/module.modulemap
+++ b/swift/Sources/SignalFfi/module.modulemap
@@ -4,4 +4,5 @@
 //
 module SignalFfi {
 	header "signal_ffi.h"
+	link "signal_ffi"
 }

--- a/swift/Tests/SignalClientTests/TestCaseBase.swift
+++ b/swift/Tests/SignalClientTests/TestCaseBase.swift
@@ -3,17 +3,17 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-import SignalClient
 import XCTest
+import SignalFfi
 
-#if canImport(CocoaLumberjack)
-import CocoaLumberjack
+#if canImport(SignalCoreKit)
+import SignalCoreKit
 #endif
 
 class TestCaseBase: XCTestCase {
     // Use a static stored property for one-time initialization.
     static let loggingInitialized: Bool = {
-#if canImport(CocoaLumberjack)
+#if canImport(SignalCoreKit)
         DDLog.add(DDOSLogger.sharedInstance)
 #else
         signal_init_logger(SignalLogLevel_Trace, .init(

--- a/swift/build_ffi.sh
+++ b/swift/build_ffi.sh
@@ -11,6 +11,8 @@ SCRIPT_DIR=$(dirname "$0")
 cd "${SCRIPT_DIR}"/..
 . bin/build_helpers.sh
 
+export CARGO_PROFILE_RELEASE_DEBUG=1 # enable line tables
+
 usage() {
   cat >&2 <<END
 Usage: $(basename "$0") [-d]


### PR DESCRIPTION
Reverts #163 in favor of an alternate approach to using cocoapods-binary that allows the Swift code to be built on the app side, avoiding some LLDB/Swift integration issues.
