### PR TITLE
CocoaPod: tag v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "libsignal-ffi"
-version = "0.1.2"
+version = "0.3.0"
 dependencies = [
  "aes-gcm-siv",
  "async-trait",

--- a/SignalClient.podspec
+++ b/SignalClient.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SignalClient'
-  s.version          = '0.1.2'
+  s.version          = '0.3.0'
   s.summary          = 'A Swift wrapper library for communicating with the Signal messaging service.'
 
   s.homepage         = 'https://github.com/signalapp/libsignal-client'

--- a/rust/bridge/ffi/Cargo.toml
+++ b/rust/bridge/ffi/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "libsignal-ffi"
-version = "0.1.2"
+version = "0.3.0"
 authors = ["Jack Lloyd <jack@signal.org>"]
 edition = "2018"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
This skips the v0.2 series to bring it in line with the Java bridge.