### PR TITLE
signal-neon-futures: Add a Node benchmark for a single round trip

### DIFF
--- a/rust/bridge/node/futures/Cargo.toml
+++ b/rust/bridge/node/futures/Cargo.toml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Signal Messenger, LLC.
+# Copyright 2020-2021 Signal Messenger, LLC.
 # SPDX-License-Identifier: AGPL-3.0-only
 #
 
@@ -13,6 +13,11 @@ edition = "2018"
 [[test]]
 name = "signal-neon-futures-tests"
 path = "tests/node.rs"
+harness = false
+
+[[bench]]
+name = "signal-neon-futures-bench"
+path = "benches/node.rs"
 harness = false
 
 [dependencies]

--- a/rust/bridge/node/futures/benches/node.rs
+++ b/rust/bridge/node/futures/benches/node.rs
@@ -3,8 +3,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+#[path = "../tests/util.rs"]
 mod util;
 
 fn main() {
-    util::run("test")
+    util::run("bench")
 }

--- a/rust/bridge/node/futures/tests/node-tests/bench.js
+++ b/rust/bridge/node/futures/tests/node-tests/bench.js
@@ -1,0 +1,24 @@
+//
+// Copyright 2021 Signal Messenger, LLC.
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+/* eslint-env es2017 */
+
+const Benchmark = require('benchmark');
+
+const Native = require(process.env.SIGNAL_NEON_FUTURES_TEST_LIB);
+
+const suite = new Benchmark.Suite();
+suite
+  .add('await Native.incrementCallbackPromise(async () => 7)', {
+    defer: true,
+    fn: async deferred => {
+      await Native.incrementCallbackPromise(async () => 7);
+      deferred.resolve();
+    },
+  })
+  .on('cycle', event => {
+    console.log(String(event.target));
+  })
+  .run();

--- a/rust/bridge/node/futures/tests/node-tests/package.json
+++ b/rust/bridge/node/futures/tests/node-tests/package.json
@@ -7,11 +7,14 @@
     "neon-cli": "^0.5.0"
   },
   "scripts": {
-    "test": "yarn install && mocha --recursive test"
+    "test": "yarn install && mocha --recursive test",
+    "bench": "yarn install && node bench.js"
   },
   "devDependencies": {
+    "benchmark": "^2.1.4",
     "chai": "4.2.0",
     "chai-as-promised": "^7.1.1",
+    "microtime": "^3.0.0",
     "mocha": "8.2.1"
   }
 }

--- a/rust/bridge/node/futures/tests/node-tests/test/basic.js
+++ b/rust/bridge/node/futures/tests/node-tests/test/basic.js
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Signal Messenger, LLC.
+// Copyright 2020-2021 Signal Messenger, LLC.
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
@@ -82,6 +82,9 @@ describe('native', () => {
     it('can fulfill promises', async () => {
       const result = await native.incrementPromise(Promise.resolve(5));
       assert.equal(result, 6);
+
+      const result2 = await native.incrementCallbackPromise(async () => 7);
+      assert.equal(result2, 8);
     });
 
     it('can handle rejection', async () => {

--- a/rust/bridge/node/futures/tests/node-tests/yarn.lock
+++ b/rust/bridge/node/futures/tests/node-tests/yarn.lock
@@ -83,6 +83,14 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+benchmark@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/benchmark/-/benchmark-2.1.4.tgz#09f3de31c916425d498cc2ee565a0ebf3c2a5629"
+  integrity sha1-CfPeMckWQl1JjMLuVloOvzwqVik=
+  dependencies:
+    lodash "^4.17.4"
+    platform "^1.3.3"
+
 binary-extensions@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.1.0.tgz#30fa40c9e7fe07dbc895678cd287024dea241dd9"
@@ -569,6 +577,11 @@ lodash@^4.17.19:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
+lodash@^4.17.4:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 log-symbols@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.0.0.tgz#69b3cc46d20f448eccdb75ea1fa733d9e821c920"
@@ -580,6 +593,14 @@ make-promises-safe@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/make-promises-safe/-/make-promises-safe-5.1.0.tgz#dd9d311f555bcaa144f12e225b3d37785f0aa8f2"
   integrity sha512-AfdZ49rtyhQR/6cqVKGoH7y4ql7XkS5HJI1lZm0/5N6CQosy1eYbBJ/qbhkKHzo17UH7M918Bysf6XB9f3kS1g==
+
+microtime@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/microtime/-/microtime-3.0.0.tgz#d140914bde88aa89b4f9fd2a18620b435af0f39b"
+  integrity sha512-SirJr7ZL4ow2iWcb54bekS4aWyBQNVcEDBiwAz9D/sTgY59A+uE8UJU15cp5wyZmPBwg/3zf8lyCJ5NUe1nVlQ==
+  dependencies:
+    node-addon-api "^1.2.0"
+    node-gyp-build "^3.8.0"
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -669,6 +690,16 @@ neon-cli@^0.5.0:
     validate-npm-package-license "^3.0.4"
     validate-npm-package-name "^3.0.0"
 
+node-addon-api@^1.2.0:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
+  integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
+
+node-gyp-build@^3.8.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-3.9.0.tgz#53a350187dd4d5276750da21605d1cb681d09e25"
+  integrity sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==
+
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
@@ -750,6 +781,11 @@ picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+
+platform@^1.3.3:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
+  integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
 
 randombytes@^2.1.0:
   version "2.1.0"

--- a/rust/bridge/node/futures/tests/util.rs
+++ b/rust/bridge/node/futures/tests/util.rs
@@ -1,0 +1,54 @@
+//
+// Copyright 2020-2021 Signal Messenger, LLC.
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+use std::path::Path;
+use std::process::Command;
+
+pub fn run(action: &str) {
+    // Note: This is brittle; it relies on the node library getting built relative to the test executable.
+    let mut library_path = std::env::current_exe()
+        .expect("can get current executable path")
+        .parent()
+        .unwrap()
+        .to_owned();
+    for possible_library_name in &[
+        "libsignal_neon_futures_tests.so",
+        "libsignal_neon_futures_tests.dylib",
+        "signal_neon_futures_tests.dll",
+    ] {
+        library_path.push(possible_library_name);
+        if library_path.exists() {
+            break;
+        }
+        library_path.pop();
+    }
+    assert!(
+        library_path.is_file(),
+        "at least one of these should exist (in {:?})",
+        library_path
+    );
+
+    // Give the built library a .node extension by copying it to temp_dir.
+    // It would be nice if we could pass this directly to Node, or use a symlink, but neither works.
+    let node_library_path = std::env::temp_dir().join("signal_neon_futures_tests.node");
+    std::fs::copy(library_path, &node_library_path).expect("can copy to temporary directory");
+
+    let test_cases = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/node-tests");
+    let status = Command::new("yarn")
+        .arg(action)
+        .env("SIGNAL_NEON_FUTURES_TEST_LIB", &node_library_path)
+        .env("MALLOC_PERTURB_", "1") // Add glibc and macOS use-after-free detection.
+        .env("MALLOC_SCRIBBLE", "1")
+        .current_dir(&test_cases)
+        .status()
+        .expect("failed to run `yarn test`");
+    if !status.success() {
+        eprintln!(
+            "\nSIGNAL_NEON_FUTURES_TEST_LIB={:?} yarn --cwd {:?} {}\n",
+            node_library_path, test_cases, action
+        );
+        panic!("Node tests failed");
+    }
+}


### PR DESCRIPTION
It turns out this takes less than a millisecond, at least when the event loop is empty, but the setup might still be useful in the future. Run with `cargo bench -p signal-neon-futures`.