### PR TITLE
Have TS binding return null on a sealed sender self-send

### DIFF
--- a/node/index.ts
+++ b/node/index.ts
@@ -1213,7 +1213,7 @@ export async function sealedSenderDecryptMessage(
   identityStore: IdentityKeyStore,
   prekeyStore: PreKeyStore,
   signedPrekeyStore: SignedPreKeyStore
-): Promise<SealedSenderDecryptionResult> {
+): Promise<SealedSenderDecryptionResult | null> {
   const ssdr = await SC.SealedSender_DecryptMessage(
     message,
     trustRoot,
@@ -1226,6 +1226,9 @@ export async function sealedSenderDecryptMessage(
     prekeyStore,
     signedPrekeyStore
   );
+  if (ssdr == null) {
+    return null;
+  }
   return SealedSenderDecryptionResult._fromNativeHandle(ssdr);
 }
 

--- a/node/libsignal_client.d.ts
+++ b/node/libsignal_client.d.ts
@@ -93,7 +93,7 @@ export function SealedSenderDecryptionResult_GetDeviceId(obj: Wrapper<SealedSend
 export function SealedSenderDecryptionResult_GetSenderE164(obj: Wrapper<SealedSenderDecryptionResult>): string | null;
 export function SealedSenderDecryptionResult_GetSenderUuid(obj: Wrapper<SealedSenderDecryptionResult>): string;
 export function SealedSenderDecryptionResult_Message(obj: Wrapper<SealedSenderDecryptionResult>): Buffer;
-export function SealedSender_DecryptMessage(message: Buffer, trustRoot: Wrapper<PublicKey>, timestamp: number, localE164: string | null, localUuid: string, localDeviceId: number, sessionStore: SessionStore, identityStore: IdentityKeyStore, prekeyStore: PreKeyStore, signedPrekeyStore: SignedPreKeyStore): Promise<SealedSenderDecryptionResult>;
+export function SealedSender_DecryptMessage(message: Buffer, trustRoot: Wrapper<PublicKey>, timestamp: number, localE164: string | null, localUuid: string, localDeviceId: number, sessionStore: SessionStore, identityStore: IdentityKeyStore, prekeyStore: PreKeyStore, signedPrekeyStore: SignedPreKeyStore): Promise<SealedSenderDecryptionResult | null>;
 export function SealedSender_DecryptToUsmc(ctext: Buffer, identityStore: IdentityKeyStore): Promise<UnidentifiedSenderMessageContent>;
 export function SealedSender_EncryptMessage(destination: Wrapper<ProtocolAddress>, senderCert: Wrapper<SenderCertificate>, ptext: Buffer, sessionStore: SessionStore, identityStore: IdentityKeyStore): Promise<Buffer>;
 export function SenderCertificate_Deserialize(buffer: Buffer): SenderCertificate;

--- a/node/test/PublicAPITest.ts
+++ b/node/test/PublicAPITest.ts
@@ -804,10 +804,14 @@ describe('SignalClient', () => {
       bSPreK
     );
 
-    assert.deepEqual(bPlaintext.message(), aPlaintext);
-    assert.deepEqual(bPlaintext.senderE164(), aE164);
-    assert.deepEqual(bPlaintext.senderUuid(), aUuid);
-    assert.deepEqual(bPlaintext.deviceId(), aDeviceId);
+    assert(bPlaintext != null);
+
+    if (bPlaintext != null) {
+      assert.deepEqual(bPlaintext.message(), aPlaintext);
+      assert.deepEqual(bPlaintext.senderE164(), aE164);
+      assert.deepEqual(bPlaintext.senderUuid(), aUuid);
+      assert.deepEqual(bPlaintext.deviceId(), aDeviceId);
+    }
   });
   it('AES-GCM-SIV test vector', () => {
     // RFC 8452, appendix C.2

--- a/rust/bridge/shared/src/protocol.rs
+++ b/rust/bridge/shared/src/protocol.rs
@@ -1081,8 +1081,8 @@ async fn SealedSender_DecryptMessage(
     identity_store: &mut dyn IdentityKeyStore,
     prekey_store: &mut dyn PreKeyStore,
     signed_prekey_store: &mut dyn SignedPreKeyStore,
-) -> Result<SealedSenderDecryptionResult> {
-    sealed_sender_decrypt(
+) -> Result<Option<SealedSenderDecryptionResult>> {
+    let result = sealed_sender_decrypt(
         message,
         trust_root,
         timestamp,
@@ -1095,7 +1095,13 @@ async fn SealedSender_DecryptMessage(
         signed_prekey_store,
         None,
     )
-    .await
+    .await;
+
+    match result {
+        Ok(r) => Ok(Some(r)),
+        Err(SignalProtocolError::SealedSenderSelfSend) => Ok(None),
+        Err(e) => Err(e),
+    }
 }
 
 #[bridge_fn(


### PR DESCRIPTION
As untyped errors make it difficult to detect this case vs other error conditions