### PR TITLE
Add registration IDs to the Sealed Sender v2 upload (encrypt) format

### DIFF
--- a/java/java/src/main/java/org/signal/internal/Native.java
+++ b/java/java/src/main/java/org/signal/internal/Native.java
@@ -178,7 +178,7 @@ public final class Native {
 
   public static native long SealedSessionCipher_DecryptToUsmc(byte[] ctext, IdentityKeyStore identityStore, Object ctx);
   public static native byte[] SealedSessionCipher_Encrypt(long destination, long content, IdentityKeyStore identityKeyStore, Object ctx);
-  public static native byte[] SealedSessionCipher_MultiRecipientEncrypt(long[] recipients, long content, IdentityKeyStore identityKeyStore, Object ctx);
+  public static native byte[] SealedSessionCipher_MultiRecipientEncrypt(long[] recipients, int[] recipientRegistrationIds, long content, IdentityKeyStore identityKeyStore, Object ctx);
   public static native byte[] SealedSessionCipher_MultiRecipientMessageForSingleRecipient(byte[] encodedMultiRecipientMessage);
 
   public static native long SenderCertificate_Deserialize(byte[] data);

--- a/java/java/src/main/java/org/signal/libsignal/metadata/SealedSessionCipher.java
+++ b/java/java/src/main/java/org/signal/libsignal/metadata/SealedSessionCipher.java
@@ -76,7 +76,7 @@ public class SealedSessionCipher {
       null);
   }
 
-  public byte[] multiRecipientEncrypt(List<SignalProtocolAddress> recipients, UnidentifiedSenderMessageContent content)
+  public byte[] multiRecipientEncrypt(List<SignalProtocolAddress> recipients, int[] recipientRegistrationIds, UnidentifiedSenderMessageContent content)
       throws InvalidKeyException, UntrustedIdentityException
   {
     long[] recipientHandles = new long[recipients.size()];
@@ -87,6 +87,7 @@ public class SealedSessionCipher {
     }
     return Native.SealedSessionCipher_MultiRecipientEncrypt(
       recipientHandles,
+      recipientRegistrationIds,
       content.nativeHandle(),
       this.signalProtocolStore,
       null);

--- a/java/tests/src/test/java/org/signal/libsignal/metadata/SealedSessionCipherTest.java
+++ b/java/tests/src/test/java/org/signal/libsignal/metadata/SealedSessionCipherTest.java
@@ -172,7 +172,7 @@ public class SealedSessionCipherTest extends TestCase {
 
     UnidentifiedSenderMessageContent usmcFromAlice = new UnidentifiedSenderMessageContent(ciphertextFromAlice, senderCertificate, UnidentifiedSenderMessageContent.CONTENT_HINT_SUPPLEMENTARY, Optional.of(new byte[]{42}));
 
-    byte[] aliceMessage = aliceCipher.multiRecipientEncrypt(Arrays.asList(bobAddress), usmcFromAlice);
+    byte[] aliceMessage = aliceCipher.multiRecipientEncrypt(Arrays.asList(bobAddress), new int[]{0x3FFD}, usmcFromAlice);
     byte[] bobMessage = SealedSessionCipher.multiRecipientMessageForSingleRecipient(aliceMessage);
 
     DecryptionResult plaintext = bobCipher.decrypt(new CertificateValidator(trustRoot.getPublicKey()), bobMessage, 31335);
@@ -211,7 +211,7 @@ public class SealedSessionCipherTest extends TestCase {
 
     UnidentifiedSenderMessageContent usmcFromAlice = new UnidentifiedSenderMessageContent(ciphertextFromAlice, senderCertificate, UnidentifiedSenderMessageContent.CONTENT_HINT_SUPPLEMENTARY, Optional.of(new byte[]{42, 1}));
 
-    byte[] aliceMessage = aliceCipher.multiRecipientEncrypt(Arrays.asList(bobAddress), usmcFromAlice);
+    byte[] aliceMessage = aliceCipher.multiRecipientEncrypt(Arrays.asList(bobAddress), new int[]{0x3FFD}, usmcFromAlice);
     byte[] bobMessage = SealedSessionCipher.multiRecipientMessageForSingleRecipient(aliceMessage);
 
     try {

--- a/node/Native.d.ts
+++ b/node/Native.d.ts
@@ -99,7 +99,7 @@ export function SealedSenderDecryptionResult_Message(obj: Wrapper<SealedSenderDe
 export function SealedSender_DecryptMessage(message: Buffer, trustRoot: Wrapper<PublicKey>, timestamp: number, localE164: string | null, localUuid: string, localDeviceId: number, sessionStore: SessionStore, identityStore: IdentityKeyStore, prekeyStore: PreKeyStore, signedPrekeyStore: SignedPreKeyStore): Promise<SealedSenderDecryptionResult>;
 export function SealedSender_DecryptToUsmc(ctext: Buffer, identityStore: IdentityKeyStore, ctx: null): Promise<UnidentifiedSenderMessageContent>;
 export function SealedSender_Encrypt(destination: Wrapper<ProtocolAddress>, content: Wrapper<UnidentifiedSenderMessageContent>, identityKeyStore: IdentityKeyStore, ctx: null): Promise<Buffer>;
-export function SealedSender_MultiRecipientEncrypt(recipients: Wrapper<ProtocolAddress>[], content: Wrapper<UnidentifiedSenderMessageContent>, identityKeyStore: IdentityKeyStore, ctx: null): Promise<Buffer>;
+export function SealedSender_MultiRecipientEncrypt(recipients: Wrapper<ProtocolAddress>[], recipientRegistrationIds: number[], content: Wrapper<UnidentifiedSenderMessageContent>, identityKeyStore: IdentityKeyStore, ctx: null): Promise<Buffer>;
 export function SealedSender_MultiRecipientMessageForSingleRecipient(encodedMultiRecipientMessage: Buffer): Buffer;
 export function SenderCertificate_Deserialize(buffer: Buffer): SenderCertificate;
 export function SenderCertificate_GetCertificate(obj: Wrapper<SenderCertificate>): Buffer;

--- a/node/index.ts
+++ b/node/index.ts
@@ -1319,10 +1319,12 @@ export function sealedSenderEncrypt(
 export function sealedSenderMultiRecipientEncrypt(
   content: UnidentifiedSenderMessageContent,
   recipients: ProtocolAddress[],
+  recipientRegistrationIds: number[],
   identityStore: IdentityKeyStore
 ): Promise<Buffer> {
   return NativeImpl.SealedSender_MultiRecipientEncrypt(
     recipients,
+    recipientRegistrationIds,
     content,
     identityStore,
     null

--- a/node/test/PublicAPITest.ts
+++ b/node/test/PublicAPITest.ts
@@ -1251,6 +1251,7 @@ describe('SignalClient', () => {
       const aSealedSenderMessage = await SignalClient.sealedSenderMultiRecipientEncrypt(
         aUsmc,
         [bAddress],
+        [0x3ffd],
         aKeys
       );
 

--- a/rust/bridge/jni/bin/gen_java_decl.py
+++ b/rust/bridge/jni/bin/gen_java_decl.py
@@ -69,6 +69,7 @@ def translate_to_java(typ):
         "JObject": "Object",
         "JClass": "Class",
         "jbyteArray": "byte[]",
+        "jintArray": "int[]",
         "jlongArray": "long[]",
         "ObjectHandle": "long",
         "jint": "int",

--- a/rust/bridge/node/bin/gen_ts_decl.py
+++ b/rust/bridge/node/bin/gen_ts_decl.py
@@ -25,6 +25,7 @@ def translate_to_ts(typ):
     type_map = {
         "()": "void",
         "&[u8]": "Buffer",
+        "&[u16]": "number[]",
         "i32": "number",
         "u8": "number",
         "u32": "number",

--- a/rust/bridge/shared/src/jni/mod.rs
+++ b/rust/bridge/shared/src/jni/mod.rs
@@ -15,7 +15,7 @@ use std::convert::{TryFrom, TryInto};
 use std::error::Error;
 
 pub(crate) use jni::objects::{AutoArray, JClass, JObject, JString, ReleaseMode};
-pub(crate) use jni::sys::{jboolean, jbyteArray, jint, jlong, jlongArray, jstring};
+pub(crate) use jni::sys::{jboolean, jbyteArray, jint, jintArray, jlong, jlongArray, jstring};
 pub(crate) use jni::JNIEnv;
 
 /// Converts a function signature to a JNI signature string.

--- a/rust/bridge/shared/src/protocol.rs
+++ b/rust/bridge/shared/src/protocol.rs
@@ -986,6 +986,7 @@ async fn SealedSessionCipher_Encrypt<E: Env>(
 async fn SealedSender_MultiRecipientEncrypt<E: Env>(
     env: E,
     recipients: &[&ProtocolAddress],
+    recipient_registration_ids: &[u16],
     content: &UnidentifiedSenderMessageContent,
     identity_key_store: &mut dyn IdentityKeyStore,
     ctx: Context,
@@ -993,6 +994,7 @@ async fn SealedSender_MultiRecipientEncrypt<E: Env>(
     let mut rng = rand::rngs::OsRng;
     let ctext = sealed_sender_multi_recipient_encrypt(
         recipients,
+        recipient_registration_ids,
         content,
         identity_key_store,
         ctx,

--- a/rust/protocol/src/sealed_sender.rs
+++ b/rust/protocol/src/sealed_sender.rs
@@ -870,11 +870,18 @@ mod sealed_sender_v2 {
 
 pub async fn sealed_sender_multi_recipient_encrypt<R: Rng + CryptoRng>(
     destinations: &[&ProtocolAddress],
+    destination_registration_ids: &[u16],
     usmc: &UnidentifiedSenderMessageContent,
     identity_store: &mut dyn IdentityKeyStore,
     ctx: Context,
     rng: &mut R,
 ) -> Result<Vec<u8>> {
+    if destinations.len() != destination_registration_ids.len() {
+        return Err(SignalProtocolError::InvalidArgument(
+            "must have the same number of destination registration IDs as addresses".to_string(),
+        ));
+    }
+
     let m: [u8; 32] = rng.gen();
     let keys = sealed_sender_v2::DerivedKeys::calculate(&m);
     let e_pub = keys.e.public_key()?;
@@ -895,7 +902,7 @@ pub async fn sealed_sender_multi_recipient_encrypt<R: Rng + CryptoRng>(
             SignalProtocolError::InternalError("failed to encrypt using AES-GCM-SIV")
         })?;
 
-    // Uses a flat representation: count || UUID_i || deviceId_i || C_i || AT_i || ... || E.pub || ciphertext
+    // Uses a flat representation: count || UUID_i || deviceId_i || registrationId_i || C_i || AT_i || ... || E.pub || ciphertext
     let version = SEALED_SENDER_V2_VERSION;
     let mut serialized: Vec<u8> = vec![(version | (version << 4))];
 
@@ -903,7 +910,7 @@ pub async fn sealed_sender_multi_recipient_encrypt<R: Rng + CryptoRng>(
         .expect("cannot fail encoding to Vec");
 
     let our_identity = identity_store.get_identity_key_pair(ctx).await?;
-    for destination in destinations {
+    for (destination, registration_id) in destinations.iter().zip(destination_registration_ids) {
         let their_uuid = Uuid::parse_str(destination.name()).map_err(|_| {
             SignalProtocolError::InvalidArgument(format!(
                 "multi-recipient sealed sender requires UUID recipients (not {})",
@@ -934,6 +941,7 @@ pub async fn sealed_sender_multi_recipient_encrypt<R: Rng + CryptoRng>(
         serialized.extend_from_slice(their_uuid.as_bytes());
         prost::encode_length_delimiter(destination.device_id() as usize, &mut serialized)
             .expect("cannot fail encoding to Vec");
+        serialized.extend_from_slice(&registration_id.to_be_bytes());
         serialized.extend_from_slice(&c_i);
         serialized.extend_from_slice(&at_i);
     }
@@ -978,6 +986,8 @@ pub fn sealed_sender_multi_recipient_fan_out(data: &[u8]) -> Result<Vec<Vec<u8>>
         let _ = advance(&mut remaining, 16)?;
         // Skip device ID.
         let _ = decode_varint(&mut remaining)?;
+        // Skip registration ID.
+        let _ = advance(&mut remaining, 2)?;
         // Read C_i and AT_i.
         let c_and_at = advance(&mut remaining, 32 + 16)?;
 

--- a/rust/protocol/tests/groups.rs
+++ b/rust/protocol/tests/groups.rs
@@ -330,6 +330,7 @@ fn group_sealed_sender() -> Result<(), SignalProtocolError> {
 
         let alice_ctext = sealed_sender_multi_recipient_encrypt(
             &[&bob_uuid_address, &carol_uuid_address],
+            &[0x3FFD, 0x07E5],
             &alice_usmc,
             &mut alice_store.identity_store,
             None,

--- a/rust/protocol/tests/sealed_sender.rs
+++ b/rust/protocol/tests/sealed_sender.rs
@@ -498,6 +498,7 @@ fn test_sealed_sender_multi_recipient() -> Result<(), SignalProtocolError> {
 
         let alice_ctext = sealed_sender_multi_recipient_encrypt(
             &[&bob_uuid_address],
+            &[0x3FFD],
             &alice_usmc,
             &mut alice_store.identity_store,
             None,
@@ -548,6 +549,7 @@ fn test_sealed_sender_multi_recipient() -> Result<(), SignalProtocolError> {
 
         let alice_ctext = sealed_sender_multi_recipient_encrypt(
             &[&bob_uuid_address],
+            &[0x3FFD],
             &alice_usmc,
             &mut alice_store.identity_store,
             None,
@@ -604,6 +606,7 @@ fn test_sealed_sender_multi_recipient() -> Result<(), SignalProtocolError> {
 
         let alice_ctext = sealed_sender_multi_recipient_encrypt(
             &[&bob_uuid_address],
+            &[0x3FFD],
             &alice_usmc,
             &mut alice_store.identity_store,
             None,

--- a/swift/Sources/SignalClient/SealedSender.swift
+++ b/swift/Sources/SignalClient/SealedSender.swift
@@ -149,6 +149,7 @@ public func sealedSenderEncrypt(_ content: UnidentifiedSenderMessageContent,
 
 public func sealedSenderMultiRecipientEncrypt(_ content: UnidentifiedSenderMessageContent,
                                               for recipients: [ProtocolAddress],
+                                              registrationIds: [UInt16],
                                               identityStore: IdentityKeyStore,
                                               context: StoreContext) throws -> [UInt8] {
     return try context.withOpaquePointer { context in
@@ -157,6 +158,8 @@ public func sealedSenderMultiRecipientEncrypt(_ content: UnidentifiedSenderMessa
                 signal_sealed_sender_multi_recipient_encrypt($0, $1,
                                                              recipients.map { $0.nativeHandle },
                                                              recipients.count,
+                                                             registrationIds,
+                                                             registrationIds.count,
                                                              content.nativeHandle,
                                                              ffiIdentityStore, context)
             }

--- a/swift/Sources/SignalFfi/signal_ffi.h
+++ b/swift/Sources/SignalFfi/signal_ffi.h
@@ -896,6 +896,8 @@ SignalFfiError *signal_sealed_sender_multi_recipient_encrypt(const unsigned char
                                                              size_t *out_len,
                                                              const SignalProtocolAddress *const *recipients,
                                                              size_t recipients_len,
+                                                             const uint16_t *recipient_registration_ids,
+                                                             size_t recipient_registration_ids_len,
                                                              const SignalUnidentifiedSenderMessageContent *content,
                                                              const SignalIdentityKeyStore *identity_key_store,
                                                              void *ctx);

--- a/swift/Tests/SignalClientTests/SessionTests.swift
+++ b/swift/Tests/SignalClientTests/SessionTests.swift
@@ -282,6 +282,7 @@ class SessionTests: TestCaseBase {
 
         let a_ctext = try! sealedSenderMultiRecipientEncrypt(a_usmc,
                                                              for: [bob_address],
+                                                             registrationIds: [0x3FFD],
                                                              identityStore: alice_store,
                                                              context: NullContext())
 


### PR DESCRIPTION
Registration IDs are used to detect if a device ID has been reused, since the new device will (with high probability) use a different randomly-generated registration ID from the old one. The server should be able to validate this for SSv2 like it does for SSv1, though the handling of this for SSv1 is in the various apps.