### PR TITLE
Start removing nightly features from support libraries

### DIFF
--- a/rust/bridge/node/futures/src/lib.rs
+++ b/rust/bridge/node/futures/src/lib.rs
@@ -18,7 +18,6 @@
 //!
 //! [Neon]: https://neon-bindings.com/
 
-#![feature(trait_alias)]
 #![feature(wake_trait)]
 #![warn(missing_docs)]
 #![warn(clippy::unwrap_used)]

--- a/rust/bridge/shared/macros/src/lib.rs
+++ b/rust/bridge/shared/macros/src/lib.rs
@@ -141,8 +141,6 @@
 //! - There is no support for multiple return values, even though some of the FFI entry points
 //!   use multiple output parameters. These functions must be implemented manually.
 
-#![feature(box_patterns)]
-
 use proc_macro::TokenStream;
 use quote::*;
 use syn::punctuated::Punctuated;

--- a/rust/bridge/shared/macros/src/node.rs
+++ b/rust/bridge/shared/macros/src/node.rs
@@ -159,12 +159,15 @@ pub(crate) fn bridge_fn(name: String, sig: &Signature, result_kind: ResultKind) 
             )),
             FnArg::Typed(PatType {
                 attrs: _,
-                pat: box Pat::Ident(name),
+                pat,
                 colon_token: _,
                 ty,
-            }) => Ok((&name.ident, &**ty)),
-            FnArg::Typed(PatType { pat, .. }) => {
-                Err(Error::new(pat.span(), "cannot use patterns in parameter"))
+            }) => {
+                if let Pat::Ident(name) = pat.as_ref() {
+                    Ok((&name.ident, &**ty))
+                } else {
+                    Err(Error::new(pat.span(), "cannot use patterns in parameter"))
+                }
             }
         })
         .collect();


### PR DESCRIPTION
In the hopes that they'll be more reusable that way. The remaining feature flags, `wake_trait` and `min_const_generics`, were both stabilized recently, so when we roll our compiler version forward we'll be able to eliminate them too.

Note that this is *not* going to get this repository off of nightly: the `crypto` crate still uses the `stdsimd` and `aarch64_target_feature` features on Android and iOS for access to intrinsics, and cbindgen always needs *some* nightly installed in order to support macros. But signal-neon-futures and libsignal-bridge-macros are potentially reusable elsewhere.