### PR TITLE
Support offset/length params for GCM encryption in Java API

### DIFF
--- a/java/java/src/main/java/org/signal/internal/Native.java
+++ b/java/java/src/main/java/org/signal/internal/Native.java
@@ -72,16 +72,19 @@ public final class Native {
   public static native void Aes256Ctr32_Destroy(long handle);
   public static native long Aes256Ctr32_New(byte[] key, byte[] nonce, int initialCtr);
   public static native byte[] Aes256Ctr32_Process(long ctr, byte[] data);
+  public static native byte[] Aes256Ctr32_ProcessWithOffset(long ctr, byte[] data, int offset, int length);
 
   public static native void Aes256GcmDecryption_Destroy(long handle);
   public static native long Aes256GcmDecryption_New(byte[] key, byte[] nonce, byte[] associatedData);
   public static native byte[] Aes256GcmDecryption_Update(long gcm, byte[] data);
+  public static native byte[] Aes256GcmDecryption_UpdateWithOffset(long gcm, byte[] data, int offset, int length);
   public static native boolean Aes256GcmDecryption_VerifyTag(long gcm, byte[] tag);
 
   public static native byte[] Aes256GcmEncryption_ComputeTag(long gcm);
   public static native void Aes256GcmEncryption_Destroy(long handle);
   public static native long Aes256GcmEncryption_New(byte[] key, byte[] nonce, byte[] associatedData);
   public static native byte[] Aes256GcmEncryption_Update(long gcm, byte[] data);
+  public static native byte[] Aes256GcmEncryption_UpdateWithOffset(long gcm, byte[] data, int offset, int length);
 
   public static native byte[] Aes256GcmSiv_Decrypt(long aesGcmSiv, byte[] ctext, byte[] nonce, byte[] associatedData);
   public static native void Aes256GcmSiv_Destroy(long handle);

--- a/java/java/src/main/java/org/signal/internal/Native.java
+++ b/java/java/src/main/java/org/signal/internal/Native.java
@@ -71,20 +71,17 @@ public final class Native {
 
   public static native void Aes256Ctr32_Destroy(long handle);
   public static native long Aes256Ctr32_New(byte[] key, byte[] nonce, int initialCtr);
-  public static native byte[] Aes256Ctr32_Process(long ctr, byte[] data);
-  public static native byte[] Aes256Ctr32_ProcessWithOffset(long ctr, byte[] data, int offset, int length);
+  public static native byte[] Aes256Ctr32_Process(long ctr, byte[] data, int offset, int length);
 
   public static native void Aes256GcmDecryption_Destroy(long handle);
   public static native long Aes256GcmDecryption_New(byte[] key, byte[] nonce, byte[] associatedData);
-  public static native byte[] Aes256GcmDecryption_Update(long gcm, byte[] data);
-  public static native byte[] Aes256GcmDecryption_UpdateWithOffset(long gcm, byte[] data, int offset, int length);
+  public static native byte[] Aes256GcmDecryption_Update(long gcm, byte[] data, int offset, int length);
   public static native boolean Aes256GcmDecryption_VerifyTag(long gcm, byte[] tag);
 
   public static native byte[] Aes256GcmEncryption_ComputeTag(long gcm);
   public static native void Aes256GcmEncryption_Destroy(long handle);
   public static native long Aes256GcmEncryption_New(byte[] key, byte[] nonce, byte[] associatedData);
-  public static native byte[] Aes256GcmEncryption_Update(long gcm, byte[] data);
-  public static native byte[] Aes256GcmEncryption_UpdateWithOffset(long gcm, byte[] data, int offset, int length);
+  public static native byte[] Aes256GcmEncryption_Update(long gcm, byte[] data, int offset, int length);
 
   public static native byte[] Aes256GcmSiv_Decrypt(long aesGcmSiv, byte[] ctext, byte[] nonce, byte[] associatedData);
   public static native void Aes256GcmSiv_Destroy(long handle);

--- a/java/java/src/main/java/org/signal/libsignal/crypto/Aes256Ctr32.java
+++ b/java/java/src/main/java/org/signal/libsignal/crypto/Aes256Ctr32.java
@@ -24,4 +24,8 @@ class Aes256Ctr32 {
     return Native.Aes256Ctr32_Process(this.handle, data);
   }
 
+  byte[] process(byte[] data, int offset, int length) {
+    return Native.Aes256Ctr32_ProcessWithOffset(this.handle, data, offset, length);
+  }
+
 }

--- a/java/java/src/main/java/org/signal/libsignal/crypto/Aes256Ctr32.java
+++ b/java/java/src/main/java/org/signal/libsignal/crypto/Aes256Ctr32.java
@@ -21,11 +21,11 @@ class Aes256Ctr32 {
   }
 
   byte[] process(byte[] data) {
-    return Native.Aes256Ctr32_Process(this.handle, data);
+    return Native.Aes256Ctr32_Process(this.handle, data, 0, data.length);
   }
 
   byte[] process(byte[] data, int offset, int length) {
-    return Native.Aes256Ctr32_ProcessWithOffset(this.handle, data, offset, length);
+    return Native.Aes256Ctr32_Process(this.handle, data, offset, length);
   }
 
 }

--- a/java/java/src/main/java/org/signal/libsignal/crypto/Aes256GcmDecryption.java
+++ b/java/java/src/main/java/org/signal/libsignal/crypto/Aes256GcmDecryption.java
@@ -24,6 +24,10 @@ class Aes256GcmDecryption {
     return Native.Aes256GcmDecryption_Update(this.handle, plaintext);
   }
 
+  byte[] decrypt(byte[] plaintext, int offset, int length) {
+    return Native.Aes256GcmDecryption_UpdateWithOffset(this.handle, plaintext, offset, length);
+  }
+
   boolean verifyTag(byte[] tag) {
     boolean tagOk = Native.Aes256GcmDecryption_VerifyTag(this.handle, tag);
     Native.Aes256GcmDecryption_Destroy(this.handle);

--- a/java/java/src/main/java/org/signal/libsignal/crypto/Aes256GcmDecryption.java
+++ b/java/java/src/main/java/org/signal/libsignal/crypto/Aes256GcmDecryption.java
@@ -21,7 +21,7 @@ class Aes256GcmDecryption {
   }
 
   byte[] decrypt(byte[] plaintext) {
-    return Native.Aes256GcmDecryption_Update(this.handle, plaintext);
+    return Native.Aes256GcmDecryption_UpdateWithOffset(this.handle, plaintext, 0, plaintext.length);
   }
 
   byte[] decrypt(byte[] plaintext, int offset, int length) {

--- a/java/java/src/main/java/org/signal/libsignal/crypto/Aes256GcmDecryption.java
+++ b/java/java/src/main/java/org/signal/libsignal/crypto/Aes256GcmDecryption.java
@@ -21,11 +21,11 @@ class Aes256GcmDecryption {
   }
 
   byte[] decrypt(byte[] plaintext) {
-    return Native.Aes256GcmDecryption_UpdateWithOffset(this.handle, plaintext, 0, plaintext.length);
+    return Native.Aes256GcmDecryption_Update(this.handle, plaintext, 0, plaintext.length);
   }
 
   byte[] decrypt(byte[] plaintext, int offset, int length) {
-    return Native.Aes256GcmDecryption_UpdateWithOffset(this.handle, plaintext, offset, length);
+    return Native.Aes256GcmDecryption_Update(this.handle, plaintext, offset, length);
   }
 
   boolean verifyTag(byte[] tag) {

--- a/java/java/src/main/java/org/signal/libsignal/crypto/Aes256GcmEncryption.java
+++ b/java/java/src/main/java/org/signal/libsignal/crypto/Aes256GcmEncryption.java
@@ -20,6 +20,10 @@ class Aes256GcmEncryption {
     Native.Aes256GcmEncryption_Destroy(this.handle);
   }
 
+  byte[] encrypt(byte[] plaintext, int offset, int length) {
+    return Native.Aes256GcmEncryption_UpdateWithOffset(this.handle, plaintext, offset, length);
+  }
+
   byte[] encrypt(byte[] plaintext) {
     return Native.Aes256GcmEncryption_Update(this.handle, plaintext);
   }

--- a/java/java/src/main/java/org/signal/libsignal/crypto/Aes256GcmEncryption.java
+++ b/java/java/src/main/java/org/signal/libsignal/crypto/Aes256GcmEncryption.java
@@ -21,11 +21,11 @@ class Aes256GcmEncryption {
   }
 
   byte[] encrypt(byte[] plaintext, int offset, int length) {
-    return Native.Aes256GcmEncryption_UpdateWithOffset(this.handle, plaintext, offset, length);
+    return Native.Aes256GcmEncryption_Update(this.handle, plaintext, offset, length);
   }
 
   byte[] encrypt(byte[] plaintext) {
-    return Native.Aes256GcmEncryption_Update(this.handle, plaintext);
+    return Native.Aes256GcmEncryption_Update(this.handle, plaintext, 0, plaintext.length);
   }
 
   byte[] computeTag() {

--- a/java/tests/src/test/java/org/signal/libsignal/crypto/Aes256GcmEncryptionTests.java
+++ b/java/tests/src/test/java/org/signal/libsignal/crypto/Aes256GcmEncryptionTests.java
@@ -46,5 +46,20 @@ public class Aes256GcmEncryptionTests extends TestCase {
    byte[] decrypted = gcmDec.decrypt(ciphertext);
    assertEquals(Hex.toHexString(decrypted), hex_plaintext);
    assertEquals(gcmDec.verifyTag(tag), true);
+
+   Aes256GcmEncryption gcmEnc2 = new Aes256GcmEncryption(key, nonce, ad);
+   byte[] ciphertext1 = gcmEnc2.encrypt(plaintext, 0, 1);
+   assertEquals(ciphertext1.length, 1);
+   byte[] ciphertext2 = gcmEnc2.encrypt(plaintext, 1, plaintext.length - 1);
+   assertEquals(ciphertext2.length, plaintext.length - 1);
+   byte[] tag2 = gcmEnc2.computeTag();
+   assertEquals(Hex.toHexString(ciphertext1) + Hex.toHexString(ciphertext2), hex_ciphertext);
+   assertEquals(Hex.toHexString(tag2), hex_tag);
+
+   Aes256GcmDecryption gcmDec2 = new Aes256GcmDecryption(key, nonce, ad);
+   byte[] decrypted1 = gcmDec2.decrypt(ciphertext, 0, 1);
+   byte[] decrypted2 = gcmDec2.decrypt(ciphertext, 1, ciphertext.length - 1);
+   assertEquals(Hex.toHexString(decrypted1) + Hex.toHexString(decrypted2), hex_plaintext);
+   assertEquals(gcmDec2.verifyTag(tag), true);
   }
 }

--- a/rust/bridge/shared/src/crypto.rs
+++ b/rust/bridge/shared/src/crypto.rs
@@ -83,15 +83,9 @@ fn Aes256Ctr32_New(key: &[u8], nonce: &[u8], initial_ctr: u32) -> Result<Aes256C
     Aes256Ctr32::from_key(key, nonce, initial_ctr)
 }
 
+// This returns a new buffer but it would be better if it operated in-place
 #[bridge_fn_buffer(node = false)]
-fn Aes256Ctr32_Process<T: Env>(env: T, ctr: &mut Aes256Ctr32, data: &[u8]) -> Result<T::Buffer> {
-    let mut buf = data.to_vec();
-    ctr.process(&mut buf)?;
-    Ok(env.buffer(buf))
-}
-
-#[bridge_fn_buffer(node = false, ffi = false)]
-fn Aes256Ctr32_ProcessWithOffset<T: Env>(
+fn Aes256Ctr32_Process<T: Env>(
     env: T,
     ctr: &mut Aes256Ctr32,
     data: &[u8],
@@ -114,19 +108,9 @@ fn Aes256GcmEncryption_New(
     Aes256GcmEncryption::new(key, nonce, associated_data)
 }
 
+// This returns a new buffer but it would be better if it operated in-place
 #[bridge_fn_buffer(node = false)]
 fn Aes256GcmEncryption_Update<T: Env>(
-    env: T,
-    gcm: &mut Aes256GcmEncryption,
-    data: &[u8],
-) -> Result<T::Buffer> {
-    let mut buf = data.to_vec();
-    gcm.encrypt(&mut buf)?;
-    Ok(env.buffer(buf))
-}
-
-#[bridge_fn_buffer(node = false, ffi = false)]
-fn Aes256GcmEncryption_UpdateWithOffset<T: Env>(
     env: T,
     gcm: &mut Aes256GcmEncryption,
     data: &[u8],
@@ -158,19 +142,9 @@ fn Aes256GcmDecryption_New(
     Aes256GcmDecryption::new(key, nonce, associated_data)
 }
 
+// This returns a new buffer but it would be better if it operated in-place
 #[bridge_fn_buffer(node = false)]
 fn Aes256GcmDecryption_Update<T: Env>(
-    env: T,
-    gcm: &mut Aes256GcmDecryption,
-    data: &[u8],
-) -> Result<T::Buffer> {
-    let mut buf = data.to_vec();
-    gcm.decrypt(&mut buf)?;
-    Ok(env.buffer(buf))
-}
-
-#[bridge_fn_buffer(node = false, ffi = false)]
-fn Aes256GcmDecryption_UpdateWithOffset<T: Env>(
     env: T,
     gcm: &mut Aes256GcmDecryption,
     data: &[u8],

--- a/rust/bridge/shared/src/crypto.rs
+++ b/rust/bridge/shared/src/crypto.rs
@@ -90,6 +90,21 @@ fn Aes256Ctr32_Process<T: Env>(env: T, ctr: &mut Aes256Ctr32, data: &[u8]) -> Re
     Ok(env.buffer(buf))
 }
 
+#[bridge_fn_buffer(node = false, ffi = false)]
+fn Aes256Ctr32_ProcessWithOffset<T: Env>(
+    env: T,
+    ctr: &mut Aes256Ctr32,
+    data: &[u8],
+    offset: u32,
+    length: u32,
+) -> Result<T::Buffer> {
+    let offset = offset as usize;
+    let length = length as usize;
+    let mut buf = data[offset..offset + length].to_vec();
+    ctr.process(&mut buf)?;
+    Ok(env.buffer(buf))
+}
+
 #[bridge_fn(node = false)]
 fn Aes256GcmEncryption_New(
     key: &[u8],
@@ -106,6 +121,21 @@ fn Aes256GcmEncryption_Update<T: Env>(
     data: &[u8],
 ) -> Result<T::Buffer> {
     let mut buf = data.to_vec();
+    gcm.encrypt(&mut buf)?;
+    Ok(env.buffer(buf))
+}
+
+#[bridge_fn_buffer(node = false, ffi = false)]
+fn Aes256GcmEncryption_UpdateWithOffset<T: Env>(
+    env: T,
+    gcm: &mut Aes256GcmEncryption,
+    data: &[u8],
+    offset: u32,
+    length: u32,
+) -> Result<T::Buffer> {
+    let offset = offset as usize;
+    let length = length as usize;
+    let mut buf = data[offset..offset + length].to_vec();
     gcm.encrypt(&mut buf)?;
     Ok(env.buffer(buf))
 }
@@ -135,6 +165,21 @@ fn Aes256GcmDecryption_Update<T: Env>(
     data: &[u8],
 ) -> Result<T::Buffer> {
     let mut buf = data.to_vec();
+    gcm.decrypt(&mut buf)?;
+    Ok(env.buffer(buf))
+}
+
+#[bridge_fn_buffer(node = false, ffi = false)]
+fn Aes256GcmDecryption_UpdateWithOffset<T: Env>(
+    env: T,
+    gcm: &mut Aes256GcmDecryption,
+    data: &[u8],
+    offset: u32,
+    length: u32,
+) -> Result<T::Buffer> {
+    let offset = offset as usize;
+    let length = length as usize;
+    let mut buf = data[offset..offset + length].to_vec();
     gcm.decrypt(&mut buf)?;
     Ok(env.buffer(buf))
 }

--- a/swift/Sources/SignalFfi/signal_ffi.h
+++ b/swift/Sources/SignalFfi/signal_ffi.h
@@ -250,7 +250,9 @@ SignalFfiError *signal_aes256_ctr32_process(const unsigned char **out,
                                             size_t *out_len,
                                             SignalAes256Ctr32 *ctr,
                                             const unsigned char *data,
-                                            size_t data_len);
+                                            size_t data_len,
+                                            uint32_t offset,
+                                            uint32_t length);
 
 SignalFfiError *signal_aes256_gcm_encryption_new(SignalAes256GcmEncryption **out,
                                                  const unsigned char *key,
@@ -264,7 +266,9 @@ SignalFfiError *signal_aes256_gcm_encryption_update(const unsigned char **out,
                                                     size_t *out_len,
                                                     SignalAes256GcmEncryption *gcm,
                                                     const unsigned char *data,
-                                                    size_t data_len);
+                                                    size_t data_len,
+                                                    uint32_t offset,
+                                                    uint32_t length);
 
 SignalFfiError *signal_aes256_gcm_encryption_compute_tag(const unsigned char **out,
                                                          size_t *out_len,
@@ -282,7 +286,9 @@ SignalFfiError *signal_aes256_gcm_decryption_update(const unsigned char **out,
                                                     size_t *out_len,
                                                     SignalAes256GcmDecryption *gcm,
                                                     const unsigned char *data,
-                                                    size_t data_len);
+                                                    size_t data_len,
+                                                    uint32_t offset,
+                                                    uint32_t length);
 
 SignalFfiError *signal_aes256_gcm_decryption_verify_tag(bool *out,
                                                         SignalAes256GcmDecryption *gcm,


### PR DESCRIPTION
As Java has no concept of slices and we need some way of doing partial updates, since this is required to implement the JCE Cipher interface, and Android uses it.