### PR TITLE
rust/crypto: bump libc to support getauxval on musl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
 name = "libloading"

--- a/rust/crypto/Cargo.toml
+++ b/rust/crypto/Cargo.toml
@@ -21,7 +21,7 @@ sha-1 = "0.9"
 sha2 = "0.9"
 
 [target.'cfg(all(target_arch = "aarch64", any(target_os = "linux")))'.dependencies]
-libc = "0.2" # for getauxval
+libc = "0.2.93" # for getauxval
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
 aesni = { version = "0.10", features = ["nocheck"] }


### PR DESCRIPTION
See https://github.com/rust-lang/libc/commit/2eaa621a00a992bfda290457329a49c9a2847711, included in 0.2.93.