### PR TITLE
Fix bridge_handle! logic for disabling for certain targets

### DIFF
--- a/node/Native.d.ts
+++ b/node/Native.d.ts
@@ -170,8 +170,6 @@ export function UnidentifiedSenderMessageContent_Serialize(obj: Wrapper<Unidenti
 export function initLogger(maxLevel: LogLevel, callback: (level: LogLevel, target: string, file: string | null, line: number | null, message: string) => void): void
 interface Aes256GcmSiv { readonly __type: unique symbol; }
 interface CiphertextMessage { readonly __type: unique symbol; }
-interface CryptographicHash { readonly __type: unique symbol; }
-interface CryptographicMac { readonly __type: unique symbol; }
 interface Fingerprint { readonly __type: unique symbol; }
 interface PreKeyBundle { readonly __type: unique symbol; }
 interface PreKeyRecord { readonly __type: unique symbol; }

--- a/rust/bridge/shared/src/ffi/convert.rs
+++ b/rust/bridge/shared/src/ffi/convert.rs
@@ -333,6 +333,7 @@ impl crate::support::Env for Env {
 /// Implementation of [`bridge_handle`](crate::support::bridge_handle) for FFI.
 macro_rules! ffi_bridge_handle {
     ( $typ:ty as false ) => {};
+    ( $typ:ty as false, clone = true ) => {};
     ( $typ:ty as $ffi_name:ident, clone = false ) => {
         impl ffi::SimpleArgTypeInfo for &$typ {
             type ArgType = *const $typ;

--- a/rust/bridge/shared/src/ffi/convert.rs
+++ b/rust/bridge/shared/src/ffi/convert.rs
@@ -332,8 +332,7 @@ impl crate::support::Env for Env {
 
 /// Implementation of [`bridge_handle`](crate::support::bridge_handle) for FFI.
 macro_rules! ffi_bridge_handle {
-    ( $typ:ty as false ) => {};
-    ( $typ:ty as false, clone = true ) => {};
+    ( $typ:ty as false $(, $($_:tt)*)? ) => {};
     ( $typ:ty as $ffi_name:ident, clone = false ) => {
         impl ffi::SimpleArgTypeInfo for &$typ {
             type ArgType = *const $typ;

--- a/rust/bridge/shared/src/jni/convert.rs
+++ b/rust/bridge/shared/src/jni/convert.rs
@@ -414,6 +414,7 @@ impl crate::support::Env for &'_ JNIEnv<'_> {
 /// Implementation of [`bridge_handle`](crate::support::bridge_handle) for JNI.
 macro_rules! jni_bridge_handle {
     ( $typ:ty as false ) => {};
+    ( $typ:ty as false, mut = true ) => {};
     ( $typ:ty as $jni_name:ident ) => {
         impl<'a> jni::SimpleArgTypeInfo<'a> for &$typ {
             type ArgType = jni::ObjectHandle;

--- a/rust/bridge/shared/src/jni/convert.rs
+++ b/rust/bridge/shared/src/jni/convert.rs
@@ -413,8 +413,7 @@ impl crate::support::Env for &'_ JNIEnv<'_> {
 
 /// Implementation of [`bridge_handle`](crate::support::bridge_handle) for JNI.
 macro_rules! jni_bridge_handle {
-    ( $typ:ty as false ) => {};
-    ( $typ:ty as false, mut = true ) => {};
+    ( $typ:ty as false $(, $($_:tt)*)? ) => {};
     ( $typ:ty as $jni_name:ident ) => {
         impl<'a> jni::SimpleArgTypeInfo<'a> for &$typ {
             type ArgType = jni::ObjectHandle;

--- a/rust/bridge/shared/src/node/convert.rs
+++ b/rust/bridge/shared/src/node/convert.rs
@@ -715,8 +715,7 @@ impl<T: Send + Sync + 'static> Finalize for PersistentBoxedValue<T> {
 
 /// Implementation of [`bridge_handle`](crate::support::bridge_handle) for Node.
 macro_rules! node_bridge_handle {
-    ( $typ:ty as false ) => {};
-    ( $typ:ty as false, mut = true ) => {};
+    ( $typ:ty as false $(, $($_:tt)*)? ) => {};
     ( $typ:ty as $node_name:ident ) => {
         impl<'storage, 'context: 'storage> node::ArgTypeInfo<'storage, 'context>
         for &'storage $typ {

--- a/rust/bridge/shared/src/node/convert.rs
+++ b/rust/bridge/shared/src/node/convert.rs
@@ -716,6 +716,7 @@ impl<T: Send + Sync + 'static> Finalize for PersistentBoxedValue<T> {
 /// Implementation of [`bridge_handle`](crate::support::bridge_handle) for Node.
 macro_rules! node_bridge_handle {
     ( $typ:ty as false ) => {};
+    ( $typ:ty as false, mut = true ) => {};
     ( $typ:ty as $node_name:ident ) => {
         impl<'storage, 'context: 'storage> node::ArgTypeInfo<'storage, 'context>
         for &'storage $typ {


### PR DESCRIPTION
It only matched exactly `$typ as false` so for example `$typ as false, mut = true` would cause the type to still be emitted.

There is probably a better way to resolve this, but this hack fixes my immediate issue