### PR TITLE
Node: Switch to our fork of Neon with faster EventQueue operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,9 +942,8 @@ checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
 
 [[package]]
 name = "neon"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcdbfbcfbb5ae2ffc7281dfe0b118374bd696369096afc252f26c0b8e7a02e91"
+version = "0.8.2"
+source = "git+https://github.com/signalapp/neon?tag=signal-2021-05-19#b30d2919fba913b35d0866712327ace5b7fff6b1"
 dependencies = [
  "cslice",
  "neon-build",
@@ -956,15 +955,13 @@ dependencies = [
 
 [[package]]
 name = "neon-build"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a529aacddb4b04e9c0a0d5e67478d9aad331c748cbbf6d1657f6d167b3fac37a"
+version = "0.8.2"
+source = "git+https://github.com/signalapp/neon?tag=signal-2021-05-19#b30d2919fba913b35d0866712327ace5b7fff6b1"
 
 [[package]]
 name = "neon-macros"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfecd558575c3997790d574be135680e5cd8d75dcd3e82fe4e71fb6fa4c1b71"
+version = "0.8.2"
+source = "git+https://github.com/signalapp/neon?tag=signal-2021-05-19#b30d2919fba913b35d0866712327ace5b7fff6b1"
 dependencies = [
  "quote",
  "syn",
@@ -972,9 +969,8 @@ dependencies = [
 
 [[package]]
 name = "neon-runtime"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dbec080794ea0939cbd4fa262e749068fd36b18bbb65b6b810e72ae98fea789"
+version = "0.8.2"
+source = "git+https://github.com/signalapp/neon?tag=signal-2021-05-19#b30d2919fba913b35d0866712327ace5b7fff6b1"
 dependencies = [
  "cfg-if 1.0.0",
  "libloading",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ default-members = [
 
 [patch.crates-io]
 curve25519-dalek = { git = 'https://github.com/signalapp/curve25519-dalek', branch = '3.0.0-lizard2' }
+neon = { git = 'https://github.com/signalapp/neon', tag = 'signal-2021-05-19' }
 
 [profile.dev.package.num-bigint-dig]
 opt-level = 2 # too slow otherwise!

--- a/rust/bridge/node/Cargo.toml
+++ b/rust/bridge/node/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib"]
 libsignal-protocol = { path = "../../protocol" }
 libsignal-bridge = { path = "../shared", features = ["node"] }
 signal-neon-futures = { path = "futures" }
-neon = { version = "0.8", default-features = false, features = ["napi-4", "event-queue-api"] }
+neon = { version = "0.8", default-features = false, features = ["napi-6", "event-queue-api"] }
 rand = "0.7.3"
 log = "0.4"
 log-panics = { version = "2.0.0", features = ["with-backtrace"] }

--- a/rust/bridge/shared/Cargo.toml
+++ b/rust/bridge/shared/Cargo.toml
@@ -26,7 +26,7 @@ uuid = "0.8"
 
 libc = { version = "0.2", optional = true }
 jni_crate = { version = "0.19", package = "jni", optional = true }
-neon = { version = "0.8", optional = true, default-features = false, features = ["napi-4"] }
+neon = { version = "0.8", optional = true, default-features = false, features = ["napi-6"] }
 linkme = { version = "0.2.4", optional = true }
 signal-neon-futures = { path = "../node/futures", optional = true }
 


### PR DESCRIPTION
See [signalapp/neon](/signalapp/neon) and neon-bindings/neon#739.