### PR TITLE
Java: Move burden of GroupCipher/SessionBuilder locking to the client

### DIFF
--- a/java/java/src/main/java/org/whispersystems/libsignal/groups/GroupCipher.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/groups/GroupCipher.java
@@ -24,11 +24,11 @@ import java.security.NoSuchAlgorithmException;
  * distributed to each member of the group, this class can be used for all subsequent encrypt/decrypt
  * operations within that session (ie: until group membership changes).
  *
+ * This class is not thread-safe.
+ *
  * @author Moxie Marlinspike
  */
 public class GroupCipher {
-
-  static final Object LOCK = new Object();
 
   private final SenderKeyStore senderKeyStore;
   private final SenderKeyName senderKeyId;
@@ -46,12 +46,10 @@ public class GroupCipher {
    * @throws NoSessionException
    */
   public byte[] encrypt(byte[] paddedPlaintext) throws NoSessionException {
-    synchronized (LOCK) {
     try {
       return Native.GroupCipher_EncryptMessage(this.senderKeyId.nativeHandle(), paddedPlaintext, this.senderKeyStore, null);
     } catch (IllegalStateException e) {
       throw new NoSessionException(e);
-    }
     }
   }
 
@@ -67,12 +65,10 @@ public class GroupCipher {
   public byte[] decrypt(byte[] senderKeyMessageBytes)
       throws LegacyMessageException, DuplicateMessageException, InvalidMessageException, NoSessionException
   {
-    synchronized (LOCK) {
-      try {
-        return Native.GroupCipher_DecryptMessage(this.senderKeyId.nativeHandle(), senderKeyMessageBytes, this.senderKeyStore, null);
+    try {
+      return Native.GroupCipher_DecryptMessage(this.senderKeyId.nativeHandle(), senderKeyMessageBytes, this.senderKeyStore, null);
     } catch (IllegalStateException e) {
       throw new NoSessionException(e);
-      }
     }
   }
 }

--- a/java/java/src/main/java/org/whispersystems/libsignal/groups/GroupSessionBuilder.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/groups/GroupSessionBuilder.java
@@ -22,6 +22,8 @@ import org.whispersystems.libsignal.protocol.SenderKeyDistributionMessage;
  * are identified by their senderId, and each logical recipientId can have multiple physical
  * devices.
  *
+ * This class is not thread-safe.
+ *
  * @author Moxie Marlinspike
  */
 
@@ -39,11 +41,9 @@ public class GroupSessionBuilder {
    * @param senderKeyDistributionMessage A received SenderKeyDistributionMessage.
    */
   public void process(SenderKeyName senderKeyName, SenderKeyDistributionMessage senderKeyDistributionMessage) {
-    synchronized (GroupCipher.LOCK) {
-       Native.GroupSessionBuilder_ProcessSenderKeyDistributionMessage(senderKeyName.nativeHandle(),
-                                                                      senderKeyDistributionMessage.nativeHandle(),
-                                                                      senderKeyStore, null);
-    }
+      Native.GroupSessionBuilder_ProcessSenderKeyDistributionMessage(senderKeyName.nativeHandle(),
+                                                                    senderKeyDistributionMessage.nativeHandle(),
+                                                                    senderKeyStore, null);
   }
 
   /**
@@ -53,8 +53,6 @@ public class GroupSessionBuilder {
    * @return A SenderKeyDistributionMessage that is individually distributed to each member of the group.
    */
   public SenderKeyDistributionMessage create(SenderKeyName senderKeyName) {
-    synchronized (GroupCipher.LOCK) {
-      return new SenderKeyDistributionMessage(Native.GroupSessionBuilder_CreateSenderKeyDistributionMessage(senderKeyName.nativeHandle(), senderKeyStore, null));
-    }
+    return new SenderKeyDistributionMessage(Native.GroupSessionBuilder_CreateSenderKeyDistributionMessage(senderKeyName.nativeHandle(), senderKeyStore, null));
   }
 }


### PR DESCRIPTION
Same as #202 but for SenderKey encryption.