### PR TITLE
signal-neon-futures: Only run Rust futures on an existing EventQueue

### DIFF
--- a/rust/bridge/node/futures/src/lib.rs
+++ b/rust/bridge/node/futures/src/lib.rs
@@ -23,7 +23,7 @@
 #![warn(clippy::unwrap_used)]
 
 mod executor;
-pub use executor::{ContextEx, EventQueueEx};
+pub use executor::EventQueueEx;
 
 mod exception;
 pub use exception::PersistentException;


### PR DESCRIPTION
Node can more efficiently handle multiple tasks coming in on the same queue*, so remove the "convenience" APIs that derive a new queue from a Context, and require an existing EventQueue instead. This cuts more time off of our decryption benchmark (not checked in).

Additionally, run the first poll for the future synchronously, to avoid having to wait for the event loop to pick up the task to start the future.

\* or will be able to when nodejs/node#38506 is released