### PR TITLE
Always clamp private keys on deserialize

### DIFF
--- a/node/test/PublicAPITest.ts
+++ b/node/test/PublicAPITest.ts
@@ -876,7 +876,7 @@ describe('SignalClient', () => {
   });
 
   it('ECC keys roundtrip through serialization', () => {
-    const key = Buffer.alloc(32, 0xab);
+    const key = Buffer.alloc(32, 0x40);
     const priv = SignalClient.PrivateKey.deserialize(key);
     assert(key.equals(priv.serialize()));
 

--- a/rust/protocol/src/curve.rs
+++ b/rust/protocol/src/curve.rs
@@ -190,6 +190,10 @@ impl PrivateKey {
         } else {
             let mut key = [0u8; 32];
             key.copy_from_slice(&value[..32]);
+            // Clamp:
+            key[0] &= 0xF8;
+            key[31] &= 0x7F;
+            key[31] |= 0x40;
             Ok(Self {
                 key: PrivateKeyData::DjbPrivateKey(key),
             })


### PR DESCRIPTION
We clamp on generate but some clients will generate non-clamped keys expecting the operation will clamp, and as of now clients who deserialize such keys will produce incorrect results.