### PR TITLE
Bridge: add support for strongly-typed Node errors

### DIFF
--- a/node/Errors.ts
+++ b/node/Errors.ts
@@ -1,0 +1,60 @@
+//
+// Copyright 2021 Signal Messenger, LLC.
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+export enum ErrorCode {
+  Generic,
+  UntrustedIdentity,
+  SealedSenderSelfSend,
+}
+
+export class SignalClientErrorBase extends Error {
+  public readonly code: ErrorCode;
+  public readonly operation: string;
+
+  constructor(
+    message: string,
+    name: keyof typeof ErrorCode | undefined,
+    operation: string,
+    extraProps?: Record<string, unknown>
+  ) {
+    super(message);
+    // Include the dynamic check for `name in ErrorCode` in case there's a bug in the Rust code.
+    if (name !== undefined && name in ErrorCode) {
+      this.name = name;
+      this.code = ErrorCode[name];
+    } else {
+      this.name = 'SignalClientError';
+      this.code = ErrorCode.Generic;
+    }
+    this.operation = operation;
+    if (extraProps !== undefined) {
+      Object.assign(this, extraProps);
+    }
+
+    // Maintains proper stack trace, where our error was thrown (only available on V8)
+    //   via https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this);
+    }
+  }
+}
+
+export type GenericError = SignalClientErrorBase & {
+  code: ErrorCode.Generic;
+};
+
+export type UntrustedIdentityError = SignalClientErrorBase & {
+  code: ErrorCode.UntrustedIdentity;
+  addr: string;
+};
+
+export type SealedSenderSelfSendError = SignalClientErrorBase & {
+  code: ErrorCode.SealedSenderSelfSend;
+};
+
+export type SignalClientError =
+  | GenericError
+  | UntrustedIdentityError
+  | SealedSenderSelfSendError;

--- a/node/Native.d.ts
+++ b/node/Native.d.ts
@@ -40,6 +40,7 @@ interface Wrapper<T> {
   readonly _nativeHandle: T
 }
 
+export function registerErrors(errorsModule: Record<string, unknown>): void;
 
 export const enum LogLevel { Error = 1, Warn, Info, Debug, Trace }
 export function Aes256GcmSiv_Decrypt(aesGcmSiv: Wrapper<Aes256GcmSiv>, ctext: Buffer, nonce: Buffer, associatedData: Buffer): Buffer;
@@ -95,7 +96,7 @@ export function SealedSenderDecryptionResult_GetDeviceId(obj: Wrapper<SealedSend
 export function SealedSenderDecryptionResult_GetSenderE164(obj: Wrapper<SealedSenderDecryptionResult>): string | null;
 export function SealedSenderDecryptionResult_GetSenderUuid(obj: Wrapper<SealedSenderDecryptionResult>): string;
 export function SealedSenderDecryptionResult_Message(obj: Wrapper<SealedSenderDecryptionResult>): Buffer;
-export function SealedSender_DecryptMessage(message: Buffer, trustRoot: Wrapper<PublicKey>, timestamp: number, localE164: string | null, localUuid: string, localDeviceId: number, sessionStore: SessionStore, identityStore: IdentityKeyStore, prekeyStore: PreKeyStore, signedPrekeyStore: SignedPreKeyStore): Promise<SealedSenderDecryptionResult | null>;
+export function SealedSender_DecryptMessage(message: Buffer, trustRoot: Wrapper<PublicKey>, timestamp: number, localE164: string | null, localUuid: string, localDeviceId: number, sessionStore: SessionStore, identityStore: IdentityKeyStore, prekeyStore: PreKeyStore, signedPrekeyStore: SignedPreKeyStore): Promise<SealedSenderDecryptionResult>;
 export function SealedSender_DecryptToUsmc(ctext: Buffer, identityStore: IdentityKeyStore, ctx: null): Promise<UnidentifiedSenderMessageContent>;
 export function SealedSender_Encrypt(destination: Wrapper<ProtocolAddress>, content: Wrapper<UnidentifiedSenderMessageContent>, identityKeyStore: IdentityKeyStore, ctx: null): Promise<Buffer>;
 export function SealedSender_MultiRecipientEncrypt(recipients: Wrapper<ProtocolAddress>[], content: Wrapper<UnidentifiedSenderMessageContent>, identityKeyStore: IdentityKeyStore, ctx: null): Promise<Buffer>;

--- a/node/index.ts
+++ b/node/index.ts
@@ -6,6 +6,9 @@
 import * as os from 'os';
 import * as uuid from 'uuid';
 
+import * as Errors from './Errors';
+export * from './Errors';
+
 import bindings = require('bindings'); // eslint-disable-line @typescript-eslint/no-require-imports
 import * as Native from './Native';
 
@@ -15,7 +18,10 @@ const NativeImpl = bindings(
 
 export const { initLogger, LogLevel } = NativeImpl;
 
+NativeImpl.registerErrors(Errors);
+
 // These enums must be kept in sync with their Rust counterparts.
+
 export const enum CiphertextMessageType {
   Whisper = 2,
   PreKey = 3,
@@ -1341,7 +1347,7 @@ export async function sealedSenderDecryptMessage(
   identityStore: IdentityKeyStore,
   prekeyStore: PreKeyStore,
   signedPrekeyStore: SignedPreKeyStore
-): Promise<SealedSenderDecryptionResult | null> {
+): Promise<SealedSenderDecryptionResult> {
   const ssdr = await NativeImpl.SealedSender_DecryptMessage(
     message,
     trustRoot,
@@ -1354,9 +1360,6 @@ export async function sealedSenderDecryptMessage(
     prekeyStore,
     signedPrekeyStore
   );
-  if (ssdr == null) {
-    return null;
-  }
   return SealedSenderDecryptionResult._fromNativeHandle(ssdr);
 }
 

--- a/rust/bridge/node/bin/Native.d.ts.in
+++ b/rust/bridge/node/bin/Native.d.ts.in
@@ -40,3 +40,4 @@ interface Wrapper<T> {
   readonly _nativeHandle: T
 }
 
+export function registerErrors(errorsModule: Record<string, unknown>): void;

--- a/rust/bridge/shared/src/node/convert.rs
+++ b/rust/bridge/shared/src/node/convert.rs
@@ -563,41 +563,6 @@ impl<'a> ResultTypeInfo<'a> for Vec<u8> {
     }
 }
 
-impl<'a, T: ResultTypeInfo<'a>> ResultTypeInfo<'a>
-    for Result<T, libsignal_protocol::SignalProtocolError>
-{
-    type ResultType = T::ResultType;
-    fn convert_into(self, cx: &mut impl Context<'a>) -> NeonResult<Handle<'a, Self::ResultType>> {
-        match self {
-            Ok(value) => value.convert_into(cx),
-            // FIXME: Use a dedicated Error type?
-            Err(err) => cx.throw_error(err.to_string()),
-        }
-    }
-}
-
-impl<'a, T: ResultTypeInfo<'a>> ResultTypeInfo<'a> for Result<T, device_transfer::Error> {
-    type ResultType = T::ResultType;
-    fn convert_into(self, cx: &mut impl Context<'a>) -> NeonResult<Handle<'a, Self::ResultType>> {
-        match self {
-            Ok(value) => value.convert_into(cx),
-            // FIXME: Use a dedicated Error type?
-            Err(err) => cx.throw_error(err.to_string()),
-        }
-    }
-}
-
-impl<'a, T: ResultTypeInfo<'a>> ResultTypeInfo<'a> for Result<T, signal_crypto::Error> {
-    type ResultType = T::ResultType;
-    fn convert_into(self, cx: &mut impl Context<'a>) -> NeonResult<Handle<'a, Self::ResultType>> {
-        match self {
-            Ok(value) => value.convert_into(cx),
-            // FIXME: Use a dedicated Error type?
-            Err(err) => cx.throw_error(err.to_string()),
-        }
-    }
-}
-
 impl<'a, T: ResultTypeInfo<'a>> ResultTypeInfo<'a> for NeonResult<T> {
     type ResultType = T::ResultType;
     fn convert_into(self, cx: &mut impl Context<'a>) -> NeonResult<Handle<'a, Self::ResultType>> {

--- a/rust/bridge/shared/src/node/error.rs
+++ b/rust/bridge/shared/src/node/error.rs
@@ -5,7 +5,144 @@
 
 use super::*;
 
+use paste::paste;
 use std::fmt;
+
+const ERRORS_PROPERTY_NAME: &str = "Errors";
+const ERROR_CLASS_NAME: &str = "SignalClientErrorBase";
+
+#[allow(non_snake_case)]
+fn node_registerErrors(mut cx: FunctionContext) -> JsResult<JsValue> {
+    let errors_module = cx.argument::<JsObject>(0)?;
+    cx.this()
+        .set(&mut cx, ERRORS_PROPERTY_NAME, errors_module)?;
+    Ok(cx.undefined().upcast())
+}
+node_register!(registerErrors);
+
+fn new_js_error<'a>(
+    cx: &mut impl Context<'a>,
+    module: Handle<'a, JsObject>,
+    name: Option<&str>,
+    message: &str,
+    operation: &str,
+    extra_props: Option<Handle<'a, JsObject>>,
+) -> Option<Handle<'a, JsObject>> {
+    let result = cx.try_catch(|cx| {
+        let errors_module: Handle<JsObject> = module
+            .get(cx, ERRORS_PROPERTY_NAME)?
+            .downcast_or_throw(cx)?;
+        let error_class: Handle<JsFunction> = errors_module
+            .get(cx, ERROR_CLASS_NAME)?
+            .downcast_or_throw(cx)?;
+        let name_arg = match name {
+            Some(name) => cx.string(name).upcast(),
+            None => cx.undefined().upcast(),
+        };
+        let extra_props_arg = match extra_props {
+            Some(props) => props.upcast(),
+            None => cx.undefined().upcast(),
+        };
+
+        let args: Vec<Handle<JsValue>> = vec![
+            cx.string(message).upcast(),
+            name_arg,
+            cx.string(operation).upcast(),
+            extra_props_arg,
+        ];
+        error_class.construct(cx, args)
+    });
+    match result {
+        Ok(error_instance) => Some(error_instance),
+        Err(failure) => {
+            log::warn!(
+                "could not construct {}: {}",
+                name.unwrap_or("SignalClientError"),
+                failure
+                    .to_string(cx)
+                    .map(|s| s.value(cx))
+                    .unwrap_or_else(|_| "(could not print error)".to_owned())
+            );
+            None
+        }
+    }
+}
+
+pub trait SignalNodeError: Sized + fmt::Display {
+    fn throw<'a>(
+        self,
+        cx: &mut impl Context<'a>,
+        module: Handle<'a, JsObject>,
+        operation_name: &str,
+    ) -> JsResult<'a, JsValue> {
+        let message = self.to_string();
+        match new_js_error(cx, module, None, &message, operation_name, None) {
+            Some(error) => cx.throw(error),
+            None => {
+                // Make sure we still throw something.
+                cx.throw_error(&message)
+            }
+        }
+    }
+}
+
+impl SignalNodeError for neon::result::Throw {
+    fn throw<'a>(
+        self,
+        _cx: &mut impl Context<'a>,
+        _module: Handle<'a, JsObject>,
+        _operation_name: &str,
+    ) -> JsResult<'a, JsValue> {
+        Err(self)
+    }
+}
+
+impl SignalNodeError for SignalProtocolError {
+    fn throw<'a>(
+        self,
+        cx: &mut impl Context<'a>,
+        module: Handle<'a, JsObject>,
+        operation_name: &str,
+    ) -> JsResult<'a, JsValue> {
+        // Check for some dedicated error types first.
+        let custom_error = match &self {
+            SignalProtocolError::UntrustedIdentity(addr) => {
+                let props = cx.empty_object();
+                let addr_string = cx.string(addr.name());
+                props.set(cx, "addr", addr_string)?;
+                new_js_error(
+                    cx,
+                    module,
+                    Some("UntrustedIdentity"),
+                    &self.to_string(),
+                    operation_name,
+                    Some(props),
+                )
+            }
+            SignalProtocolError::SealedSenderSelfSend => new_js_error(
+                cx,
+                module,
+                Some("SealedSenderSelfSend"),
+                &self.to_string(),
+                operation_name,
+                None,
+            ),
+            _ => new_js_error(cx, module, None, &self.to_string(), operation_name, None),
+        };
+
+        match custom_error {
+            Some(error) => cx.throw(error),
+            None => {
+                // Make sure we still throw something.
+                cx.throw_error(&self.to_string())
+            }
+        }
+    }
+}
+
+impl SignalNodeError for device_transfer::Error {}
+
+impl SignalNodeError for signal_crypto::Error {}
 
 /// Represents an error returned by a callback.
 #[derive(Debug)]

--- a/rust/bridge/shared/src/node/mod.rs
+++ b/rust/bridge/shared/src/node/mod.rs
@@ -10,6 +10,23 @@ use std::ops::Deref;
 pub(crate) use neon::context::Context;
 pub(crate) use neon::prelude::*;
 
+/// Used to keep track of all generated entry points.
+///
+/// Takes the *JavaScript* name `fooBar` of a function; the corresponding Rust function must be
+/// declared `node_fooBar`.
+// Declared early so it can be used in submodules.
+macro_rules! node_register {
+    ( $name:ident ) => {
+        paste! {
+            #[no_mangle] // necessary because we are linking as a cdylib
+            #[allow(non_upper_case_globals)]
+            #[linkme::distributed_slice(crate::node::LIBSIGNAL_FNS)]
+            static [<signal_register_node_ $name>]: (&str, crate::node::JsFn) =
+                (stringify!($name), [<node_ $name>]);
+        }
+    };
+}
+
 #[macro_use]
 mod convert;
 pub use convert::*;
@@ -113,21 +130,6 @@ pub(crate) fn with_buffer_contents<R>(
     f(slice)
 }
 
-/// Used in the implementation of `bridge_fn` to keep track of all generated entry points.
-///
-/// Not intended to be invoked directly.
-macro_rules! node_register {
-    ( $name:ident ) => {
-        paste! {
-            #[no_mangle] // necessary because we are linking as a cdylib
-            #[allow(non_upper_case_globals)]
-            #[linkme::distributed_slice(node::LIBSIGNAL_FNS)]
-            static [<signal_register_node_ $name>]: (&str, node::JsFn) =
-                (stringify!($name), [<node_ $name>]);
-        }
-    };
-}
-
 /// Implementation of [`bridge_deserialize`](crate::support::bridge_deserialize) for Node.
 macro_rules! node_bridge_deserialize {
     ( $typ:ident::$fn:path as false ) => {};
@@ -141,7 +143,17 @@ macro_rules! node_bridge_deserialize {
                 let buffer = cx.argument::<node::JsBuffer>(0)?;
                 let obj: Result<$typ> =
                     node::with_buffer_contents(&mut cx, buffer, |buf| $typ::$fn(buf));
-                node::ResultTypeInfo::convert_into(obj, &mut cx)
+                match obj {
+                    Ok(obj) => node::ResultTypeInfo::convert_into(obj, &mut cx),
+                    Err(err) => {
+                        let module = cx.this();
+                        node::SignalNodeError::throw(
+                            err,
+                            &mut cx,
+                            module,
+                            stringify!([<$node_name "_Deserialize">]))
+                    }
+                }
             }
 
             node_register!([<$node_name _Deserialize>]);

--- a/rust/bridge/shared/src/protocol.rs
+++ b/rust/bridge/shared/src/protocol.rs
@@ -1022,8 +1022,8 @@ async fn SealedSender_DecryptMessage(
     identity_store: &mut dyn IdentityKeyStore,
     prekey_store: &mut dyn PreKeyStore,
     signed_prekey_store: &mut dyn SignedPreKeyStore,
-) -> Result<Option<SealedSenderDecryptionResult>> {
-    let result = sealed_sender_decrypt(
+) -> Result<SealedSenderDecryptionResult> {
+    sealed_sender_decrypt(
         message,
         trust_root,
         timestamp,
@@ -1036,13 +1036,7 @@ async fn SealedSender_DecryptMessage(
         signed_prekey_store,
         None,
     )
-    .await;
-
-    match result {
-        Ok(r) => Ok(Some(r)),
-        Err(SignalProtocolError::SealedSenderSelfSend) => Ok(None),
-        Err(e) => Err(e),
-    }
+    .await
 }
 
 #[bridge_fn(jni = "GroupSessionBuilder_1CreateSenderKeyDistributionMessage")]


### PR DESCRIPTION
- After loading the Rust library into Node, set an 'Errors' property with the relevant error types on the module object.

- Whenever a `bridge_fn` produces an error, pass it to a new `SignalNodeError::throw` API along with the `this` object, which is assumed to have to be the object with the 'Errors' property.

This is a little less tidy than how we do Java exceptions, but it comes from not having access to the error classes by some kind of absolute name. Alternate approaches considered include:

- Use an initialized-once global. Downside: would not work if you ever had more than one Node engine live in a process, or quit and restarted it. Upside: available everywhere.

- Store the errors on the global object under some long, complicated key (like "org.signal.libsignal-client.Errors"). Downside: pollutes the global object.

- Generate the classes using Neon instead of writing them in TypeScript. Downsides: inconvenient, difficult to maintain, harder to use *from* TypeScript.