### PR TITLE
Put aarch64 simd feature behind nightly feature flag

### DIFF
--- a/rust/bridge/ffi/Cargo.toml
+++ b/rust/bridge/ffi/Cargo.toml
@@ -14,6 +14,9 @@ license = "AGPL-3.0-only"
 name = "signal_ffi"
 crate-type = ["staticlib"]
 
+[features]
+nightly = ["signal-crypto/nightly", "libsignal-protocol/nightly"]
+
 [dependencies]
 libsignal-protocol = { path = "../../protocol" }
 device-transfer = { path = "../../device-transfer" }

--- a/rust/bridge/jni/Cargo.toml
+++ b/rust/bridge/jni/Cargo.toml
@@ -14,6 +14,9 @@ license = "AGPL-3.0-only"
 name = "signal_jni"
 crate-type = ["cdylib"]
 
+[features]
+nightly = ["libsignal-protocol/nightly", "signal-crypto/nightly"]
+
 [dependencies]
 libsignal-protocol = { path = "../../protocol" }
 signal-crypto = { path = "../../crypto" }

--- a/rust/bridge/node/Cargo.toml
+++ b/rust/bridge/node/Cargo.toml
@@ -14,6 +14,9 @@ edition = "2018"
 name = "signal_node"
 crate-type = ["cdylib"]
 
+[features]
+nightly = ["libsignal-protocol/nightly", "libsignal-bridge/nightly"]
+
 [dependencies]
 libsignal-protocol = { path = "../../protocol" }
 libsignal-bridge = { path = "../shared", features = ["node"] }

--- a/rust/bridge/shared/Cargo.toml
+++ b/rust/bridge/shared/Cargo.toml
@@ -34,3 +34,4 @@ signal-neon-futures = { path = "../node/futures", optional = true }
 ffi = ["libc", "libsignal-bridge-macros/ffi"]
 jni = ["jni_crate", "libsignal-bridge-macros/jni"]
 node = ["neon", "linkme", "signal-neon-futures", "libsignal-bridge-macros/node"]
+nightly = ["signal-crypto/nightly", "libsignal-protocol/nightly"]

--- a/rust/crypto/Cargo.toml
+++ b/rust/crypto/Cargo.toml
@@ -20,6 +20,9 @@ rand = "0.7.3"
 sha-1 = "0.9"
 sha2 = "0.9"
 
+[features]
+nightly = []
+
 [target.'cfg(all(target_arch = "aarch64", any(target_os = "linux")))'.dependencies]
 libc = "0.2" # for getauxval
 

--- a/rust/crypto/src/aes.rs
+++ b/rust/crypto/src/aes.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", feature = "nightly"))]
 mod aarch64;
 
 use crate::error::{Error, Result};
@@ -17,7 +17,7 @@ pub enum Aes256 {
     Soft(aes_soft::Aes256),
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     AesNi(aesni::Aes256),
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(all(target_arch = "aarch64", feature = "nightly"))]
     Aarch64(aarch64::Aes256Aarch64),
 }
 
@@ -27,7 +27,7 @@ impl Aes256 {
             return Err(Error::InvalidKeySize);
         }
 
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(all(target_arch = "aarch64", feature = "nightly"))]
         {
             if crate::cpuid::has_armv8_crypto() {
                 unsafe {
@@ -85,7 +85,7 @@ impl Aes256 {
             Aes256::Soft(aes) => trait_encrypt(aes, buf),
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             Aes256::AesNi(aes) => trait_encrypt(aes, buf),
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(all(target_arch = "aarch64", feature = "nightly"))]
             Aes256::Aarch64(aes) => unsafe { aes.encrypt(buf) },
         }
     }

--- a/rust/crypto/src/cpuid.rs
+++ b/rust/crypto/src/cpuid.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+#[cfg(all(target_arch = "aarch64", feature = "nightly", target_os = "linux"))]
 pub fn has_armv8_crypto() -> bool {
     // Require NEON, AES and PMULL
     let hwcap_crypto = (1 << 1) | (1 << 3) | (1 << 4);
@@ -11,7 +11,7 @@ pub fn has_armv8_crypto() -> bool {
     hwcap & hwcap_crypto == hwcap_crypto
 }
 
-#[cfg(all(target_arch = "aarch64", target_os = "ios"))]
+#[cfg(all(target_arch = "aarch64", feature = "nightly", target_os = "ios"))]
 pub fn has_armv8_crypto() -> bool {
     // All 64-bit iOS devices have AES/PMUL support
     true
@@ -19,6 +19,7 @@ pub fn has_armv8_crypto() -> bool {
 
 #[cfg(all(
     target_arch = "aarch64",
+    feature = "nightly",
     not(any(target_os = "linux", target_os = "ios"))
 ))]
 pub fn has_armv8_crypto() -> bool {

--- a/rust/crypto/src/lib.rs
+++ b/rust/crypto/src/lib.rs
@@ -3,8 +3,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-#![cfg_attr(target_arch = "aarch64", feature(stdsimd))]
-#![cfg_attr(target_arch = "aarch64", feature(aarch64_target_feature))]
+#![cfg_attr(all(target_arch = "aarch64", feature = "nightly"), feature(stdsimd))]
+#![cfg_attr(
+    all(target_arch = "aarch64", feature = "nightly"),
+    feature(aarch64_target_feature)
+)]
 #![deny(clippy::unwrap_used)]
 
 mod error;

--- a/rust/crypto/src/polyval.rs
+++ b/rust/crypto/src/polyval.rs
@@ -10,7 +10,7 @@ mod polyval_soft;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod polyval_clmul;
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", feature = "nightly"))]
 mod polyval_pmul;
 
 #[derive(Clone)]
@@ -18,7 +18,7 @@ pub enum Polyval {
     Soft(polyval_soft::PolyvalSoft),
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     Clmul(polyval_clmul::PolyvalClmul),
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(all(target_arch = "aarch64", feature = "nightly"))]
     Pmul(polyval_pmul::PolyvalPmul),
 }
 
@@ -35,7 +35,7 @@ impl Polyval {
             }
         }
 
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(all(target_arch = "aarch64", feature = "nightly"))]
         {
             if crate::cpuid::has_armv8_crypto() {
                 return Ok(Polyval::Pmul(polyval_pmul::PolyvalPmul::new(key)?));
@@ -54,7 +54,7 @@ impl Polyval {
             Polyval::Soft(polyval) => polyval.update(data),
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             Polyval::Clmul(polyval) => polyval.update(data),
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(all(target_arch = "aarch64", feature = "nightly"))]
             Polyval::Pmul(polyval) => polyval.update(data),
         }
     }
@@ -64,7 +64,7 @@ impl Polyval {
             Polyval::Soft(polyval) => polyval.update_padded(data),
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             Polyval::Clmul(polyval) => polyval.update_padded(data),
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(all(target_arch = "aarch64", feature = "nightly"))]
             Polyval::Pmul(polyval) => polyval.update_padded(data),
         }
     }
@@ -74,7 +74,7 @@ impl Polyval {
             Polyval::Soft(polyval) => polyval.finalize(),
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             Polyval::Clmul(polyval) => polyval.finalize(),
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(all(target_arch = "aarch64", feature = "nightly"))]
             Polyval::Pmul(polyval) => polyval.finalize(),
         }
     }

--- a/rust/protocol/Cargo.toml
+++ b/rust/protocol/Cargo.toml
@@ -40,7 +40,7 @@ default = ["u64_backend"]
 u32_backend = ["curve25519-dalek/u32_backend"]
 u64_backend = ["curve25519-dalek/u64_backend"]
 simd_backend = ["curve25519-dalek/simd_backend"]
-nightly = ["curve25519-dalek/nightly"]
+nightly = ["curve25519-dalek/nightly", "signal-crypto/nightly"]
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
Hi! We've [just merged](https://github.com/Michael-F-Bryan/libsignal-service-rs/pull/83) the `libsignal-client` swap in `libsignal-service-rs`. Everything went smooth, except for one thing! Whisperfish' `aarch64` target [does not compile](https://gitlab.com/whisperfish/whisperfish/-/jobs/1228985751) on Rust stable; all others (armv7hl, i[46]86) work perfectly.

Since we have some other requirements w.r.t. Rust compiler versions (Tokio, mostly), I figured I could take a look on how to get `libsignal-client` to compile with stable Rust. Seemingly, the only real place where the nightly-1.49 compiler is required (for the Rust library, that is), is for the aarch64 SIMD optimizations.

---

This pull request models the simplest solution that I could come up with: expose a `nightly` flag from the affected crates (basically *all* crates), and only enable `feature(stdsimd)` when that feature is enabled.

I've also taken the liberty of linking that `nightly` flag to the `nightly` flag of the Dalek set of crates. This has a side effect: the Dalek-`nightly` flag was previously *not* enabled as far as I could tell. I've linked it through because I feel it would be *more* confusing if I did not, with this name.

## Possible approaches

### `nightly` flag (this pull request)

The approach in this pull request.

#### Pro

-  Simple

#### Con

- Also enabled Dalek-nightly
- aarch64-simd is now by default off, except if you set it default-on in ffi, which would then default-on Dalek-nightly too

### Separate feature flag (e.g. `aarch64simd`)

The same idea, but separate flag

#### Pro

- Relatively simple
- Keeps dalek separate from `aarch64`

#### Con

- More feature flags to maintain, more configurations to test

---

If you have more suggestions, I'll add them to the list. I have the current proposal in a separate branch that we can use for now.