### PR TITLE
Node: Make a dedicated error code for DuplicatedMessage

### DIFF
--- a/node/Errors.ts
+++ b/node/Errors.ts
@@ -5,8 +5,10 @@
 
 export enum ErrorCode {
   Generic,
-  UntrustedIdentity,
+
+  DuplicatedMessage,
   SealedSenderSelfSend,
+  UntrustedIdentity,
 }
 
 export class SignalClientErrorBase extends Error {
@@ -45,16 +47,21 @@ export type GenericError = SignalClientErrorBase & {
   code: ErrorCode.Generic;
 };
 
-export type UntrustedIdentityError = SignalClientErrorBase & {
-  code: ErrorCode.UntrustedIdentity;
-  addr: string;
+export type DuplicatedMessageError = SignalClientErrorBase & {
+  code: ErrorCode.DuplicatedMessage;
 };
 
 export type SealedSenderSelfSendError = SignalClientErrorBase & {
   code: ErrorCode.SealedSenderSelfSend;
 };
 
+export type UntrustedIdentityError = SignalClientErrorBase & {
+  code: ErrorCode.UntrustedIdentity;
+  addr: string;
+};
+
 export type SignalClientError =
   | GenericError
-  | UntrustedIdentityError
-  | SealedSenderSelfSendError;
+  | DuplicatedMessageError
+  | SealedSenderSelfSendError
+  | UntrustedIdentityError;

--- a/rust/bridge/shared/src/node/error.rs
+++ b/rust/bridge/shared/src/node/error.rs
@@ -106,6 +106,22 @@ impl SignalNodeError for SignalProtocolError {
     ) -> JsResult<'a, JsValue> {
         // Check for some dedicated error types first.
         let custom_error = match &self {
+            SignalProtocolError::DuplicatedMessage(..) => new_js_error(
+                cx,
+                module,
+                Some("DuplicatedMessage"),
+                &self.to_string(),
+                operation_name,
+                None,
+            ),
+            SignalProtocolError::SealedSenderSelfSend => new_js_error(
+                cx,
+                module,
+                Some("SealedSenderSelfSend"),
+                &self.to_string(),
+                operation_name,
+                None,
+            ),
             SignalProtocolError::UntrustedIdentity(addr) => {
                 let props = cx.empty_object();
                 let addr_string = cx.string(addr.name());
@@ -119,14 +135,6 @@ impl SignalNodeError for SignalProtocolError {
                     Some(props),
                 )
             }
-            SignalProtocolError::SealedSenderSelfSend => new_js_error(
-                cx,
-                module,
-                Some("SealedSenderSelfSend"),
-                &self.to_string(),
-                operation_name,
-                None,
-            ),
             _ => new_js_error(cx, module, None, &self.to_string(), operation_name, None),
         };
 


### PR DESCRIPTION
This was MessageCounterError in libtextsecure; it's an "error" in that it interrupts processing of an individual message, but that message is then discarded in practice.