### PR TITLE
Fix or mark-as-allowed Clippy lints in tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -114,7 +114,7 @@ jobs:
       run: cargo build --benches --verbose
 
     - name: Clippy
-      run: cargo clippy --all -- -D warnings
+      run: cargo clippy --all-targets -- -D warnings
 
   rust_ios:
     name: Build Rust for iOS

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "libsignal-node"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "libsignal-bridge",

--- a/rust/aes-gcm-siv/tests/aes_gcm_siv.rs
+++ b/rust/aes-gcm-siv/tests/aes_gcm_siv.rs
@@ -70,7 +70,7 @@ fn test_kat(kat: WycheproofTest) {
     let mut buf = pt.clone();
     let generated_tag = aes_gcm_siv.encrypt(&mut buf, &nonce, &aad).unwrap();
 
-    if valid == true {
+    if valid {
         assert_eq!(hex::encode(generated_tag), hex::encode(&tag));
         assert_eq!(hex::encode(&buf), hex::encode(ct));
         aes_gcm_siv.decrypt(&mut buf, &nonce, &aad, &tag).unwrap();
@@ -78,7 +78,7 @@ fn test_kat(kat: WycheproofTest) {
     } else {
         assert_ne!(hex::encode(generated_tag), hex::encode(&tag));
 
-        if buf.len() > 0 {
+        if !buf.is_empty() {
             assert_ne!(hex::encode(&buf), hex::encode(ct));
         }
 
@@ -137,8 +137,8 @@ impl FromStr for BoringKat {
 
     fn from_str(s: &str) -> Result<BoringKat, Self::Err> {
         let mut kat: BoringKat = Default::default();
-        for line in s.split("\n") {
-            if line == "" {
+        for line in s.split('\n') {
+            if line.is_empty() {
                 continue;
             }
             let parts = line.split(": ").collect::<Vec<_>>();

--- a/rust/poksho/src/sign.rs
+++ b/rust/poksho/src/sign.rs
@@ -50,6 +50,7 @@ mod tests {
     use curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT;
 
     #[test]
+    #[allow(clippy::needless_range_loop)]
     fn test_signature() {
         let mut block64 = [0u8; 64];
         let mut block32 = [0u8; 32];

--- a/rust/poksho/src/statement.rs
+++ b/rust/poksho/src/statement.rs
@@ -446,6 +446,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::needless_range_loop, clippy::redundant_clone)]
     fn test_complex_statement() {
         let mut block32 = [0u8; 32];
         let mut block64a = [0u8; 64];
@@ -520,10 +521,10 @@ mod tests {
         scalar_args2.add("abc", a);
 
         // Test bad args - extra scalar
-        match st.prove(&scalar_args2, &point_args, &message, &randomness) {
-            Err(PokshoError::BadArgsWrongNumberOfScalarArgs) => (),
-            _ => assert!(false),
-        }
+        assert!(matches!(
+            st.prove(&scalar_args2, &point_args, &message, &randomness),
+            Err(PokshoError::BadArgsWrongNumberOfScalarArgs)
+        ));
 
         // Good proof
         let mut proof = st
@@ -558,47 +559,47 @@ mod tests {
         // Test bad args - extra point
         let mut point_args2 = point_args.clone();
         point_args2.add("xyz", A);
-        match st.verify_proof(&proof, &point_args2, &message) {
-            Err(PokshoError::BadArgsWrongNumberOfPointArgs) => (),
-            _ => assert!(false),
-        }
+        assert!(matches!(
+            st.verify_proof(&proof, &point_args2, &message),
+            Err(PokshoError::BadArgsWrongNumberOfPointArgs)
+        ));
 
         // Test bad message
-        match st.verify_proof(&proof, &point_args, &block32) {
-            Err(VerificationFailure) => (),
-            _ => assert!(false),
-        }
+        assert!(matches!(
+            st.verify_proof(&proof, &point_args, &block32),
+            Err(VerificationFailure)
+        ));
 
         // Test bad proof #1 - extra byte at end
         let mut proof2 = proof.clone();
         proof2.push(0);
-        match st.verify_proof(&proof2, &point_args, &message) {
-            Err(VerificationFailure) => (),
-            _ => assert!(false),
-        }
+        assert!(matches!(
+            st.verify_proof(&proof2, &point_args, &message),
+            Err(VerificationFailure)
+        ));
 
         // Test bad proof #2 - last byte changed
         let prooflen = proof.len();
         proof[prooflen - 1] += 1;
-        match st.verify_proof(&proof, &point_args, &message) {
-            Err(VerificationFailure) => (),
-            _ => assert!(false),
-        }
+        assert!(matches!(
+            st.verify_proof(&proof, &point_args, &message),
+            Err(VerificationFailure)
+        ));
 
         // Test bad proof #3 - incorrect # of scalars (1 too few)
         let mut proof2 = proof.clone();
         proof2.truncate(proof2.len() - 32);
-        match st.verify_proof(&proof2, &point_args, &message) {
-            Err(VerificationFailure) => (),
-            _ => assert!(false),
-        }
+        assert!(matches!(
+            st.verify_proof(&proof2, &point_args, &message),
+            Err(VerificationFailure)
+        ));
 
         // Test bad proof #3 - incorrect # of scalars (1 too few)
         let mut proof2 = proof.clone();
         proof2.truncate(proof2.len() - 32);
-        match st.verify_proof(&proof2, &point_args, &message) {
-            Err(VerificationFailure) => (),
-            _ => assert!(false),
-        }
+        assert!(matches!(
+            st.verify_proof(&proof2, &point_args, &message),
+            Err(VerificationFailure)
+        ));
     }
 }

--- a/rust/protocol/src/crypto.rs
+++ b/rust/protocol/src/crypto.rs
@@ -135,7 +135,7 @@ mod test {
 
         let ctext = super::aes_256_ctr_encrypt(&ptext, &key).unwrap();
         assert_eq!(
-            hex::encode(ctext.clone()),
+            hex::encode(ctext),
             "e568f68194cf76d6174d4cc04310a85491151e5d0b7a1f1bc0d7acd0ae3e51e4170e23"
         );
     }

--- a/rust/protocol/tests/sealed_sender.rs
+++ b/rust/protocol/tests/sealed_sender.rs
@@ -25,7 +25,7 @@ fn test_server_cert() -> Result<(), SignalProtocolError> {
 
     assert_eq!(recovered.validate(&trust_root.public_key)?, true);
 
-    let mut cert_data = serialized.clone();
+    let mut cert_data = serialized;
     let cert_bits = cert_data.len() * 8;
 
     for b in 0..cert_bits {

--- a/rust/protocol/tests/session.rs
+++ b/rust/protocol/tests/session.rs
@@ -12,6 +12,7 @@ use std::convert::TryFrom;
 use support::*;
 
 #[test]
+#[allow(clippy::eval_order_dependence)]
 fn test_basic_prekey_v3() -> Result<(), SignalProtocolError> {
     block_on(async {
         let mut csprng = OsRng;
@@ -242,6 +243,7 @@ fn test_basic_prekey_v3() -> Result<(), SignalProtocolError> {
 }
 
 #[test]
+#[allow(clippy::eval_order_dependence)]
 fn test_bad_signed_pre_key_signature() -> Result<(), SignalProtocolError> {
     block_on(async {
         let bob_address = ProtocolAddress::new("+14151111112".to_owned(), 1);
@@ -320,6 +322,7 @@ fn test_bad_signed_pre_key_signature() -> Result<(), SignalProtocolError> {
 // testRepeatBundleMessageV2 cannot be represented
 
 #[test]
+#[allow(clippy::eval_order_dependence)]
 fn repeat_bundle_message_v3() -> Result<(), SignalProtocolError> {
     block_on(async {
         let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1);
@@ -439,6 +442,7 @@ fn repeat_bundle_message_v3() -> Result<(), SignalProtocolError> {
 }
 
 #[test]
+#[allow(clippy::eval_order_dependence)]
 fn bad_message_bundle() -> Result<(), SignalProtocolError> {
     block_on(async {
         let mut csprng = OsRng;
@@ -556,6 +560,7 @@ fn bad_message_bundle() -> Result<(), SignalProtocolError> {
 }
 
 #[test]
+#[allow(clippy::eval_order_dependence)]
 fn optional_one_time_prekey() -> Result<(), SignalProtocolError> {
     block_on(async {
         let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1);
@@ -703,6 +708,7 @@ fn message_key_limits() -> Result<(), SignalProtocolError> {
     })
 }
 
+#[allow(clippy::needless_range_loop)]
 fn run_session_interaction(
     alice_session: SessionRecord,
     bob_session: SessionRecord,
@@ -865,6 +871,7 @@ async fn run_interaction(
     Ok(())
 }
 
+#[allow(clippy::eval_order_dependence)]
 async fn is_session_id_equal(
     alice_store: &dyn ProtocolStore,
     alice_address: &ProtocolAddress,

--- a/rust/protocol/tests/support/mod.rs
+++ b/rust/protocol/tests/support/mod.rs
@@ -50,7 +50,7 @@ pub async fn decrypt(
     .await
 }
 
-#[allow(dead_code)]
+#[allow(dead_code, clippy::eval_order_dependence)]
 pub async fn create_pre_key_bundle<R: Rng + CryptoRng>(
     store: &mut dyn ProtocolStore,
     mut csprng: &mut R,


### PR DESCRIPTION
And tweak the GitHub Clippy enforcement so this doesn't regress.

I do feel better about marking Clippy lints as allowed *in tests* because sometimes the test is trying to test something that you wouldn't write in normal code, or can safely ignore something you wouldn't want to ignore in normal code. I do think it still makes sense to decide that on a test-by-test basis, though.