### PR TITLE
By default, skip Rust tests that take over 10s in debug builds

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -108,7 +108,7 @@ jobs:
       run: cargo build --all --verbose
 
     - name: Run tests
-      run: cargo test --all --verbose
+      run: cargo test --all --verbose -- -Z unstable-options --include-ignored
 
     - name: Build benches
       run: cargo build --benches --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "libsignal-jni"
-version = "0.2.3"
+version = "0.3.4"
 dependencies = [
  "aes-gcm-siv",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ default-members = [
 
 [patch.crates-io]
 curve25519-dalek = { git = 'https://github.com/signalapp/curve25519-dalek', branch = '3.0.0-lizard2' }
+
+[profile.dev.package.num-bigint-dig]
+opt-level = 2 # too slow otherwise!

--- a/rust/bridge/shared/macros/src/lib.rs
+++ b/rust/bridge/shared/macros/src/lib.rs
@@ -17,6 +17,7 @@
 //! # Example
 //!
 //! ```ignore
+//! # #[cfg(ignore_even_when_running_all_tests)]
 //! #[bridge_fn]
 //! fn SenderKeyMessage_New(
 //!     key_id: u32,
@@ -84,6 +85,7 @@
 //! Any of these names can be replaced by specifying an argument to the `bridge_fn` attribute:
 //!
 //! ```ignore
+//! # #[cfg(ignore_even_when_running_all_tests)]
 //! #[bridge_fn(ffi = "magic_alakazam", jni = "Magic_1Alakazam")]
 //! fn Abracadabra() {
 //!   // ...
@@ -252,6 +254,7 @@ fn bridge_fn_impl(attr: TokenStream, item: TokenStream, result_kind: ResultKind)
 /// // Produces a C function named "signal_checksum_buffer"
 /// // and a TypeScript function manually named "Buffer_Checksum",
 /// // with the Java entry point disabled.
+/// # #[cfg(ignore_even_when_running_all_tests)]
 /// #[bridge_fn(jni = false, node = "Buffer_Checksum")]
 /// fn ChecksumBuffer(buffer: &[u8]) -> u64 {
 ///   // ...
@@ -277,6 +280,7 @@ pub fn bridge_fn(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// // Produces a JNI function manually named "Cipher_Rot13" (with JNI "_1" mangling)
 /// // and a TypeScript function named "Rot13",
 /// // with the FFI entry point disabled.
+/// # #[cfg(ignore_even_when_running_all_tests)]
 /// #[bridge_fn_buffer(ffi = false, jni = "Cipher_1Rot13")]
 /// fn Rot13<E: Env>(env: E, buffer: &[u8]) -> E::Buffer {
 ///   // let result = ...;
@@ -301,6 +305,7 @@ pub fn bridge_fn_buffer(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// // Produces a C function manually named "signal_process_postkey"
 /// // and a JNI function named "PostKey_1Process" (with JNI "_1" mangling for an underscore),
 /// // with the Node entry point disabled.
+/// # #[cfg(ignore_even_when_running_all_tests)]
 /// #[bridge_fn_void(ffi = "process_postkey", node = false)]
 /// fn PostKey_Process(post_key: &PostKey) -> Result<()> {
 ///   // ...

--- a/rust/protocol/tests/groups.rs
+++ b/rust/protocol/tests/groups.rs
@@ -465,6 +465,7 @@ fn group_out_of_order() -> Result<(), SignalProtocolError> {
 }
 
 #[test]
+#[ignore = "slow to run locally"]
 fn group_too_far_in_the_future() -> Result<(), SignalProtocolError> {
     block_on(async {
         let mut csprng = OsRng;

--- a/rust/protocol/tests/session.rs
+++ b/rust/protocol/tests/session.rs
@@ -255,6 +255,7 @@ fn test_basic_prekey_v3() -> Result<(), SignalProtocolError> {
 }
 
 #[test]
+#[ignore = "slow to run locally"]
 #[allow(clippy::eval_order_dependence)]
 fn chain_jump_over_limit() -> Result<(), SignalProtocolError> {
     block_on(async {
@@ -341,6 +342,7 @@ fn chain_jump_over_limit() -> Result<(), SignalProtocolError> {
 }
 
 #[test]
+#[ignore = "slow to run locally"]
 #[allow(clippy::eval_order_dependence)]
 fn chain_jump_over_limit_with_self() -> Result<(), SignalProtocolError> {
     block_on(async {


### PR DESCRIPTION
We'll still run them in CI, but we don't need to run them locally.