### PR TITLE
Fix a flaky test

### DIFF
--- a/rust/protocol/tests/sealed_sender.rs
+++ b/rust/protocol/tests/sealed_sender.rs
@@ -40,7 +40,8 @@ fn test_server_cert() -> Result<(), SignalProtocolError> {
             Err(e) => match e {
                 SignalProtocolError::InvalidProtobufEncoding
                 | SignalProtocolError::ProtobufDecodingError(_)
-                | SignalProtocolError::BadKeyType(_) => {}
+                | SignalProtocolError::BadKeyType(_)
+                | SignalProtocolError::BadKeyLength(_, _) => {}
 
                 unexpected_err => {
                     panic!("unexpected error {:?}", unexpected_err)


### PR DESCRIPTION
It would occasionally fail with an unexpected error, as in
https://github.com/signalapp/libsignal-client/runs/1938610036