### PR TITLE
Use a new branch for the 3.0.0 fork of curve25519-dalek

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "3.0.0"
-source = "git+https://github.com/signalapp/curve25519-dalek?branch=lizard2#2694ad3b789635f90f941648ae952f58d59ffc73"
+source = "git+https://github.com/signalapp/curve25519-dalek.git?branch=3.0.0-lizard2#2694ad3b789635f90f941648ae952f58d59ffc73"
 dependencies = [
  "byteorder",
  "digest",
@@ -666,7 +666,7 @@ dependencies = [
  "log",
  "neon",
  "paste",
- "rand",
+ "rand 0.7.3",
  "scopeguard",
  "signal-neon-futures",
  "static_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ default-members = [
 ]
 
 [patch.crates-io]
-curve25519-dalek = { git = 'https://github.com/signalapp/curve25519-dalek', branch = 'lizard2' }
+curve25519-dalek = { git = 'https://github.com/signalapp/curve25519-dalek', branch = '3.0.0-lizard2' }

--- a/rust/poksho/Cargo.toml
+++ b/rust/poksho/Cargo.toml
@@ -21,7 +21,7 @@ hex = "0.4"
 features = ["serde", "alloc"]
 version = "3.0.0"
 git = "https://github.com/signalapp/curve25519-dalek.git"
-branch = "lizard2"
+branch = "3.0.0-lizard2"
 
 [features]
 default = ["u64_backend"]

--- a/rust/protocol/Cargo.toml
+++ b/rust/protocol/Cargo.toml
@@ -32,7 +32,7 @@ log = "0.4"
 features = ["serde", "alloc"]
 version = "3.0.0"
 git = "https://github.com/signalapp/curve25519-dalek.git"
-branch = "lizard2"
+branch = "3.0.0-lizard2"
 
 [features]
 default = ["u64_backend"]


### PR DESCRIPTION
As reusing the old branch breaks building zkgroup