### PR TITLE
Node: accept both `null` and `undefined` for optional arguments

### DIFF
--- a/rust/bridge/shared/src/node/convert.rs
+++ b/rust/bridge/shared/src/node/convert.rs
@@ -249,7 +249,7 @@ where
         cx: &mut FunctionContext<'context>,
         foreign: Handle<'context, Self::ArgType>,
     ) -> NeonResult<Self::StoredType> {
-        if foreign.downcast::<JsNull, _>(cx).is_ok() {
+        if foreign.is_a::<JsNull, _>(cx) || foreign.is_a::<JsUndefined, _>(cx) {
             return Ok(None);
         }
         let non_optional_value = foreign.downcast_or_throw::<T::ArgType, _>(cx)?;
@@ -286,7 +286,7 @@ where
         cx: &mut FunctionContext,
         foreign: Handle<Self::ArgType>,
     ) -> NeonResult<Self::StoredType> {
-        if foreign.downcast::<JsNull, _>(cx).is_ok() {
+        if foreign.is_a::<JsNull, _>(cx) || foreign.is_a::<JsUndefined, _>(cx) {
             return Ok(FinalizableOption(None));
         }
         let non_optional_value = foreign.downcast_or_throw::<T::ArgType, _>(cx)?;

--- a/rust/bridge/shared/src/node/storage.rs
+++ b/rust/bridge/shared/src/node/storage.rs
@@ -410,7 +410,7 @@ impl NodeIdentityKeyStore {
             Ok(value) => match value.downcast::<DefaultJsBox<PublicKey>, _>(cx) {
                 Ok(obj) => Ok(Some(***obj)),
                 Err(_) => {
-                    if value.is_a::<JsNull, _>(cx) {
+                    if value.is_a::<JsNull, _>(cx) || value.is_a::<JsUndefined, _>(cx) {
                         Ok(None)
                     } else {
                         Err("result must be an object".to_owned())
@@ -586,7 +586,7 @@ impl NodeSenderKeyStore {
             Ok(value) => match value.downcast::<DefaultJsBox<SenderKeyRecord>, _>(cx) {
                 Ok(obj) => Ok(Some((***obj).clone())),
                 Err(_) => {
-                    if value.is_a::<JsNull, _>(cx) {
+                    if value.is_a::<JsNull, _>(cx) || value.is_a::<JsUndefined, _>(cx) {
                         Ok(None)
                     } else {
                         Err("result must be an object".to_owned())


### PR DESCRIPTION
Return values will continue to use `null` rather than `undefined` for the time being.