### PR TITLE
Core-52: libsignalclient leaks memory when setting up logging

### DIFF
--- a/swift/Sources/SignalClient/Logging.m
+++ b/swift/Sources/SignalClient/Logging.m
@@ -71,6 +71,8 @@ static void flush()
 
 __attribute__((constructor)) static void initLogging()
 {
-    SignalLogLevel logLevel = ShouldLogDebug() ? SignalLogLevel_Trace : SignalLogLevel_Info;
-    signal_init_logger(logLevel, (SignalFfiLogger) { .enabled = isEnabled, .log = logMessage, .flush = flush });
+    @autoreleasepool {
+        SignalLogLevel logLevel = ShouldLogDebug() ? SignalLogLevel_Trace : SignalLogLevel_Info;
+        signal_init_logger(logLevel, (SignalFfiLogger) { .enabled = isEnabled, .log = logMessage, .flush = flush });
+    }
 }


### PR DESCRIPTION
commit 51a3b61ebae7a97f71a812b1b9909992e8013f9d (HEAD -> mlin/PR/LoggingLeak, public/mlin/PR/LoggingLeak, origin/mlin/PR/LoggingLeak)
Author: Michelle Linington <michelle@signal.org>
Date:   Fri Mar 26 20:38:43 2021 -0700

    Core-52: libsignalclient leaks memory when setting up logging
    
    initLogging() has __attribute__((constructor)), so it'll run before main
    and before we have an autoreleasepool for the thread.
    
    After logging is configured, it posts a log message which results in
    some objects being autoreleased. This change adds a pool to track these
    objects.
