### PR TITLE
Log session state when we fail to process a pre-key

### DIFF
--- a/swift/Tests/SignalClientTests/SessionTests.swift
+++ b/swift/Tests/SignalClientTests/SessionTests.swift
@@ -142,7 +142,7 @@ class SessionTests: TestCaseBase {
                                                      context: NullContext()),
                              "should fail to decrypt") { error in
             guard case BadStore.Error.badness = error else {
-                XCTFail("wrong error thrown")
+                XCTFail("wrong error thrown: \(error)")
                 return
             }
         }


### PR DESCRIPTION
This joins the logging for when the session cipher fails; when pre-key processing fails (especially with a "no such pre-key" error), we want to see what state the session's in.