### PR TITLE
[CocoaPod] Properly quote path to libsignal_ffi.a in build script

### DIFF
--- a/SignalClient.podspec
+++ b/SignalClient.podspec
@@ -46,9 +46,13 @@ Pod::Spec.new do |s|
     { :name => 'Check libsignal-ffi',
       :execution_position => :before_compile,
       :script => %q(
-        test -e ${LIBSIGNAL_FFI_LIB_IF_NEEDED} && exit 0
-        echo 'error: libsignal_ffi.a not built; run the following to build it:' >&2
-        echo "CARGO_BUILD_TARGET=${CARGO_BUILD_TARGET} \"${PODS_TARGET_SRCROOT}/swift/build_ffi.sh\" --release" >&2
+        test -e "${LIBSIGNAL_FFI_LIB_IF_NEEDED}" && exit 0
+        if test -e "${PODS_TARGET_SRCROOT}/swift/build_ffi.sh"; then
+          echo 'error: libsignal_ffi.a not built; run the following to build it:' >&2
+          echo "CARGO_BUILD_TARGET=${CARGO_BUILD_TARGET} \"${PODS_TARGET_SRCROOT}/swift/build_ffi.sh\" --release" >&2
+        else
+          echo 'error: libsignal_ffi.a not built; try re-running `pod install`' >&2
+        fi
         false
       ),
     }


### PR DESCRIPTION
Also, if the library somehow isn't built when used as a non-local CocoaPods dependency, don't suggest running swift/build_ffi.sh; CocoaPods will have removed it already. Re-running `pod install` is more likely to help, though in practice something's probably gone wrong in the configuration.