### PR TITLE
A SenderKeyMessage's version must match the SenderKeyState

### DIFF
--- a/java/java/src/main/java/org/signal/internal/Native.java
+++ b/java/java/src/main/java/org/signal/internal/Native.java
@@ -203,7 +203,7 @@ public final class Native {
   public static native int SenderKeyDistributionMessage_GetIteration(long obj);
   public static native byte[] SenderKeyDistributionMessage_GetSerialized(long obj);
   public static native byte[] SenderKeyDistributionMessage_GetSignatureKey(long m);
-  public static native long SenderKeyDistributionMessage_New(UUID distributionId, int chainId, int iteration, byte[] chainkey, long pk);
+  public static native long SenderKeyDistributionMessage_New(int messageVersion, UUID distributionId, int chainId, int iteration, byte[] chainkey, long pk);
 
   public static native long SenderKeyMessage_Deserialize(byte[] data);
   public static native void SenderKeyMessage_Destroy(long handle);
@@ -212,7 +212,7 @@ public final class Native {
   public static native UUID SenderKeyMessage_GetDistributionId(long obj);
   public static native int SenderKeyMessage_GetIteration(long obj);
   public static native byte[] SenderKeyMessage_GetSerialized(long obj);
-  public static native long SenderKeyMessage_New(UUID distributionId, int chainId, int iteration, byte[] ciphertext, long pk);
+  public static native long SenderKeyMessage_New(int messageVersion, UUID distributionId, int chainId, int iteration, byte[] ciphertext, long pk);
   public static native boolean SenderKeyMessage_VerifySignature(long skm, long pubkey);
 
   public static native long SenderKeyRecord_Deserialize(byte[] data);

--- a/java/java/src/main/java/org/whispersystems/libsignal/protocol/PreKeySignalMessage.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/protocol/PreKeySignalMessage.java
@@ -33,15 +33,6 @@ public class PreKeySignalMessage implements CiphertextMessage {
     this.handle = handle;
   }
 
-  public PreKeySignalMessage(int messageVersion, int registrationId, Optional<Integer> preKeyId,
-                             int signedPreKeyId, ECPublicKey baseKey, IdentityKey identityKey,
-                             SignalMessage message) {
-    this.handle = Native.PreKeySignalMessage_New(messageVersion, registrationId, preKeyId.or(-1),
-                                                 signedPreKeyId, baseKey.nativeHandle(),
-                                                 identityKey.getPublicKey().nativeHandle(),
-                                                 message.nativeHandle());
-  }
-
   public int getMessageVersion() {
     return Native.PreKeySignalMessage_GetVersion(this.handle);
   }

--- a/java/java/src/main/java/org/whispersystems/libsignal/protocol/SenderKeyDistributionMessage.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/protocol/SenderKeyDistributionMessage.java
@@ -27,10 +27,6 @@ public class SenderKeyDistributionMessage {
     this.handle = handle;
   }
 
-  public SenderKeyDistributionMessage(UUID distributionId, int id, int iteration, byte[] chainKey, ECPublicKey signatureKey) {
-    handle = Native.SenderKeyDistributionMessage_New(distributionId, id, iteration, chainKey, signatureKey.nativeHandle());
-  }
-
   public SenderKeyDistributionMessage(byte[] serialized) throws LegacyMessageException, InvalidMessageException {
     handle = Native.SenderKeyDistributionMessage_Deserialize(serialized);
   }

--- a/java/java/src/main/java/org/whispersystems/libsignal/protocol/SenderKeyMessage.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/protocol/SenderKeyMessage.java
@@ -37,10 +37,6 @@ public class SenderKeyMessage implements CiphertextMessage {
     handle = Native.SenderKeyMessage_Deserialize(serialized);
   }
 
-  public SenderKeyMessage(UUID distributionId, int chainId, int iteration, byte[] ciphertext, ECPrivateKey signatureKey) {
-    handle = Native.SenderKeyMessage_New(distributionId, chainId, iteration, ciphertext, signatureKey.nativeHandle());
-  }
-
   public UUID getDistributionId() {
     return Native.SenderKeyMessage_GetDistributionId(this.handle);
   }

--- a/java/java/src/main/java/org/whispersystems/libsignal/protocol/SignalMessage.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/protocol/SignalMessage.java
@@ -31,17 +31,6 @@ public class SignalMessage implements CiphertextMessage {
     this.handle = handle;
   }
 
-  public SignalMessage(int messageVersion, SecretKeySpec macKey, ECPublicKey senderRatchetKey,
-                       int counter, int previousCounter, byte[] ciphertext,
-                       IdentityKey senderIdentityKey,
-                       IdentityKey receiverIdentityKey)
-  {
-    handle = Native.SignalMessage_New(messageVersion, macKey.getEncoded(), senderRatchetKey.nativeHandle(),
-                 counter, previousCounter, ciphertext,
-                 senderIdentityKey.getPublicKey().nativeHandle(),
-                 receiverIdentityKey.getPublicKey().nativeHandle());
-  }
-
   public ECPublicKey getSenderRatchetKey()  {
     return new ECPublicKey(Native.SignalMessage_GetSenderRatchetKey(this.handle));
   }

--- a/node/Native.d.ts
+++ b/node/Native.d.ts
@@ -119,7 +119,7 @@ export function SenderKeyDistributionMessage_GetChainId(obj: Wrapper<SenderKeyDi
 export function SenderKeyDistributionMessage_GetChainKey(obj: Wrapper<SenderKeyDistributionMessage>): Buffer;
 export function SenderKeyDistributionMessage_GetDistributionId(obj: Wrapper<SenderKeyDistributionMessage>): Uuid;
 export function SenderKeyDistributionMessage_GetIteration(obj: Wrapper<SenderKeyDistributionMessage>): number;
-export function SenderKeyDistributionMessage_New(distributionId: Uuid, chainId: number, iteration: number, chainkey: Buffer, pk: Wrapper<PublicKey>): SenderKeyDistributionMessage;
+export function SenderKeyDistributionMessage_New(messageVersion: number, distributionId: Uuid, chainId: number, iteration: number, chainkey: Buffer, pk: Wrapper<PublicKey>): SenderKeyDistributionMessage;
 export function SenderKeyDistributionMessage_Process(sender: Wrapper<ProtocolAddress>, senderKeyDistributionMessage: Wrapper<SenderKeyDistributionMessage>, store: SenderKeyStore, ctx: null): Promise<void>;
 export function SenderKeyDistributionMessage_Serialize(obj: Wrapper<SenderKeyDistributionMessage>): Buffer;
 export function SenderKeyMessage_Deserialize(buffer: Buffer): SenderKeyMessage;
@@ -127,7 +127,7 @@ export function SenderKeyMessage_GetChainId(obj: Wrapper<SenderKeyMessage>): num
 export function SenderKeyMessage_GetCipherText(obj: Wrapper<SenderKeyMessage>): Buffer;
 export function SenderKeyMessage_GetDistributionId(obj: Wrapper<SenderKeyMessage>): Uuid;
 export function SenderKeyMessage_GetIteration(obj: Wrapper<SenderKeyMessage>): number;
-export function SenderKeyMessage_New(distributionId: Uuid, chainId: number, iteration: number, ciphertext: Buffer, pk: Wrapper<PrivateKey>): SenderKeyMessage;
+export function SenderKeyMessage_New(messageVersion: number, distributionId: Uuid, chainId: number, iteration: number, ciphertext: Buffer, pk: Wrapper<PrivateKey>): SenderKeyMessage;
 export function SenderKeyMessage_Serialize(obj: Wrapper<SenderKeyMessage>): Buffer;
 export function SenderKeyMessage_VerifySignature(skm: Wrapper<SenderKeyMessage>, pubkey: Wrapper<PublicKey>): boolean;
 export function SenderKeyRecord_Deserialize(buffer: Buffer): SenderKeyRecord;

--- a/node/index.ts
+++ b/node/index.ts
@@ -473,7 +473,7 @@ export class SignalMessage {
     this._nativeHandle = handle;
   }
 
-  static new(
+  static _new(
     messageVersion: number,
     macKey: Buffer,
     senderRatchetKey: PublicKey,
@@ -538,7 +538,7 @@ export class PreKeySignalMessage {
     this._nativeHandle = handle;
   }
 
-  static new(
+  static _new(
     messageVersion: number,
     registrationId: number,
     preKeyId: number | null,
@@ -800,7 +800,7 @@ export class SenderKeyDistributionMessage {
     return new SenderKeyDistributionMessage(handle);
   }
 
-  static new(
+  static _new(
     distributionId: Uuid,
     chainId: number,
     iteration: number,
@@ -867,7 +867,7 @@ export class SenderKeyMessage {
     this._nativeHandle = nativeHandle;
   }
 
-  static new(
+  static _new(
     distributionId: Uuid,
     chainId: number,
     iteration: number,

--- a/node/index.ts
+++ b/node/index.ts
@@ -801,6 +801,7 @@ export class SenderKeyDistributionMessage {
   }
 
   static _new(
+    messageVersion: number,
     distributionId: Uuid,
     chainId: number,
     iteration: number,
@@ -809,6 +810,7 @@ export class SenderKeyDistributionMessage {
   ): SenderKeyDistributionMessage {
     return new SenderKeyDistributionMessage(
       NativeImpl.SenderKeyDistributionMessage_New(
+        messageVersion,
         Buffer.from(uuid.parse(distributionId) as Uint8Array),
         chainId,
         iteration,
@@ -868,6 +870,7 @@ export class SenderKeyMessage {
   }
 
   static _new(
+    messageVersion: number,
     distributionId: Uuid,
     chainId: number,
     iteration: number,
@@ -876,6 +879,7 @@ export class SenderKeyMessage {
   ): SenderKeyMessage {
     return new SenderKeyMessage(
       NativeImpl.SenderKeyMessage_New(
+        messageVersion,
         Buffer.from(uuid.parse(distributionId) as Uint8Array),
         chainId,
         iteration,

--- a/node/test/PublicAPITest.ts
+++ b/node/test/PublicAPITest.ts
@@ -323,7 +323,7 @@ describe('SignalClient', () => {
     const ciphertext = Buffer.alloc(32, 0xfe);
     const pk = SignalClient.PrivateKey.generate();
 
-    const skm = SignalClient.SenderKeyMessage.new(
+    const skm = SignalClient.SenderKeyMessage._new(
       distributionId,
       chainId,
       iteration,
@@ -349,7 +349,7 @@ describe('SignalClient', () => {
     const chainKey = Buffer.alloc(32, 0xfe);
     const pk = SignalClient.PrivateKey.generate();
 
-    const skdm = SignalClient.SenderKeyDistributionMessage.new(
+    const skdm = SignalClient.SenderKeyDistributionMessage._new(
       distributionId,
       chainId,
       iteration,
@@ -530,7 +530,7 @@ describe('SignalClient', () => {
     const receiverIdentityKey = SignalClient.PrivateKey.generate().getPublicKey();
     const ciphertext = Buffer.from('01020304', 'hex');
 
-    const sm = SignalClient.SignalMessage.new(
+    const sm = SignalClient.SignalMessage._new(
       messageVersion,
       macKey,
       senderRatchetKey,
@@ -556,7 +556,7 @@ describe('SignalClient', () => {
     const baseKey = SignalClient.PrivateKey.generate().getPublicKey();
     const identityKey = SignalClient.PrivateKey.generate().getPublicKey();
 
-    const pkm = SignalClient.PreKeySignalMessage.new(
+    const pkm = SignalClient.PreKeySignalMessage._new(
       messageVersion,
       registrationId,
       preKeyId,

--- a/node/test/PublicAPITest.ts
+++ b/node/test/PublicAPITest.ts
@@ -324,6 +324,7 @@ describe('SignalClient', () => {
     const pk = SignalClient.PrivateKey.generate();
 
     const skm = SignalClient.SenderKeyMessage._new(
+      3,
       distributionId,
       chainId,
       iteration,
@@ -350,6 +351,7 @@ describe('SignalClient', () => {
     const pk = SignalClient.PrivateKey.generate();
 
     const skdm = SignalClient.SenderKeyDistributionMessage._new(
+      3,
       distributionId,
       chainId,
       iteration,

--- a/rust/bridge/shared/src/protocol.rs
+++ b/rust/bridge/shared/src/protocol.rs
@@ -355,8 +355,10 @@ fn SenderKeyMessageGetDistributionId(out: &mut [u8; 16], obj: &SenderKeyMessage)
     Ok(())
 }
 
+// For testing
 #[bridge_fn]
 fn SenderKeyMessage_New(
+    message_version: u8,
     distribution_id: Uuid,
     chain_id: u32,
     iteration: u32,
@@ -365,6 +367,7 @@ fn SenderKeyMessage_New(
 ) -> Result<SenderKeyMessage> {
     let mut csprng = rand::rngs::OsRng;
     SenderKeyMessage::new(
+        message_version,
         distribution_id,
         chain_id,
         iteration,
@@ -412,15 +415,24 @@ fn SenderKeyDistributionMessageGetDistributionId(
     Ok(())
 }
 
+// For testing
 #[bridge_fn]
 fn SenderKeyDistributionMessage_New(
+    message_version: u8,
     distribution_id: Uuid,
     chain_id: u32,
     iteration: u32,
     chainkey: &[u8],
     pk: &PublicKey,
 ) -> Result<SenderKeyDistributionMessage> {
-    SenderKeyDistributionMessage::new(distribution_id, chain_id, iteration, chainkey.into(), *pk)
+    SenderKeyDistributionMessage::new(
+        message_version,
+        distribution_id,
+        chain_id,
+        iteration,
+        chainkey.into(),
+        *pk,
+    )
 }
 
 #[bridge_fn(jni = false, node = false)]

--- a/rust/protocol/src/group_cipher.rs
+++ b/rust/protocol/src/group_cipher.rs
@@ -11,6 +11,7 @@ use crate::{
     SenderKeyRecord, SenderKeyStore, SignalProtocolError,
 };
 
+use crate::protocol::SENDERKEY_MESSAGE_CURRENT_VERSION;
 use crate::sender_keys::{SenderKeyState, SenderMessageKey};
 
 use rand::{CryptoRng, Rng};
@@ -103,6 +104,13 @@ pub async fn group_decrypt(
 
     let mut sender_key_state = record.sender_key_state_for_chain_id(skm.chain_id())?;
 
+    let message_version = skm.message_version() as u32;
+    if message_version != sender_key_state.message_version()? {
+        return Err(SignalProtocolError::UnrecognizedMessageVersion(
+            message_version,
+        ));
+    }
+
     let signing_key = sender_key_state.signing_key_public()?;
     if !skm.verify_signature(&signing_key)? {
         return Err(SignalProtocolError::SignatureValidationFailed);
@@ -136,6 +144,7 @@ pub async fn process_sender_key_distribution_message(
         .unwrap_or_else(SenderKeyRecord::new_empty);
 
     sender_key_record.add_sender_key_state(
+        skdm.message_version(),
         skdm.chain_id()?,
         skdm.iteration()?,
         skdm.chain_key()?,
@@ -167,6 +176,7 @@ pub async fn create_sender_key_distribution_message<R: Rng + CryptoRng>(
         let sender_key: [u8; 32] = csprng.gen();
         let signing_key = KeyPair::generate(csprng);
         sender_key_record.set_sender_key_state(
+            SENDERKEY_MESSAGE_CURRENT_VERSION,
             chain_id,
             iteration,
             &sender_key,

--- a/rust/protocol/src/group_cipher.rs
+++ b/rust/protocol/src/group_cipher.rs
@@ -41,6 +41,7 @@ pub async fn group_encrypt<R: Rng + CryptoRng>(
     let signing_key = sender_key_state.signing_key_private()?;
 
     let skm = SenderKeyMessage::new(
+        sender_key_state.message_version()? as u8,
         distribution_id,
         sender_key_state.chain_id()?,
         sender_key.iteration()?,
@@ -192,6 +193,7 @@ pub async fn create_sender_key_distribution_message<R: Rng + CryptoRng>(
     let sender_chain_key = state.sender_chain_key()?;
 
     SenderKeyDistributionMessage::new(
+        state.message_version()? as u8,
         distribution_id,
         state.chain_id()?,
         sender_chain_key.iteration()?,

--- a/rust/protocol/src/proto/storage.proto
+++ b/rust/protocol/src/proto/storage.proto
@@ -96,6 +96,7 @@ message SenderKeyStateStructure {
     bytes private = 2;
   }
 
+  uint32                    message_version     = 5;
   uint32                    chain_id            = 1;
   SenderChainKey            sender_chain_key    = 2;
   SenderSigningKey          sender_signing_key  = 3;

--- a/rust/protocol/src/protocol.rs
+++ b/rust/protocol/src/protocol.rs
@@ -16,6 +16,7 @@ use subtle::ConstantTimeEq;
 use uuid::Uuid;
 
 pub const CIPHERTEXT_MESSAGE_CURRENT_VERSION: u8 = 3;
+pub const SENDERKEY_MESSAGE_CURRENT_VERSION: u8 = 3;
 
 pub enum CiphertextMessage {
     SignalMessage(SignalMessage),
@@ -400,13 +401,13 @@ impl SenderKeyMessage {
         let proto_message_len = proto_message.encoded_len();
         let mut serialized = vec![0u8; 1 + proto_message_len + Self::SIGNATURE_LEN];
         serialized[0] =
-            ((CIPHERTEXT_MESSAGE_CURRENT_VERSION & 0xF) << 4) | CIPHERTEXT_MESSAGE_CURRENT_VERSION;
+            ((SENDERKEY_MESSAGE_CURRENT_VERSION & 0xF) << 4) | SENDERKEY_MESSAGE_CURRENT_VERSION;
         proto_message.encode(&mut &mut serialized[1..1 + proto_message_len])?;
         let signature =
             signature_key.calculate_signature(&serialized[..1 + proto_message_len], csprng)?;
         serialized[1 + proto_message_len..].copy_from_slice(&signature[..]);
         Ok(Self {
-            message_version: CIPHERTEXT_MESSAGE_CURRENT_VERSION,
+            message_version: SENDERKEY_MESSAGE_CURRENT_VERSION,
             distribution_id,
             chain_id,
             iteration,
@@ -469,12 +470,12 @@ impl TryFrom<&[u8]> for SenderKeyMessage {
             return Err(SignalProtocolError::CiphertextMessageTooShort(value.len()));
         }
         let message_version = value[0] >> 4;
-        if message_version < CIPHERTEXT_MESSAGE_CURRENT_VERSION {
+        if message_version < SENDERKEY_MESSAGE_CURRENT_VERSION {
             return Err(SignalProtocolError::LegacyCiphertextVersion(
                 message_version,
             ));
         }
-        if message_version > CIPHERTEXT_MESSAGE_CURRENT_VERSION {
+        if message_version > SENDERKEY_MESSAGE_CURRENT_VERSION {
             return Err(SignalProtocolError::UnrecognizedCiphertextVersion(
                 message_version,
             ));
@@ -534,7 +535,7 @@ impl SenderKeyDistributionMessage {
             chain_key: Some(chain_key.clone()),
             signing_key: Some(signing_key.serialize().to_vec()),
         };
-        let message_version = CIPHERTEXT_MESSAGE_CURRENT_VERSION;
+        let message_version = SENDERKEY_MESSAGE_CURRENT_VERSION;
         let mut serialized = vec![0u8; 1 + proto_message.encoded_len()];
         serialized[0] = ((message_version & 0xF) << 4) | message_version;
         proto_message.encode(&mut &mut serialized[1..])?;
@@ -603,12 +604,12 @@ impl TryFrom<&[u8]> for SenderKeyDistributionMessage {
 
         let message_version = value[0] >> 4;
 
-        if message_version < CIPHERTEXT_MESSAGE_CURRENT_VERSION {
+        if message_version < SENDERKEY_MESSAGE_CURRENT_VERSION {
             return Err(SignalProtocolError::LegacyCiphertextVersion(
                 message_version,
             ));
         }
-        if message_version > CIPHERTEXT_MESSAGE_CURRENT_VERSION {
+        if message_version > SENDERKEY_MESSAGE_CURRENT_VERSION {
             return Err(SignalProtocolError::UnrecognizedCiphertextVersion(
                 message_version,
             ));

--- a/swift/Sources/SignalClient/messages/PreKeySignalMessage.swift
+++ b/swift/Sources/SignalClient/messages/PreKeySignalMessage.swift
@@ -21,24 +21,6 @@ public class PreKeySignalMessage {
         }
     }
 
-    public init(version: UInt8,
-                registrationId: UInt32,
-                preKeyId: UInt32?,
-                signedPreKeyId: UInt32,
-                baseKey: PublicKey,
-                identityKey: PublicKey,
-                message: SignalMessage) throws {
-
-        try checkError(signal_pre_key_signal_message_new(&handle,
-                                                         version,
-                                                         registrationId,
-                                                         preKeyId ?? .max,
-                                                         signedPreKeyId,
-                                                         baseKey.nativeHandle,
-                                                         identityKey.nativeHandle,
-                                                         message.nativeHandle))
-    }
-
     public func serialize() throws -> [UInt8] {
         return try invokeFnReturningArray {
             signal_pre_key_signal_message_serialize($0, $1, handle)

--- a/swift/Sources/SignalClient/messages/SenderKeyDistributionMessage.swift
+++ b/swift/Sources/SignalClient/messages/SenderKeyDistributionMessage.swift
@@ -33,26 +33,6 @@ public class SenderKeyDistributionMessage {
         }
     }
 
-    public init<Bytes: ContiguousBytes>(distributionId: UUID,
-                                        chainId: UInt32,
-                                        iteration: UInt32,
-                                        chainKey: Bytes,
-                                        publicKey: PublicKey) throws {
-        var result: OpaquePointer?
-        try chainKey.withUnsafeBytes { chainKeyBytes in
-            try withUnsafePointer(to: distributionId.uuid) { distributionId in
-                try checkError(signal_sender_key_distribution_message_new(&result,
-                                                                          distributionId,
-                                                                          chainId,
-                                                                          iteration,
-                                                                          chainKeyBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
-                                                                          chainKeyBytes.count,
-                                                                          publicKey.nativeHandle))
-            }
-        }
-        handle = result
-    }
-
     public init(bytes: [UInt8]) throws {
         try checkError(signal_sender_key_distribution_message_deserialize(&handle, bytes, bytes.count))
     }

--- a/swift/Sources/SignalClient/messages/SenderKeyMessage.swift
+++ b/swift/Sources/SignalClient/messages/SenderKeyMessage.swift
@@ -13,26 +13,6 @@ public class SenderKeyMessage {
         failOnError(signal_sender_key_message_destroy(handle))
     }
 
-    public init<Bytes: ContiguousBytes>(distributionId: UUID,
-                                        chainId: UInt32,
-                                        iteration: UInt32,
-                                        ciphertext: Bytes,
-                                        privateKey: PrivateKey) throws {
-        var result: OpaquePointer?
-        try ciphertext.withUnsafeBytes { ciphertextBytes in
-            try withUnsafePointer(to: distributionId.uuid) { distributionId in
-                try checkError(signal_sender_key_message_new(&result,
-                                                             distributionId,
-                                                             chainId,
-                                                             iteration,
-                                                             ciphertextBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
-                                                             ciphertextBytes.count,
-                                                             privateKey.nativeHandle))
-            }
-        }
-        handle = result
-    }
-
     public init<Bytes: ContiguousBytes>(bytes: Bytes) throws {
         handle = try bytes.withUnsafeBytes {
             var result: OpaquePointer?

--- a/swift/Sources/SignalClient/messages/SignalMessage.swift
+++ b/swift/Sources/SignalClient/messages/SignalMessage.swift
@@ -25,34 +25,6 @@ public class SignalMessage {
         }
     }
 
-    public init<MacBytes, CiphertextBytes>(version: UInt8,
-                                           macKey: MacBytes,
-                                           senderRatchetKey: PublicKey,
-                                           counter: UInt32,
-                                           previousCounter: UInt32,
-                                           ciphertext: CiphertextBytes,
-                                           sender senderIdentityKey: PublicKey,
-                                           receiver receiverIdentityKey: PublicKey) throws
-    where MacBytes: ContiguousBytes, CiphertextBytes: ContiguousBytes {
-        handle = try macKey.withUnsafeBytes { macBytes in
-            try ciphertext.withUnsafeBytes { ciphertextBytes in
-                var result: OpaquePointer?
-                try checkError(signal_message_new(&result,
-                                                  version,
-                                                  macBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
-                                                  macBytes.count,
-                                                  senderRatchetKey.nativeHandle,
-                                                  counter,
-                                                  previousCounter,
-                                                  ciphertextBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
-                                                  ciphertextBytes.count,
-                                                  senderIdentityKey.nativeHandle,
-                                                  receiverIdentityKey.nativeHandle))
-                return result
-            }
-        }
-    }
-
     public var senderRatchetKey: PublicKey {
         return failOnError {
             try invokeFnReturningPublicKey {

--- a/swift/Sources/SignalFfi/signal_ffi.h
+++ b/swift/Sources/SignalFfi/signal_ffi.h
@@ -580,6 +580,7 @@ SignalFfiError *signal_sender_key_message_get_distribution_id(uint8_t (*out)[16]
                                                               const SignalSenderKeyMessage *obj);
 
 SignalFfiError *signal_sender_key_message_new(SignalSenderKeyMessage **out,
+                                              uint8_t message_version,
                                               const uint8_t (*distribution_id)[16],
                                               uint32_t chain_id,
                                               uint32_t iteration,
@@ -613,6 +614,7 @@ SignalFfiError *signal_sender_key_distribution_message_get_distribution_id(uint8
                                                                            const SignalSenderKeyDistributionMessage *obj);
 
 SignalFfiError *signal_sender_key_distribution_message_new(SignalSenderKeyDistributionMessage **out,
+                                                           uint8_t message_version,
                                                            const uint8_t (*distribution_id)[16],
                                                            uint32_t chain_id,
                                                            uint32_t iteration,


### PR DESCRIPTION
...or it should fail to decrypt. This parallels a similar check for SignalMessage and SessionState. Since we haven't been storing this field previously, treat a default "0" value as if it were version 3, the current version.

Additionally, when creating new messages we should use the session's version rather than the current version, also matching SignalMessage. We still encode the "current" version in the message version byte, but the part that the receiver checks is now based on the session's version rather than the "current" version in the sender. (Note that these are the *same* version right now, so this change won't have any effect on the current wire format.)

Finally, remove the direct-construction API for all \*Message types in Java, Swift, and TypeScript; these should always be created through a session.