### PR TITLE
signal-neon-futures: Poll a future once before queuing it

### DIFF
--- a/rust/bridge/node/futures/src/promise.rs
+++ b/rust/bridge/node/futures/src/promise.rs
@@ -81,7 +81,7 @@ where
     let callbacks_object_root = callbacks_object.root(cx);
     let queue = cx.queue();
 
-    cx.run_future_on_queue(async move {
+    cx.run_future(async move {
         let result: std::thread::Result<Result<F, PersistentException>> =
             future.catch_unwind().await;
 

--- a/rust/bridge/node/futures/tests-node-module/src/lib.rs
+++ b/rust/bridge/node/futures/tests-node-module/src/lib.rs
@@ -27,7 +27,7 @@ fn increment_async(mut cx: FunctionContext) -> JsResult<JsUndefined> {
         Err(err) => Err(err.to_string(cx).unwrap().value(cx)),
     })?;
 
-    cx.run_future_on_queue(async move {
+    cx.run_future(async move {
         let value_or_error = future.await;
         queue.send(move |mut cx| {
             let new_value = match value_or_error {


### PR DESCRIPTION
Previously, when using the JavaScript context to run a Rust future, the future would be put into the event queue immediately, without starting it first. The new implementation runs the future synchronously to its first suspension point. There are pros and cons to each approach (and I left the "delayed start" version behind as `queue_future`), but in practice we're not worried about, say, blocking other work behind this one.