### PR TITLE
Curve related cleanups

### DIFF
--- a/rust/bridge/node/src/lib.rs
+++ b/rust/bridge/node/src/lib.rs
@@ -10,10 +10,10 @@ use libsignal_protocol::*;
 use neon::context::Context;
 use neon::prelude::*;
 use signal_neon_futures::*;
+use std::convert::TryFrom;
 use std::fmt;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
-use std::convert::TryFrom;
 
 pub mod logging;
 

--- a/rust/bridge/node/src/lib.rs
+++ b/rust/bridge/node/src/lib.rs
@@ -538,7 +538,7 @@ impl IdentityKeyStore for NodeIdentityStore {
             .await
             .map_err(|s| js_error_to_rust("getIdentityPrivateKey", s))?;
 
-        IdentityKeyPair::from_private_key(pk)
+        IdentityKeyPair::try_from(pk)
     }
 
     async fn get_local_registration_id(

--- a/rust/bridge/node/src/lib.rs
+++ b/rust/bridge/node/src/lib.rs
@@ -13,6 +13,7 @@ use signal_neon_futures::*;
 use std::fmt;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
+use std::convert::TryFrom;
 
 pub mod logging;
 

--- a/rust/protocol/src/curve.rs
+++ b/rust/protocol/src/curve.rs
@@ -5,7 +5,7 @@
 
 mod curve25519;
 
-use crate::error::{Result, SignalProtocolError};
+use crate::{Result, SignalProtocolError};
 
 use std::cmp::Ordering;
 use std::convert::TryFrom;

--- a/rust/protocol/src/fingerprint.rs
+++ b/rust/protocol/src/fingerprint.rs
@@ -3,9 +3,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use crate::error::{Result, SignalProtocolError};
 use crate::proto;
-use crate::IdentityKey;
+use crate::{IdentityKey, Result, SignalProtocolError};
 use prost::Message;
 use sha2::{digest::Digest, Sha512};
 use std::fmt;

--- a/rust/protocol/src/group_cipher.rs
+++ b/rust/protocol/src/group_cipher.rs
@@ -5,11 +5,10 @@
 
 use crate::consts;
 use crate::crypto;
-use crate::curve;
 use crate::error::Result;
 use crate::protocol::{SenderKeyDistributionMessage, SenderKeyMessage};
 use crate::sender_keys::{SenderKeyRecord, SenderKeyState, SenderMessageKey};
-use crate::{Context, SenderKeyName, SenderKeyStore, SignalProtocolError};
+use crate::{Context, KeyPair, SenderKeyName, SenderKeyStore, SignalProtocolError};
 
 use rand::{CryptoRng, Rng};
 use std::convert::TryFrom;
@@ -159,7 +158,7 @@ pub async fn create_sender_key_distribution_message<R: Rng + CryptoRng>(
         let sender_key_id = (csprng.gen::<u32>()) >> 1;
         let iteration = 0;
         let sender_key: [u8; 32] = csprng.gen();
-        let signing_key = curve::KeyPair::generate(csprng);
+        let signing_key = KeyPair::generate(csprng);
         sender_key_record.set_sender_key_state(
             sender_key_id,
             iteration,

--- a/rust/protocol/src/group_cipher.rs
+++ b/rust/protocol/src/group_cipher.rs
@@ -5,10 +5,13 @@
 
 use crate::consts;
 use crate::crypto;
-use crate::error::Result;
-use crate::protocol::{SenderKeyDistributionMessage, SenderKeyMessage};
-use crate::sender_keys::{SenderKeyRecord, SenderKeyState, SenderMessageKey};
-use crate::{Context, KeyPair, SenderKeyName, SenderKeyStore, SignalProtocolError};
+
+use crate::{
+    Context, KeyPair, Result, SenderKeyDistributionMessage, SenderKeyMessage, SenderKeyName,
+    SenderKeyRecord, SenderKeyStore, SignalProtocolError,
+};
+
+use crate::sender_keys::{SenderKeyState, SenderMessageKey};
 
 use rand::{CryptoRng, Rng};
 use std::convert::TryFrom;

--- a/rust/protocol/src/kdf.rs
+++ b/rust/protocol/src/kdf.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use crate::error::{Result, SignalProtocolError};
+use crate::{Result, SignalProtocolError};
 
 use hmac::{Hmac, Mac, NewMac};
 use sha2::Sha256;

--- a/rust/protocol/src/lib.rs
+++ b/rust/protocol/src/lib.rs
@@ -25,6 +25,8 @@ mod state;
 mod storage;
 mod utils;
 
+use error::Result;
+
 pub use {
     address::ProtocolAddress,
     curve::{KeyPair, PrivateKey, PublicKey},

--- a/rust/protocol/src/protocol.rs
+++ b/rust/protocol/src/protocol.rs
@@ -5,7 +5,7 @@
 
 use crate::error::{Result, SignalProtocolError};
 use crate::IdentityKey;
-use crate::{curve, proto};
+use crate::{proto, PrivateKey, PublicKey};
 
 use std::convert::TryFrom;
 
@@ -57,7 +57,7 @@ impl CiphertextMessage {
 #[derive(Debug, Clone)]
 pub struct SignalMessage {
     message_version: u8,
-    sender_ratchet_key: curve::PublicKey,
+    sender_ratchet_key: PublicKey,
     counter: u32,
     #[allow(dead_code)]
     previous_counter: u32,
@@ -71,7 +71,7 @@ impl SignalMessage {
     pub fn new(
         message_version: u8,
         mac_key: &[u8],
-        sender_ratchet_key: curve::PublicKey,
+        sender_ratchet_key: PublicKey,
         counter: u32,
         previous_counter: u32,
         ciphertext: &[u8],
@@ -112,7 +112,7 @@ impl SignalMessage {
     }
 
     #[inline]
-    pub fn sender_ratchet_key(&self) -> &curve::PublicKey {
+    pub fn sender_ratchet_key(&self) -> &PublicKey {
         &self.sender_ratchet_key
     }
 
@@ -212,7 +212,7 @@ impl TryFrom<&[u8]> for SignalMessage {
         let sender_ratchet_key = proto_structure
             .ratchet_key
             .ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
-        let sender_ratchet_key = curve::decode_point(&sender_ratchet_key)?;
+        let sender_ratchet_key = PublicKey::deserialize(&sender_ratchet_key)?;
         let counter = proto_structure
             .counter
             .ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
@@ -239,7 +239,7 @@ pub struct PreKeySignalMessage {
     registration_id: u32,
     pre_key_id: Option<u32>,
     signed_pre_key_id: u32,
-    base_key: curve::PublicKey,
+    base_key: PublicKey,
     identity_key: IdentityKey,
     message: SignalMessage,
     serialized: Box<[u8]>,
@@ -251,7 +251,7 @@ impl PreKeySignalMessage {
         registration_id: u32,
         pre_key_id: Option<u32>,
         signed_pre_key_id: u32,
-        base_key: curve::PublicKey,
+        base_key: PublicKey,
         identity_key: IdentityKey,
         message: SignalMessage,
     ) -> Result<Self> {
@@ -299,7 +299,7 @@ impl PreKeySignalMessage {
     }
 
     #[inline]
-    pub fn base_key(&self) -> &curve::PublicKey {
+    pub fn base_key(&self) -> &PublicKey {
         &self.base_key
     }
 
@@ -354,7 +354,7 @@ impl TryFrom<&[u8]> for PreKeySignalMessage {
         {
             return Err(SignalProtocolError::InvalidProtobufEncoding);
         }
-        let base_key = curve::decode_point(proto_structure.base_key.unwrap().as_ref())?;
+        let base_key = PublicKey::deserialize(proto_structure.base_key.unwrap().as_ref())?;
         Ok(PreKeySignalMessage {
             message_version,
             registration_id: proto_structure.registration_id.unwrap_or(0),
@@ -385,7 +385,7 @@ impl SenderKeyMessage {
         iteration: u32,
         ciphertext: &[u8],
         csprng: &mut R,
-        signature_key: &curve::PrivateKey,
+        signature_key: &PrivateKey,
     ) -> Result<Self> {
         let proto_message = proto::wire::SenderKeyMessage {
             id: Some(key_id),
@@ -397,11 +397,8 @@ impl SenderKeyMessage {
         serialized[0] =
             ((CIPHERTEXT_MESSAGE_CURRENT_VERSION & 0xF) << 4) | CIPHERTEXT_MESSAGE_CURRENT_VERSION;
         proto_message.encode(&mut &mut serialized[1..1 + proto_message_len])?;
-        let signature = curve::calculate_signature(
-            csprng,
-            signature_key,
-            &serialized[..1 + proto_message_len],
-        )?;
+        let signature =
+            signature_key.calculate_signature(&serialized[..1 + proto_message_len], csprng)?;
         serialized[1 + proto_message_len..].copy_from_slice(&signature[..]);
         Ok(Self {
             message_version: CIPHERTEXT_MESSAGE_CURRENT_VERSION,
@@ -412,9 +409,8 @@ impl SenderKeyMessage {
         })
     }
 
-    pub fn verify_signature(&self, signature_key: &curve::PublicKey) -> Result<bool> {
-        let valid = curve::verify_signature(
-            signature_key,
+    pub fn verify_signature(&self, signature_key: &PublicKey) -> Result<bool> {
+        let valid = signature_key.verify_signature(
             &self.serialized[..self.serialized.len() - Self::SIGNATURE_LEN],
             &self.serialized[self.serialized.len() - Self::SIGNATURE_LEN..],
         )?;
@@ -503,17 +499,12 @@ pub struct SenderKeyDistributionMessage {
     id: u32,
     iteration: u32,
     chain_key: Vec<u8>,
-    signing_key: curve::PublicKey,
+    signing_key: PublicKey,
     serialized: Box<[u8]>,
 }
 
 impl SenderKeyDistributionMessage {
-    pub fn new(
-        id: u32,
-        iteration: u32,
-        chain_key: &[u8],
-        signing_key: curve::PublicKey,
-    ) -> Result<Self> {
+    pub fn new(id: u32, iteration: u32, chain_key: &[u8], signing_key: PublicKey) -> Result<Self> {
         let proto_message = proto::wire::SenderKeyDistributionMessage {
             id: Some(id),
             iteration: Some(iteration),
@@ -556,7 +547,7 @@ impl SenderKeyDistributionMessage {
     }
 
     #[inline]
-    pub fn signing_key(&self) -> Result<&curve::PublicKey> {
+    pub fn signing_key(&self) -> Result<&PublicKey> {
         Ok(&self.signing_key)
     }
 
@@ -613,7 +604,7 @@ impl TryFrom<&[u8]> for SenderKeyDistributionMessage {
             return Err(SignalProtocolError::InvalidProtobufEncoding);
         }
 
-        let signing_key = curve::PublicKey::deserialize(&signing_key)?;
+        let signing_key = PublicKey::deserialize(&signing_key)?;
 
         Ok(SenderKeyDistributionMessage {
             message_version,
@@ -629,6 +620,7 @@ impl TryFrom<&[u8]> for SenderKeyDistributionMessage {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::KeyPair;
 
     use rand::rngs::OsRng;
     use rand::{CryptoRng, Rng};
@@ -645,9 +637,9 @@ mod tests {
         csprng.fill_bytes(&mut ciphertext);
         let ciphertext = ciphertext;
 
-        let sender_ratchet_key_pair = curve::KeyPair::generate(csprng);
-        let sender_identity_key_pair = curve::KeyPair::generate(csprng);
-        let receiver_identity_key_pair = curve::KeyPair::generate(csprng);
+        let sender_ratchet_key_pair = KeyPair::generate(csprng);
+        let sender_identity_key_pair = KeyPair::generate(csprng);
+        let receiver_identity_key_pair = KeyPair::generate(csprng);
 
         SignalMessage::new(
             3,
@@ -683,8 +675,8 @@ mod tests {
     #[test]
     fn test_pre_key_signal_message_serialize_deserialize() {
         let mut csprng = OsRng;
-        let identity_key_pair = curve::KeyPair::generate(&mut csprng);
-        let base_key_pair = curve::KeyPair::generate(&mut csprng);
+        let identity_key_pair = KeyPair::generate(&mut csprng);
+        let base_key_pair = KeyPair::generate(&mut csprng);
         let message = create_signal_message(&mut csprng);
         let pre_key_signal_message = PreKeySignalMessage::new(
             3,
@@ -736,7 +728,7 @@ mod tests {
     #[test]
     fn test_sender_key_message_serialize_deserialize() {
         let mut csprng = OsRng;
-        let signature_key_pair = curve::KeyPair::generate(&mut csprng);
+        let signature_key_pair = KeyPair::generate(&mut csprng);
         let sender_key_message = SenderKeyMessage::new(
             42,
             7,

--- a/rust/protocol/src/protocol.rs
+++ b/rust/protocol/src/protocol.rs
@@ -3,9 +3,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use crate::error::{Result, SignalProtocolError};
-use crate::IdentityKey;
-use crate::{proto, PrivateKey, PublicKey};
+use crate::proto;
+use crate::{IdentityKey, PrivateKey, PublicKey, Result, SignalProtocolError};
 
 use std::convert::TryFrom;
 

--- a/rust/protocol/src/ratchet.rs
+++ b/rust/protocol/src/ratchet.rs
@@ -10,8 +10,8 @@ pub use self::keys::{ChainKey, MessageKeys, RootKey};
 pub use self::params::{AliceSignalProtocolParameters, BobSignalProtocolParameters};
 use crate::proto::storage::SessionStructure;
 use crate::protocol::CIPHERTEXT_MESSAGE_CURRENT_VERSION;
-use crate::state::{SessionRecord, SessionState};
-use crate::{KeyPair, Result};
+use crate::state::SessionState;
+use crate::{KeyPair, Result, SessionRecord};
 use rand::{CryptoRng, Rng};
 
 fn derive_keys(secret_input: &[u8]) -> Result<(RootKey, ChainKey)> {

--- a/rust/protocol/src/ratchet.rs
+++ b/rust/protocol/src/ratchet.rs
@@ -8,11 +8,10 @@ mod params;
 
 pub use self::keys::{ChainKey, MessageKeys, RootKey};
 pub use self::params::{AliceSignalProtocolParameters, BobSignalProtocolParameters};
-use crate::curve;
-use crate::error::Result;
 use crate::proto::storage::SessionStructure;
 use crate::protocol::CIPHERTEXT_MESSAGE_CURRENT_VERSION;
 use crate::state::{SessionRecord, SessionState};
+use crate::{KeyPair, Result};
 use rand::{CryptoRng, Rng};
 
 fn derive_keys(secret_input: &[u8]) -> Result<(RootKey, ChainKey)> {
@@ -32,7 +31,7 @@ pub(crate) fn initialize_alice_session<R: Rng + CryptoRng>(
 ) -> Result<SessionState> {
     let local_identity = parameters.our_identity_key_pair().identity_key();
 
-    let sending_ratchet_key = curve::KeyPair::generate(&mut csprng);
+    let sending_ratchet_key = KeyPair::generate(&mut csprng);
 
     let mut secrets = Vec::with_capacity(32 * 5);
 
@@ -40,26 +39,24 @@ pub(crate) fn initialize_alice_session<R: Rng + CryptoRng>(
 
     let our_base_private_key = parameters.our_base_key_pair().private_key;
 
-    secrets.extend_from_slice(&curve::calculate_agreement(
-        parameters.their_signed_pre_key(),
-        parameters.our_identity_key_pair().private_key(),
-    )?);
+    secrets.extend_from_slice(
+        &parameters
+            .our_identity_key_pair()
+            .private_key()
+            .calculate_agreement(parameters.their_signed_pre_key())?,
+    );
 
-    secrets.extend_from_slice(&curve::calculate_agreement(
-        parameters.their_identity_key().public_key(),
-        &our_base_private_key,
-    )?);
+    secrets.extend_from_slice(
+        &our_base_private_key.calculate_agreement(parameters.their_identity_key().public_key())?,
+    );
 
-    secrets.extend_from_slice(&curve::calculate_agreement(
-        parameters.their_signed_pre_key(),
-        &our_base_private_key,
-    )?);
+    secrets.extend_from_slice(
+        &our_base_private_key.calculate_agreement(parameters.their_signed_pre_key())?,
+    );
 
     if let Some(their_one_time_prekey) = parameters.their_one_time_pre_key() {
-        secrets.extend_from_slice(&curve::calculate_agreement(
-            their_one_time_prekey,
-            &our_base_private_key,
-        )?);
+        secrets
+            .extend_from_slice(&our_base_private_key.calculate_agreement(their_one_time_prekey)?);
     }
 
     let (root_key, chain_key) = derive_keys(&secrets)?;
@@ -101,26 +98,33 @@ pub(crate) fn initialize_bob_session(
 
     secrets.extend_from_slice(&[0xFFu8; 32]); // "discontinuity bytes"
 
-    secrets.extend_from_slice(&curve::calculate_agreement(
-        parameters.their_identity_key().public_key(),
-        &parameters.our_signed_pre_key_pair().private_key,
-    )?);
+    secrets.extend_from_slice(
+        &parameters
+            .our_signed_pre_key_pair()
+            .private_key
+            .calculate_agreement(parameters.their_identity_key().public_key())?,
+    );
 
-    secrets.extend_from_slice(&curve::calculate_agreement(
-        parameters.their_base_key(),
-        parameters.our_identity_key_pair().private_key(),
-    )?);
+    secrets.extend_from_slice(
+        &parameters
+            .our_identity_key_pair()
+            .private_key()
+            .calculate_agreement(parameters.their_base_key())?,
+    );
 
-    secrets.extend_from_slice(&curve::calculate_agreement(
-        parameters.their_base_key(),
-        &parameters.our_signed_pre_key_pair().private_key,
-    )?);
+    secrets.extend_from_slice(
+        &parameters
+            .our_signed_pre_key_pair()
+            .private_key
+            .calculate_agreement(parameters.their_base_key())?,
+    );
 
     if let Some(our_one_time_pre_key_pair) = parameters.our_one_time_pre_key_pair() {
-        secrets.extend_from_slice(&curve::calculate_agreement(
-            parameters.their_base_key(),
-            &our_one_time_pre_key_pair.private_key,
-        )?);
+        secrets.extend_from_slice(
+            &our_one_time_pre_key_pair
+                .private_key
+                .calculate_agreement(parameters.their_base_key())?,
+        );
     }
 
     let (root_key, chain_key) = derive_keys(&secrets)?;

--- a/rust/protocol/src/ratchet/keys.rs
+++ b/rust/protocol/src/ratchet/keys.rs
@@ -6,8 +6,7 @@
 use arrayref::array_ref;
 
 use crate::crypto;
-use crate::kdf::HKDF;
-use crate::{PrivateKey, PublicKey, Result, SignalProtocolError};
+use crate::{PrivateKey, PublicKey, Result, SignalProtocolError, HKDF};
 use std::fmt;
 
 pub struct MessageKeys {

--- a/rust/protocol/src/ratchet/keys.rs
+++ b/rust/protocol/src/ratchet/keys.rs
@@ -6,9 +6,8 @@
 use arrayref::array_ref;
 
 use crate::crypto;
-use crate::curve;
-use crate::error::{Result, SignalProtocolError};
 use crate::kdf::HKDF;
+use crate::{PrivateKey, PublicKey, Result, SignalProtocolError};
 use std::fmt;
 
 pub struct MessageKeys {
@@ -146,10 +145,10 @@ impl RootKey {
 
     pub fn create_chain(
         &self,
-        their_ratchet_key: &curve::PublicKey,
-        our_ratchet_key: &curve::PrivateKey,
+        their_ratchet_key: &PublicKey,
+        our_ratchet_key: &PrivateKey,
     ) -> Result<(RootKey, ChainKey)> {
-        let shared_secret = curve::calculate_agreement(their_ratchet_key, our_ratchet_key)?;
+        let shared_secret = our_ratchet_key.calculate_agreement(their_ratchet_key)?;
         let derived_secret_bytes = self.kdf.derive_salted_secrets(
             shared_secret.as_ref(),
             &self.key,
@@ -179,6 +178,7 @@ impl fmt::Display for RootKey {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{PrivateKey, PublicKey};
 
     #[test]
     fn test_chain_key_derivation_v2() -> Result<()> {
@@ -285,8 +285,8 @@ mod tests {
             0xa7, 0xe3, 0x35, 0xd1,
         ];
 
-        let alice_private_key = curve::decode_private_point(&alice_private)?;
-        let bob_public_key = curve::decode_point(&bob_public)?;
+        let alice_private_key = PrivateKey::deserialize(&alice_private)?;
+        let bob_public_key = PublicKey::deserialize(&bob_public)?;
         let root_key = RootKey::new(HKDF::new(2)?, &root_key_seed)?;
 
         let (next_root_key, next_chain_key) =

--- a/rust/protocol/src/sealed_sender.rs
+++ b/rust/protocol/src/sealed_sender.rs
@@ -53,10 +53,10 @@ impl ServerCertificate {
             .ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
         let certificate_data =
             proto::sealed_sender::server_certificate::Certificate::decode(certificate.as_ref())?;
-        let key = PublicKey::deserialize(
+        let key = PublicKey::try_from(
             &certificate_data
                 .key
-                .ok_or(SignalProtocolError::InvalidProtobufEncoding)?,
+                .ok_or(SignalProtocolError::InvalidProtobufEncoding)?[..],
         )?;
         let key_id = certificate_data
             .id
@@ -177,10 +177,10 @@ impl SenderCertificate {
             .ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
         let sender_e164 = certificate_data.sender_e164;
 
-        let key = PublicKey::deserialize(
+        let key = PublicKey::try_from(
             &certificate_data
                 .identity_key
-                .ok_or(SignalProtocolError::InvalidProtobufEncoding)?,
+                .ok_or(SignalProtocolError::InvalidProtobufEncoding)?[..],
         )?;
 
         let mut signer_bits = vec![];
@@ -434,7 +434,7 @@ impl UnidentifiedSenderMessage {
             .encrypted_message
             .ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
 
-        let ephemeral_public = PublicKey::deserialize(&ephemeral_public)?;
+        let ephemeral_public = PublicKey::try_from(&ephemeral_public[..])?;
 
         let serialized = data.to_vec();
 
@@ -643,7 +643,7 @@ pub async fn sealed_sender_decrypt_to_usmc(
         &eph_keys.mac_key()?,
     )?;
 
-    let static_key = PublicKey::deserialize(&static_key_bytes)?;
+    let static_key = PublicKey::try_from(&static_key_bytes[..])?;
 
     let static_keys = StaticKeys::calculate(
         &static_key,

--- a/rust/protocol/src/sealed_sender.rs
+++ b/rust/protocol/src/sealed_sender.rs
@@ -3,16 +3,15 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use crate::crypto;
-use crate::error::{Result, SignalProtocolError};
-use crate::kdf::HKDF;
-use crate::proto;
-use crate::session_cipher;
 use crate::{
     message_encrypt, CiphertextMessageType, Context, IdentityKeyStore, KeyPair,
-    PreKeySignalMessage, PreKeyStore, PrivateKey, ProtocolAddress, PublicKey, SessionStore,
-    SignalMessage, SignedPreKeyStore,
+    PreKeySignalMessage, PreKeyStore, PrivateKey, ProtocolAddress, PublicKey, Result, SessionStore,
+    SignalMessage, SignalProtocolError, SignedPreKeyStore, HKDF,
 };
+
+use crate::crypto;
+use crate::proto;
+use crate::session_cipher;
 use prost::Message;
 use rand::{CryptoRng, Rng};
 use std::convert::TryFrom;

--- a/rust/protocol/src/sender_keys.rs
+++ b/rust/protocol/src/sender_keys.rs
@@ -5,14 +5,13 @@
 
 use crate::consts;
 use crate::crypto::hmac_sha256;
-use crate::curve;
-use crate::error::{Result, SignalProtocolError};
 use crate::kdf::HKDF;
 use crate::proto::storage as storage_proto;
-use crate::ProtocolAddress;
+use crate::{PrivateKey, ProtocolAddress, PublicKey, Result, SignalProtocolError};
 
 use prost::Message;
 use std::collections::VecDeque;
+use std::convert::TryFrom;
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct SenderKeyName {
@@ -158,8 +157,8 @@ impl SenderKeyState {
         id: u32,
         iteration: u32,
         chain_key: &[u8],
-        signature_key: curve::PublicKey,
-        signature_private_key: Option<curve::PrivateKey>,
+        signature_key: PublicKey,
+        signature_private_key: Option<PrivateKey>,
     ) -> Result<SenderKeyState> {
         let state = storage_proto::SenderKeyStateStructure {
             sender_key_id: id,
@@ -214,17 +213,17 @@ impl SenderKeyState {
         Ok(())
     }
 
-    pub fn signing_key_public(&self) -> Result<curve::PublicKey> {
+    pub fn signing_key_public(&self) -> Result<PublicKey> {
         if let Some(ref signing_key) = self.state.sender_signing_key {
-            Ok(curve::PublicKey::deserialize(&signing_key.public)?)
+            Ok(PublicKey::try_from(&signing_key.public[..])?)
         } else {
             Err(SignalProtocolError::InvalidProtobufEncoding)
         }
     }
 
-    pub fn signing_key_private(&self) -> Result<curve::PrivateKey> {
+    pub fn signing_key_private(&self) -> Result<PrivateKey> {
         if let Some(ref signing_key) = self.state.sender_signing_key {
-            Ok(curve::PrivateKey::deserialize(&signing_key.private)?)
+            Ok(PrivateKey::deserialize(&signing_key.private)?)
         } else {
             Err(SignalProtocolError::InvalidProtobufEncoding)
         }
@@ -318,8 +317,8 @@ impl SenderKeyRecord {
         id: u32,
         iteration: u32,
         chain_key: &[u8],
-        signature_key: curve::PublicKey,
-        signature_private_key: Option<curve::PrivateKey>,
+        signature_key: PublicKey,
+        signature_private_key: Option<PrivateKey>,
     ) -> Result<()> {
         self.states.push_front(SenderKeyState::new(
             id,
@@ -340,8 +339,8 @@ impl SenderKeyRecord {
         id: u32,
         iteration: u32,
         chain_key: &[u8],
-        signature_key: curve::PublicKey,
-        signature_private_key: Option<curve::PrivateKey>,
+        signature_key: PublicKey,
+        signature_private_key: Option<PrivateKey>,
     ) -> Result<()> {
         self.states.clear();
         self.add_sender_key_state(

--- a/rust/protocol/src/sender_keys.rs
+++ b/rust/protocol/src/sender_keys.rs
@@ -5,9 +5,8 @@
 
 use crate::consts;
 use crate::crypto::hmac_sha256;
-use crate::kdf::HKDF;
 use crate::proto::storage as storage_proto;
-use crate::{PrivateKey, ProtocolAddress, PublicKey, Result, SignalProtocolError};
+use crate::{PrivateKey, ProtocolAddress, PublicKey, Result, SignalProtocolError, HKDF};
 
 use prost::Message;
 use std::collections::VecDeque;

--- a/rust/protocol/src/session.rs
+++ b/rust/protocol/src/session.rs
@@ -4,11 +4,10 @@
 //
 
 use crate::{
-    Context, IdentityKeyStore, PreKeyStore, ProtocolAddress, SessionRecord, SessionStore,
+    Context, IdentityKeyStore, KeyPair, PreKeyStore, ProtocolAddress, SessionRecord, SessionStore,
     SignalProtocolError, SignedPreKeyStore,
 };
 
-use crate::curve;
 use crate::error::Result;
 use crate::protocol::PreKeySignalMessage;
 use crate::ratchet;
@@ -142,8 +141,7 @@ pub async fn process_prekey_bundle<R: Rng + CryptoRng>(
         ));
     }
 
-    if !curve::verify_signature(
-        their_identity_key.public_key(),
+    if !their_identity_key.public_key().verify_signature(
         &bundle.signed_pre_key_public()?.serialize(),
         bundle.signed_pre_key_signature()?,
     )? {
@@ -155,7 +153,7 @@ pub async fn process_prekey_bundle<R: Rng + CryptoRng>(
         .await?
         .unwrap_or_else(SessionRecord::new_fresh);
 
-    let our_base_key_pair = curve::KeyPair::generate(&mut csprng);
+    let our_base_key_pair = KeyPair::generate(&mut csprng);
     let their_signed_prekey = bundle.signed_pre_key_public()?;
 
     let their_one_time_prekey = bundle.pre_key_public()?;

--- a/rust/protocol/src/session.rs
+++ b/rust/protocol/src/session.rs
@@ -4,16 +4,13 @@
 //
 
 use crate::{
-    Context, IdentityKeyStore, KeyPair, PreKeyStore, ProtocolAddress, SessionRecord, SessionStore,
-    SignalProtocolError, SignedPreKeyStore,
+    Context, Direction, IdentityKeyStore, KeyPair, PreKeyBundle, PreKeySignalMessage, PreKeyStore,
+    ProtocolAddress, Result, SessionRecord, SessionStore, SignalProtocolError, SignedPreKeyStore,
 };
 
-use crate::error::Result;
-use crate::protocol::PreKeySignalMessage;
 use crate::ratchet;
 use crate::ratchet::{AliceSignalProtocolParameters, BobSignalProtocolParameters};
-use crate::state::{PreKeyBundle, PreKeyId};
-use crate::storage::Direction;
+use crate::state::PreKeyId;
 use rand::{CryptoRng, Rng};
 
 /*

--- a/rust/protocol/src/session_cipher.rs
+++ b/rust/protocol/src/session_cipher.rs
@@ -4,19 +4,16 @@
 //
 
 use crate::{
-    Context, IdentityKeyStore, PreKeyStore, ProtocolAddress, SessionRecord, SessionStore,
+    CiphertextMessage, Context, Direction, IdentityKeyStore, KeyPair, PreKeySignalMessage,
+    PreKeyStore, ProtocolAddress, PublicKey, Result, SessionRecord, SessionStore, SignalMessage,
     SignalProtocolError, SignedPreKeyStore,
 };
 
 use crate::consts::MAX_FORWARD_JUMPS;
 use crate::crypto;
-use crate::curve;
-use crate::error::Result;
-use crate::protocol::{CiphertextMessage, PreKeySignalMessage, SignalMessage};
 use crate::ratchet::{ChainKey, MessageKeys};
 use crate::session;
 use crate::state::SessionState;
-use crate::storage::Direction;
 
 use rand::{CryptoRng, Rng};
 
@@ -487,7 +484,7 @@ fn decrypt_message_with_state<R: Rng + CryptoRng>(
 
 fn get_or_create_chain_key<R: Rng + CryptoRng>(
     state: &mut SessionState,
-    their_ephemeral: &curve::PublicKey,
+    their_ephemeral: &PublicKey,
     remote_address: &ProtocolAddress,
     csprng: &mut R,
 ) -> Result<ChainKey> {
@@ -501,7 +498,7 @@ fn get_or_create_chain_key<R: Rng + CryptoRng>(
     let root_key = state.root_key()?;
     let our_ephemeral = state.sender_ratchet_private_key()?;
     let receiver_chain = root_key.create_chain(their_ephemeral, &our_ephemeral)?;
-    let our_new_ephemeral = curve::KeyPair::generate(csprng);
+    let our_new_ephemeral = KeyPair::generate(csprng);
     let sender_chain = receiver_chain
         .0
         .create_chain(their_ephemeral, &our_new_ephemeral.private_key)?;
@@ -523,7 +520,7 @@ fn get_or_create_chain_key<R: Rng + CryptoRng>(
 
 fn get_or_create_message_key(
     state: &mut SessionState,
-    their_ephemeral: &curve::PublicKey,
+    their_ephemeral: &PublicKey,
     remote_address: &ProtocolAddress,
     chain_key: &ChainKey,
     counter: u32,

--- a/rust/protocol/src/state/bundle.rs
+++ b/rust/protocol/src/state/bundle.rs
@@ -3,20 +3,17 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use crate::curve;
-use crate::IdentityKey;
-
-use crate::error::Result;
 use crate::state::{PreKeyId, SignedPreKeyId};
+use crate::{IdentityKey, PublicKey, Result};
 
 #[derive(Debug, Clone)]
 pub struct PreKeyBundle {
     registration_id: u32,
     device_id: u32,
     pre_key_id: Option<PreKeyId>,
-    pre_key_public: Option<curve::PublicKey>,
+    pre_key_public: Option<PublicKey>,
     signed_pre_key_id: SignedPreKeyId,
-    signed_pre_key_public: curve::PublicKey,
+    signed_pre_key_public: PublicKey,
     signed_pre_key_signature: Vec<u8>,
     identity_key: IdentityKey,
 }
@@ -25,9 +22,9 @@ impl PreKeyBundle {
     pub fn new(
         registration_id: u32,
         device_id: u32,
-        pre_key: Option<(PreKeyId, curve::PublicKey)>,
+        pre_key: Option<(PreKeyId, PublicKey)>,
         signed_pre_key_id: SignedPreKeyId,
-        signed_pre_key_public: curve::PublicKey,
+        signed_pre_key_public: PublicKey,
         signed_pre_key_signature: Vec<u8>,
         identity_key: IdentityKey,
     ) -> Result<Self> {
@@ -60,7 +57,7 @@ impl PreKeyBundle {
         Ok(self.pre_key_id)
     }
 
-    pub fn pre_key_public(&self) -> Result<Option<curve::PublicKey>> {
+    pub fn pre_key_public(&self) -> Result<Option<PublicKey>> {
         Ok(self.pre_key_public)
     }
 
@@ -68,7 +65,7 @@ impl PreKeyBundle {
         Ok(self.signed_pre_key_id)
     }
 
-    pub fn signed_pre_key_public(&self) -> Result<curve::PublicKey> {
+    pub fn signed_pre_key_public(&self) -> Result<PublicKey> {
         Ok(self.signed_pre_key_public)
     }
 

--- a/rust/protocol/src/state/prekey.rs
+++ b/rust/protocol/src/state/prekey.rs
@@ -3,9 +3,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use crate::curve;
-use crate::error::Result;
 use crate::proto::storage::PreKeyRecordStructure;
+use crate::{KeyPair, PrivateKey, PublicKey, Result};
 use prost::Message;
 
 pub type PreKeyId = u32;
@@ -16,7 +15,7 @@ pub struct PreKeyRecord {
 }
 
 impl PreKeyRecord {
-    pub fn new(id: PreKeyId, key: &curve::KeyPair) -> Self {
+    pub fn new(id: PreKeyId, key: &KeyPair) -> Self {
         let public_key = key.public_key.serialize().to_vec();
         let private_key = key.private_key.serialize().to_vec();
         Self {
@@ -38,16 +37,16 @@ impl PreKeyRecord {
         Ok(self.pre_key.id)
     }
 
-    pub fn key_pair(&self) -> Result<curve::KeyPair> {
-        curve::KeyPair::from_public_and_private(&self.pre_key.public_key, &self.pre_key.private_key)
+    pub fn key_pair(&self) -> Result<KeyPair> {
+        KeyPair::from_public_and_private(&self.pre_key.public_key, &self.pre_key.private_key)
     }
 
-    pub fn public_key(&self) -> Result<curve::PublicKey> {
-        curve::PublicKey::deserialize(&self.pre_key.public_key)
+    pub fn public_key(&self) -> Result<PublicKey> {
+        PublicKey::deserialize(&self.pre_key.public_key)
     }
 
-    pub fn private_key(&self) -> Result<curve::PrivateKey> {
-        curve::PrivateKey::deserialize(&self.pre_key.private_key)
+    pub fn private_key(&self) -> Result<PrivateKey> {
+        PrivateKey::deserialize(&self.pre_key.private_key)
     }
 
     pub fn serialize(&self) -> Result<Vec<u8>> {

--- a/rust/protocol/src/state/session.rs
+++ b/rust/protocol/src/state/session.rs
@@ -3,16 +3,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use crate::error::{Result, SignalProtocolError};
 use crate::ratchet::{ChainKey, MessageKeys, RootKey};
-use crate::{IdentityKey, KeyPair, PrivateKey, PublicKey};
+use crate::{IdentityKey, KeyPair, PrivateKey, PublicKey, Result, SignalProtocolError, HKDF};
 
 use crate::consts;
-use crate::kdf;
 use crate::proto::storage::session_structure;
 use crate::proto::storage::{RecordStructure, SessionStructure};
-use crate::state::prekey::PreKeyId;
-use crate::state::signed_prekey::SignedPreKeyId;
+use crate::state::{PreKeyId, SignedPreKeyId};
 use prost::Message;
 
 use std::collections::VecDeque;
@@ -112,7 +109,7 @@ impl SessionState {
         if self.session.root_key.len() != 32 {
             return Err(SignalProtocolError::InvalidProtobufEncoding);
         }
-        let hkdf = kdf::HKDF::new(self.session_version()?)?;
+        let hkdf = HKDF::new(self.session_version()?)?;
         RootKey::new(hkdf, &self.session.root_key)
     }
 
@@ -191,7 +188,7 @@ impl SessionState {
                     if c.key.len() != 32 {
                         return Err(SignalProtocolError::InvalidProtobufEncoding);
                     }
-                    let hkdf = kdf::HKDF::new(self.session_version()?)?;
+                    let hkdf = HKDF::new(self.session_version()?)?;
                     Ok(Some(ChainKey::new(hkdf, &c.key, c.index)?))
                 }
             },
@@ -261,7 +258,7 @@ impl SessionState {
             SignalProtocolError::InvalidState("get_sender_chain_key", "No chain key".to_owned())
         })?;
 
-        let hkdf = kdf::HKDF::new(self.session_version()?)?;
+        let hkdf = HKDF::new(self.session_version()?)?;
         ChainKey::new(hkdf, &chain_key.key, chain_key.index)
     }
 

--- a/rust/protocol/src/state/signed_prekey.rs
+++ b/rust/protocol/src/state/signed_prekey.rs
@@ -3,9 +3,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use crate::curve;
-use crate::error::Result;
 use crate::proto::storage::SignedPreKeyRecordStructure;
+use crate::{KeyPair, PrivateKey, PublicKey, Result};
 use prost::Message;
 
 pub type SignedPreKeyId = u32;
@@ -16,7 +15,7 @@ pub struct SignedPreKeyRecord {
 }
 
 impl SignedPreKeyRecord {
-    pub fn new(id: SignedPreKeyId, timestamp: u64, key: &curve::KeyPair, signature: &[u8]) -> Self {
+    pub fn new(id: SignedPreKeyId, timestamp: u64, key: &KeyPair, signature: &[u8]) -> Self {
         let public_key = key.public_key.serialize().to_vec();
         let private_key = key.private_key.serialize().to_vec();
         let signature = signature.to_vec();
@@ -49,16 +48,16 @@ impl SignedPreKeyRecord {
         Ok(self.signed_pre_key.signature.clone())
     }
 
-    pub fn public_key(&self) -> Result<curve::PublicKey> {
-        curve::PublicKey::deserialize(&self.signed_pre_key.public_key)
+    pub fn public_key(&self) -> Result<PublicKey> {
+        PublicKey::deserialize(&self.signed_pre_key.public_key)
     }
 
-    pub fn private_key(&self) -> Result<curve::PrivateKey> {
-        curve::PrivateKey::deserialize(&self.signed_pre_key.private_key)
+    pub fn private_key(&self) -> Result<PrivateKey> {
+        PrivateKey::deserialize(&self.signed_pre_key.private_key)
     }
 
-    pub fn key_pair(&self) -> Result<curve::KeyPair> {
-        curve::KeyPair::from_public_and_private(
+    pub fn key_pair(&self) -> Result<KeyPair> {
+        KeyPair::from_public_and_private(
             &self.signed_pre_key.public_key,
             &self.signed_pre_key.private_key,
         )

--- a/rust/protocol/src/storage/inmem.rs
+++ b/rust/protocol/src/storage/inmem.rs
@@ -3,11 +3,14 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use crate::error::{Result, SignalProtocolError};
-use crate::state::{PreKeyId, PreKeyRecord, SessionRecord, SignedPreKeyId, SignedPreKeyRecord};
+use crate::{
+    IdentityKey, IdentityKeyPair, PreKeyRecord, ProtocolAddress, Result, SenderKeyName,
+    SenderKeyRecord, SessionRecord, SignalProtocolError, SignedPreKeyRecord,
+};
+
+use crate::state::{PreKeyId, SignedPreKeyId};
 use crate::storage::traits;
 use crate::storage::Context;
-use crate::{IdentityKey, IdentityKeyPair, ProtocolAddress, SenderKeyName, SenderKeyRecord};
 
 use async_trait::async_trait;
 use std::collections::HashMap;

--- a/rust/protocol/src/storage/traits.rs
+++ b/rust/protocol/src/storage/traits.rs
@@ -5,9 +5,11 @@
 
 use async_trait::async_trait;
 
-use crate::error::Result;
-use crate::state::{PreKeyId, PreKeyRecord, SessionRecord, SignedPreKeyId, SignedPreKeyRecord};
-use crate::{IdentityKey, IdentityKeyPair, ProtocolAddress, SenderKeyName, SenderKeyRecord};
+use crate::state::{PreKeyId, SignedPreKeyId};
+use crate::{
+    IdentityKey, IdentityKeyPair, PreKeyRecord, ProtocolAddress, Result, SenderKeyName,
+    SenderKeyRecord, SessionRecord, SignedPreKeyRecord,
+};
 
 pub type Context = Option<*mut std::ffi::c_void>;
 


### PR DESCRIPTION
Remove free-standing functions in curve for signatures, etc - always call the version on the struct

Don't import anything via `curve::` anymore - always get these via `crate::`

Add impl of `TryFrom` where appropriate

Second commit is kind of unrelated (though inspired by the changes removing use of ``curve::`` in prior commit), but cleans up imports within `protocol` - if something is in the public API import it via ``crate::X`` rather than ``crate::random_submodule::X``.