### PR TITLE
Add a JCE compat layer

### DIFF
--- a/java/java/src/main/java/org/signal/libsignal/crypto/Aes256Ctr32.java
+++ b/java/java/src/main/java/org/signal/libsignal/crypto/Aes256Ctr32.java
@@ -8,7 +8,7 @@ package org.signal.libsignal.crypto;
 import org.signal.client.internal.Native;
 import org.whispersystems.libsignal.InvalidKeyException;
 
-class Aes256Ctr32 {
+public class Aes256Ctr32 {
   private final long handle;
 
   public Aes256Ctr32(byte[] key, byte[] nonce, int initialCtr) throws InvalidKeyException {
@@ -20,11 +20,11 @@ class Aes256Ctr32 {
     Native.Aes256Ctr32_Destroy(this.handle);
   }
 
-  byte[] process(byte[] data) {
+  public byte[] process(byte[] data) {
     return Native.Aes256Ctr32_Process(this.handle, data, 0, data.length);
   }
 
-  byte[] process(byte[] data, int offset, int length) {
+  public byte[] process(byte[] data, int offset, int length) {
     return Native.Aes256Ctr32_Process(this.handle, data, offset, length);
   }
 

--- a/java/java/src/main/java/org/signal/libsignal/crypto/Aes256GcmDecryption.java
+++ b/java/java/src/main/java/org/signal/libsignal/crypto/Aes256GcmDecryption.java
@@ -8,7 +8,7 @@ package org.signal.libsignal.crypto;
 import org.signal.client.internal.Native;
 import org.whispersystems.libsignal.InvalidKeyException;
 
-class Aes256GcmDecryption {
+public class Aes256GcmDecryption {
   private long handle;
 
   public Aes256GcmDecryption(byte[] key, byte[] nonce, byte[] associatedData) throws InvalidKeyException {
@@ -20,15 +20,15 @@ class Aes256GcmDecryption {
     Native.Aes256GcmDecryption_Destroy(this.handle);
   }
 
-  byte[] decrypt(byte[] plaintext) {
+  public byte[] decrypt(byte[] plaintext) {
     return Native.Aes256GcmDecryption_Update(this.handle, plaintext, 0, plaintext.length);
   }
 
-  byte[] decrypt(byte[] plaintext, int offset, int length) {
+  public byte[] decrypt(byte[] plaintext, int offset, int length) {
     return Native.Aes256GcmDecryption_Update(this.handle, plaintext, offset, length);
   }
 
-  boolean verifyTag(byte[] tag) {
+  public boolean verifyTag(byte[] tag) {
     boolean tagOk = Native.Aes256GcmDecryption_VerifyTag(this.handle, tag);
     Native.Aes256GcmDecryption_Destroy(this.handle);
     this.handle = 0;

--- a/java/java/src/main/java/org/signal/libsignal/crypto/Aes256GcmEncryption.java
+++ b/java/java/src/main/java/org/signal/libsignal/crypto/Aes256GcmEncryption.java
@@ -8,7 +8,7 @@ package org.signal.libsignal.crypto;
 import org.signal.client.internal.Native;
 import org.whispersystems.libsignal.InvalidKeyException;
 
-class Aes256GcmEncryption {
+public class Aes256GcmEncryption {
   private long handle;
 
   public Aes256GcmEncryption(byte[] key, byte[] nonce, byte[] associatedData) throws InvalidKeyException {
@@ -20,15 +20,15 @@ class Aes256GcmEncryption {
     Native.Aes256GcmEncryption_Destroy(this.handle);
   }
 
-  byte[] encrypt(byte[] plaintext, int offset, int length) {
+  public byte[] encrypt(byte[] plaintext, int offset, int length) {
     return Native.Aes256GcmEncryption_Update(this.handle, plaintext, offset, length);
   }
 
-  byte[] encrypt(byte[] plaintext) {
+  public byte[] encrypt(byte[] plaintext) {
     return Native.Aes256GcmEncryption_Update(this.handle, plaintext, 0, plaintext.length);
   }
 
-  byte[] computeTag() {
+  public byte[] computeTag() {
     byte[] tag = Native.Aes256GcmEncryption_ComputeTag(this.handle);
     Native.Aes256GcmEncryption_Destroy(this.handle);
     this.handle = 0;

--- a/java/java/src/main/java/org/signal/libsignal/crypto/jce/Cipher.java
+++ b/java/java/src/main/java/org/signal/libsignal/crypto/jce/Cipher.java
@@ -1,0 +1,194 @@
+//
+// Copyright 2021 Signal Messenger, LLC.
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+package org.signal.libsignal.crypto.jce;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import javax.crypto.BadPaddingException;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.signal.libsignal.crypto.Aes256GcmDecryption;
+import org.signal.libsignal.crypto.Aes256GcmEncryption;
+
+/*
+This is a rough compatability layer with Java JCE interface. It diverges from
+the behavior of actual JCE in (at least) the following ways
+
+- JCE allows encrypting multiple messages without setting a new nonce. Quoting
+  the docs "Upon finishing, this method [doFinal] resets this cipher object to
+  the state it was in when previously initialized via a call to init."  If you
+  do that with GCM you immediately cause a huge vulnerability. You must call
+  init again to set a new nonce.
+
+- JCE allows you to not provide parameters (eg a nonce) and then it will
+  randomly generate them for you. This is not implementned.
+
+- JCE allows incremental update of the associated data. This is not supported.
+  You may call updateAAD at most 1 time, and it must be before any calls to
+  update have been made.
+
+- JCE allows you to not provide the tag to doFinal. As a result, when decrypting
+  the JCE implementation must unavoidably buffer 16 bytes to ensure that it does
+  not attempt to process the tag as ciphertext. We don't do this. Instead the
+  caller must provide the tag to doFinal
+
+- Many irrelevant APIs (ie ones not used by Signal Android app) are not
+  implemented at all.
+
+- Only precisely 128-bit tags, 96-bit nonces, and 256-bit keys are supported.
+
+*/
+class Cipher {
+
+  static int ENCRYPT_MODE = 0;
+  static int DECRYPT_MODE = 1;
+
+  Aes256GcmEncryption gcmEnc;
+  Aes256GcmDecryption gcmDec;
+  int mode;
+  byte[] key;
+  byte[] nonce;
+  byte[] aad;
+  byte[] tagBuf;
+
+  public static Cipher getInstance(String algoName) throws NoSuchAlgorithmException {
+    if (algoName != "AES/GCM/NoPadding") {
+      throw new NoSuchAlgorithmException(algoName);
+    }
+
+    return new Cipher(algoName);
+  }
+
+  private Cipher(String algoName) {
+    this.mode = -1;
+    this.gcmEnc = null;
+    this.gcmDec = null;
+  }
+
+  public void init(int mode, SecretKeySpec key, IvParameterSpec params)
+      throws InvalidKeyException, InvalidAlgorithmParameterException {
+
+    this.mode = mode;
+    this.key = key.getEncoded();
+    this.nonce = params.getIV();
+    this.aad = null;
+    this.tagBuf = null;
+
+    this.gcmEnc = null;
+    this.gcmDec = null;
+
+    if (this.key.length != 32) {
+      throw new InvalidKeyException("GCM implementation only supports 256 bit keys");
+    }
+
+    if (this.nonce.length != 12) {
+      throw new InvalidAlgorithmParameterException("GCM implementation only supports 96 bit nonce");
+    }
+  }
+
+  public void init(int mode, SecretKeySpec key, GCMParameterSpec params)
+      throws InvalidKeyException, InvalidAlgorithmParameterException {
+
+    if (params.getTLen() != 128) {
+      throw new InvalidAlgorithmParameterException(
+          "This GCM implementation supports only 128 bit tags");
+    }
+
+    this.mode = mode;
+    this.key = key.getEncoded();
+    this.nonce = params.getIV();
+    this.aad = null;
+
+    gcmEnc = null;
+    gcmDec = null;
+
+    if (this.key.length != 32) {
+      throw new InvalidKeyException("GCM implementation only supports 256 bit keys");
+    }
+
+    if (this.nonce.length != 12) {
+      throw new InvalidAlgorithmParameterException("GCM implementation only supports 96 bit nonce");
+    }
+  }
+
+  public void updateAAD(byte[] aad) throws IllegalStateException {
+    if (this.aad != null) {
+      throw new IllegalStateException("This API does not support incremental AAD update");
+    }
+    if (this.gcmEnc != null || this.gcmDec != null) {
+      throw new IllegalStateException(
+          "This API does not support setting AAD after processing ciphertext");
+    }
+
+    this.aad = aad;
+  }
+
+  public void update(byte[] input, int offset, int len) throws IllegalStateException {
+    if (this.gcmEnc == null && this.gcmDec == null) {
+
+      try {
+        if (this.mode == ENCRYPT_MODE) {
+          this.gcmEnc = new Aes256GcmEncryption(this.key, this.nonce, this.aad);
+        } else {
+          this.gcmDec = new Aes256GcmDecryption(this.key, this.nonce, this.aad);
+        }
+      } catch (org.whispersystems.libsignal.InvalidKeyException e) {
+        // We already checked the length so this should never happen
+        throw new AssertionError(e);
+      }
+
+      this.key = null;
+      this.nonce = null;
+      this.mode = -1;
+    }
+
+    if (this.gcmEnc != null) {
+      byte[] ctext = this.gcmEnc.encrypt(input, offset, len);
+      System.arraycopy(ctext, 0, input, offset, len);
+    } else {
+      byte[] ptext = this.gcmDec.decrypt(input, offset, len);
+      System.arraycopy(ptext, 0, input, offset, len);
+    }
+  }
+
+  public void update(byte[] input) throws IllegalStateException {
+    update(input, 0, input.length);
+  }
+
+  public byte[] doFinal() throws IllegalStateException {
+    if (this.gcmEnc != null) {
+      byte[] tag = this.gcmEnc.computeTag();
+      this.gcmEnc = null;
+      return tag;
+    } else {
+      throw new IllegalStateException("Must provide tag to doFinal for GCM decryption");
+    }
+  }
+
+  public byte[] doFinal(byte[] last) throws IllegalStateException, BadPaddingException {
+
+    if (this.gcmEnc != null) {
+      update(last);
+      byte[] tag = this.gcmEnc.computeTag();
+      this.gcmEnc = null;
+      return tag;
+    } else {
+      if (last.length < 16) {
+        throw new IllegalStateException("Must provide tag to doFinal for GCM decryption");
+      }
+
+      update(last, 0, last.length - 16);
+      byte[] tag = new byte[16];
+      System.arraycopy(last, last.length - 16, tag, 0, 16);
+      if (!this.gcmDec.verifyTag(tag)) {
+        throw new BadPaddingException();
+      }
+      return null;
+    }
+  }
+}

--- a/java/java/src/main/java/org/signal/libsignal/crypto/jce/Mac.java
+++ b/java/java/src/main/java/org/signal/libsignal/crypto/jce/Mac.java
@@ -1,0 +1,63 @@
+//
+// Copyright 2021 Signal Messenger, LLC.
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+package org.signal.libsignal.crypto.jce;
+
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import org.signal.libsignal.crypto.CryptographicMac;
+import javax.crypto.spec.SecretKeySpec;
+
+public class Mac {
+
+  String algoName;
+  CryptographicMac hmac;
+
+  public static Mac getInstance(String algoName) throws NoSuchAlgorithmException {
+    return new Mac(algoName);
+  }
+
+  private Mac(String algoName) throws NoSuchAlgorithmException {
+    if (!algoName.equals("HMACSha256") && !algoName.equals("HMACSha1")) {
+      throw new NoSuchAlgorithmException(algoName);
+    }
+
+    this.algoName = algoName;
+  }
+
+  public void init(SecretKeySpec key) throws InvalidKeyException, IllegalStateException {
+    this.hmac = new CryptographicMac(this.algoName, key.getEncoded());
+  }
+
+  public void update(byte[] input, int offset, int len) throws IllegalStateException {
+    if (this.hmac == null) {
+      throw new IllegalStateException("Mac instance was never keyed");
+    }
+
+    this.hmac.update(input, offset, len);
+  }
+
+  public void update(byte[] input) throws IllegalStateException {
+    update(input, 0, input.length);
+  }
+
+  public byte[] doFinal() throws IllegalStateException {
+    if (this.hmac == null) {
+      throw new IllegalStateException("Mac instance was never keyed");
+    }
+
+    return this.hmac.finish();
+  }
+
+  public byte[] doFinal(byte[] last) throws IllegalStateException {
+    update(last);
+    return doFinal();
+  }
+
+  public byte[] doFinal(byte[] last, int offset, int len) throws IllegalStateException {
+    update(last, offset, len);
+    return doFinal();
+  }
+}

--- a/java/java/src/main/java/org/signal/libsignal/crypto/jce/MessageDigest.java
+++ b/java/java/src/main/java/org/signal/libsignal/crypto/jce/MessageDigest.java
@@ -1,0 +1,43 @@
+//
+// Copyright 2021 Signal Messenger, LLC.
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+package org.signal.libsignal.crypto.jce;
+
+import java.security.NoSuchAlgorithmException;
+import org.signal.libsignal.crypto.CryptographicHash;
+
+public class MessageDigest {
+  CryptographicHash hash;
+
+  public static MessageDigest getInstance(String algoName) throws NoSuchAlgorithmException {
+    return new MessageDigest(algoName);
+  }
+
+  private MessageDigest(String algoName) throws NoSuchAlgorithmException {
+    this.hash = new CryptographicHash(algoName);
+  }
+
+  public void update(byte[] input, int offset, int len) {
+    this.hash.update(input, offset, len);
+  }
+
+  public void update(byte[] input) {
+    update(input, 0, input.length);
+  }
+
+  public byte[] doFinal() {
+    return this.hash.finish();
+  }
+
+  public byte[] doFinal(byte[] last) {
+    update(last);
+    return doFinal();
+  }
+
+  public byte[] doFinal(byte[] last, int offset, int len) {
+    update(last, offset, len);
+    return doFinal();
+  }
+}


### PR DESCRIPTION
This is ugly and pretty limited but it should handle most of the cases Android uses `Cipher` with GCM. It might ease the transition to using the Rust-based GCM impl. IMO it's probably better in the long run to just change Android to use our directly provided APIs.

Hash and MAC should work just like JCE's, `Cipher` comes with a lot of caveats though. (Documented in the comments in `Cipher.java`)