### PR TITLE
Bump version to 0.6.0-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "libsignal-ffi"
-version = "0.5.1"
+version = "0.6.0-alpha"
 dependencies = [
  "async-trait",
  "device-transfer",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "libsignal-jni"
-version = "0.5.1"
+version = "0.6.0-alpha"
 dependencies = [
  "async-trait",
  "jni",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "libsignal-node"
-version = "0.5.1"
+version = "0.6.0-alpha"
 dependencies = [
  "async-trait",
  "libsignal-bridge",

--- a/SignalClient.podspec
+++ b/SignalClient.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SignalClient'
-  s.version          = '0.5.1'
+  s.version          = '0.6.0-alpha'
   s.summary          = 'A Swift wrapper library for communicating with the Signal messaging service.'
 
   s.homepage         = 'https://github.com/signalapp/libsignal-client'

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -1,5 +1,5 @@
 subprojects {
-    ext.version_number     = "0.5.1"
+    ext.version_number     = "0.6.0-alpha"
     ext.group_info         = "org.whispersystems"
 
     if (JavaVersion.current().isJava8Compatible()) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalapp/signal-client",
-  "version": "0.5.1",
+  "version": "0.6.0-alpha",
   "license": "AGPL-3.0-only",
   "main": "node/dist/index.js",
   "types": "node/dist/index.d.ts",

--- a/rust/bridge/ffi/Cargo.toml
+++ b/rust/bridge/ffi/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "libsignal-ffi"
-version = "0.5.1"
+version = "0.6.0-alpha"
 authors = ["Jack Lloyd <jack@signal.org>"]
 edition = "2018"
 license = "AGPL-3.0-only"

--- a/rust/bridge/jni/Cargo.toml
+++ b/rust/bridge/jni/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "libsignal-jni"
-version = "0.5.1"
+version = "0.6.0-alpha"
 authors = ["Jack Lloyd <jack@signal.org>"]
 edition = "2018"
 license = "AGPL-3.0-only"

--- a/rust/bridge/node/Cargo.toml
+++ b/rust/bridge/node/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "libsignal-node"
-version = "0.5.1"
+version = "0.6.0-alpha"
 authors = ["Jordan Rose <jrose@signal.org>", "Jack Lloyd <jack@signal.org>"]
 license = "AGPL-3.0-only"
 edition = "2018"


### PR DESCRIPTION
0.6.0 pending the change to the Sealed Sender v2 encrypt API mentioned in #304 and #305.