### PR TITLE
Java: switch to Debian for Docker builds instead of Ubuntu

### DIFF
--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -1,12 +1,16 @@
 #
-# Copyright (C) 2020 Signal Messenger, LLC.
+# Copyright 2020-2021 Signal Messenger, LLC.
 # SPDX-License-Identifier: AGPL-3.0-only
 #
 
-FROM ubuntu:18.04
+FROM debian:stretch
 
+COPY java/docker/ docker/
+COPY java/docker/apt.conf java/docker/sources.list /etc/apt/
+
+# Install tools
 RUN    apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && apt-get install -y \
                apt-transport-https \
                build-essential \
                git \
@@ -16,7 +20,9 @@ RUN    apt-get update \
                openssh-client \
                unzip
 
-RUN    apt-get install -y --no-install-recommends openjdk-8-jdk=8u272-b10-0ubuntu1~18.04
+# Install pinned dependencies
+RUN    apt-get install -y $(cat docker/dependencies.txt)
+RUN    docker/print-versions.sh docker/dependencies.txt
 
 ARG UID
 ARG GID

--- a/java/docker/apt.conf
+++ b/java/docker/apt.conf
@@ -1,0 +1,6 @@
+Acquire::Check-Valid-Until "false";
+Acquire::Languages "none";
+Binary::apt-get::Acquire::AllowInsecureRepositories "false";
+
+APT::Install-Recommends "false";
+APT::Immediate-Configure "false";

--- a/java/docker/dependencies.txt
+++ b/java/docker/dependencies.txt
@@ -1,0 +1,1 @@
+openjdk-8-jdk=8u252-b09-1

--- a/java/docker/print-versions.sh
+++ b/java/docker/print-versions.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+while read dep; do
+  dep_name=$(echo $dep | cut -f1 -d '=')
+  version=$(dpkg -s $dep_name | grep 'Version: ' | cut -f2 -d ' ')
+  echo "$dep_name=$version"
+done < $1

--- a/java/docker/sources.list
+++ b/java/docker/sources.list
@@ -1,0 +1,2 @@
+deb http://snapshot.debian.org/archive/debian-security/20200731T201723Z stretch/updates main
+deb http://snapshot.debian.org/archive/debian/20200731T211026Z/ unstable main


### PR DESCRIPTION
Debian has a more stable retention period for pinned dependencies (the version of OpenJDK 8 we were using for Ubuntu is gone already!), and it matches what the Signal-Android repository is doing.