### PR TITLE
Bump Java version to 0.3.4

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -1,5 +1,5 @@
 subprojects {
-    ext.version_number     = "0.2.3"
+    ext.version_number     = "0.3.4"
     ext.group_info         = "org.whispersystems"
 
     if (JavaVersion.current().isJava8Compatible()) {

--- a/rust/bridge/jni/Cargo.toml
+++ b/rust/bridge/jni/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "libsignal-jni"
-version = "0.2.3"
+version = "0.3.4"
 authors = ["Jack Lloyd <jack@signal.org>"]
 edition = "2018"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
@jrose-signal Bumping from 0.2.3->0.4.0 to indicate new support for DeviceTransferKey, with the idea that next Swift build also goes to 0.4.0 (from current 0.3.1) for same reason. Seems ok?