### PR TITLE
protocol: Test version bytes the same way as libsignal-protocol-java

### DIFF
--- a/node/test/PublicAPITest.ts
+++ b/node/test/PublicAPITest.ts
@@ -521,7 +521,7 @@ describe('SignalClient', () => {
     assert.deepEqual(skr, skrFromBytes);
   });
   it('SignalMessage and PreKeySignalMessage', () => {
-    const messageVersion = 2;
+    const messageVersion = 3;
     const macKey = Buffer.alloc(32, 0xab);
     const senderRatchetKey = SignalClient.PrivateKey.generate().getPublicKey();
     const counter = 9;

--- a/rust/protocol/src/protocol.rs
+++ b/rust/protocol/src/protocol.rs
@@ -193,15 +193,14 @@ impl TryFrom<&[u8]> for SignalMessage {
             return Err(SignalProtocolError::CiphertextMessageTooShort(value.len()));
         }
         let message_version = value[0] >> 4;
-        let ciphertext_version = value[0] & 0x0F;
-        if ciphertext_version < CIPHERTEXT_MESSAGE_CURRENT_VERSION {
+        if message_version < CIPHERTEXT_MESSAGE_CURRENT_VERSION {
             return Err(SignalProtocolError::LegacyCiphertextVersion(
-                ciphertext_version,
+                message_version,
             ));
         }
-        if ciphertext_version > CIPHERTEXT_MESSAGE_CURRENT_VERSION {
+        if message_version > CIPHERTEXT_MESSAGE_CURRENT_VERSION {
             return Err(SignalProtocolError::UnrecognizedCiphertextVersion(
-                ciphertext_version,
+                message_version,
             ));
         }
 
@@ -333,15 +332,14 @@ impl TryFrom<&[u8]> for PreKeySignalMessage {
         }
 
         let message_version = value[0] >> 4;
-        let ciphertext_version = value[0] & 0x0F;
-        if ciphertext_version < CIPHERTEXT_MESSAGE_CURRENT_VERSION {
+        if message_version < CIPHERTEXT_MESSAGE_CURRENT_VERSION {
             return Err(SignalProtocolError::LegacyCiphertextVersion(
-                ciphertext_version,
+                message_version,
             ));
         }
-        if ciphertext_version > CIPHERTEXT_MESSAGE_CURRENT_VERSION {
+        if message_version > CIPHERTEXT_MESSAGE_CURRENT_VERSION {
             return Err(SignalProtocolError::UnrecognizedCiphertextVersion(
-                ciphertext_version,
+                message_version,
             ));
         }
 
@@ -474,15 +472,14 @@ impl TryFrom<&[u8]> for SenderKeyMessage {
             return Err(SignalProtocolError::CiphertextMessageTooShort(value.len()));
         }
         let message_version = value[0] >> 4;
-        let ciphertext_version = value[0] & 0x0F;
-        if ciphertext_version < CIPHERTEXT_MESSAGE_CURRENT_VERSION {
+        if message_version < CIPHERTEXT_MESSAGE_CURRENT_VERSION {
             return Err(SignalProtocolError::LegacyCiphertextVersion(
-                ciphertext_version,
+                message_version,
             ));
         }
-        if ciphertext_version > CIPHERTEXT_MESSAGE_CURRENT_VERSION {
+        if message_version > CIPHERTEXT_MESSAGE_CURRENT_VERSION {
             return Err(SignalProtocolError::UnrecognizedCiphertextVersion(
-                ciphertext_version,
+                message_version,
             ));
         }
         let proto_structure =


### PR DESCRIPTION
This slipped in the original translation to Rust, but it hasn't mattered in practice because both nibbles of the version byte have had the same value for a long time.