### PR TITLE
Make sure SignalProtocolError is Sync

### DIFF
--- a/rust/protocol/src/error.rs
+++ b/rust/protocol/src/error.rs
@@ -56,7 +56,10 @@ pub enum SignalProtocolError {
     InvalidMessage(&'static str),
     InternalError(&'static str),
     FfiBindingError(String),
-    ApplicationCallbackError(&'static str, Box<dyn Error + Send + UnwindSafe + 'static>),
+    ApplicationCallbackError(
+        &'static str,
+        Box<dyn Error + Send + Sync + UnwindSafe + 'static>,
+    ),
 
     InvalidSealedSenderMessage(String),
     UnknownSealedSenderVersion(u8),


### PR DESCRIPTION
When using wrapper types like [`anyhow::Error`](https://docs.rs/anyhow/1.0.25/anyhow/struct.Error.html), it is required that all underlying error types are `Send`, `Sync`, and `'static`. I tried to compile the other crates (with all features) after this change, and it looks like it doesn't break anything.