### PR TITLE
Android: force-link libdl

### DIFF
--- a/rust/bridge/jni/build.rs
+++ b/rust/bridge/jni/build.rs
@@ -1,0 +1,17 @@
+//
+// Copyright 2021 Signal Messenger, LLC.
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+use std::env;
+
+fn main() {
+    if env::var("CARGO_CFG_TARGET_ARCH").expect("set by Cargo") == "aarch64"
+        && env::var("CARGO_CFG_TARGET_OS").expect("set by Cargo") == "android"
+    {
+        // HACK: Force libdl to be linked.
+        // Something about the Docker-based build results in it getting skipped;
+        // if we figure out what, we can remove this.
+        println!("cargo:rustc-cdylib-link-arg=-Wl,--no-as-needed,-ldl,--as-needed");
+    }
+}


### PR DESCRIPTION
For some reason, the Docker build of libsignal_jni.so doesn't link to libdl, even though the build on my local machine does. This doesn't seem to be a problem on most phones, presumably because the libdl functions are re-exported through libc. However, on a small subset of Android phones this is not good enough and libsignal_jni.so fails to load. For now, work around this by forcing the Android cross-compilation linker to link to libdl (instead of doing it "as needed").

[Docs for `cargo:rustc-cdylib-link-arg`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-cdylib-link-arg)