### PR TITLE
Get registration IDs from sessions for Sealed Sender v2

### DIFF
--- a/java/java/src/main/java/org/signal/internal/Native.java
+++ b/java/java/src/main/java/org/signal/internal/Native.java
@@ -178,7 +178,7 @@ public final class Native {
 
   public static native long SealedSessionCipher_DecryptToUsmc(byte[] ctext, IdentityKeyStore identityStore, Object ctx);
   public static native byte[] SealedSessionCipher_Encrypt(long destination, long content, IdentityKeyStore identityKeyStore, Object ctx);
-  public static native byte[] SealedSessionCipher_MultiRecipientEncrypt(long[] recipients, long content, IdentityKeyStore identityKeyStore, Object ctx);
+  public static native byte[] SealedSessionCipher_MultiRecipientEncrypt(long[] recipients, long[] recipientSessions, long content, IdentityKeyStore identityKeyStore, Object ctx);
   public static native byte[] SealedSessionCipher_MultiRecipientMessageForSingleRecipient(byte[] encodedMultiRecipientMessage);
 
   public static native long SenderCertificate_Deserialize(byte[] data);

--- a/java/java/src/main/java/org/whispersystems/libsignal/state/SessionRecord.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/state/SessionRecord.java
@@ -145,7 +145,7 @@ public class SessionRecord {
             theirBaseKey.nativeHandle()));
   }
 
-  long nativeHandle() {
+  public long nativeHandle() {
     return this.handle;
   }
 }

--- a/java/java/src/main/java/org/whispersystems/libsignal/state/SessionStore.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/state/SessionStore.java
@@ -5,6 +5,7 @@
  */
 package org.whispersystems.libsignal.state;
 
+import org.whispersystems.libsignal.NoSessionException;
 import org.whispersystems.libsignal.SignalProtocolAddress;
 
 import java.util.List;
@@ -31,6 +32,15 @@ public interface SessionStore {
    *         a new SessionRecord if one does not currently exist.
    */
   public SessionRecord loadSession(SignalProtocolAddress address);
+
+  /**
+   * Returns the {@link SessionRecord}s corresponding to the given addresses.
+   *
+   * @param addresses The name and device ID of each remote client.
+   * @return the SessionRecords corresponding to each recipientId + deviceId tuple.
+   * @throws NoSessionException if any address does not have an active session.
+   */
+  public List<SessionRecord> loadExistingSessions(List<SignalProtocolAddress> addresses) throws NoSessionException;
 
   /**
    * Returns all known devices with active sessions for a recipient

--- a/java/java/src/main/java/org/whispersystems/libsignal/state/impl/InMemorySessionStore.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/state/impl/InMemorySessionStore.java
@@ -5,6 +5,7 @@
  */
 package org.whispersystems.libsignal.state.impl;
 
+import org.whispersystems.libsignal.NoSessionException;
 import org.whispersystems.libsignal.SignalProtocolAddress;
 import org.whispersystems.libsignal.state.SessionRecord;
 import org.whispersystems.libsignal.state.SessionStore;
@@ -32,6 +33,23 @@ public class InMemorySessionStore implements SessionStore {
     } catch (IOException e) {
       throw new AssertionError(e);
     }
+  }
+
+  @Override
+  public synchronized List<SessionRecord> loadExistingSessions(List<SignalProtocolAddress> addresses) throws NoSessionException {
+    List<SessionRecord> resultSessions = new LinkedList<>();
+    for (SignalProtocolAddress remoteAddress : addresses) {
+      byte[] serialized = sessions.get(remoteAddress);
+      if (serialized == null) {
+        throw new NoSessionException("no session for " + remoteAddress);
+      }
+      try {
+        resultSessions.add(new SessionRecord(serialized));
+      } catch (IOException e) {
+        throw new AssertionError(e);
+      }
+    }
+    return resultSessions;
   }
 
   @Override

--- a/java/java/src/main/java/org/whispersystems/libsignal/state/impl/InMemorySignalProtocolStore.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/state/impl/InMemorySignalProtocolStore.java
@@ -9,6 +9,7 @@ import org.whispersystems.libsignal.SignalProtocolAddress;
 import org.whispersystems.libsignal.IdentityKey;
 import org.whispersystems.libsignal.IdentityKeyPair;
 import org.whispersystems.libsignal.InvalidKeyIdException;
+import org.whispersystems.libsignal.NoSessionException;
 import org.whispersystems.libsignal.groups.state.InMemorySenderKeyStore;
 import org.whispersystems.libsignal.groups.state.SenderKeyRecord;
 import org.whispersystems.libsignal.state.SignalProtocolStore;
@@ -80,6 +81,11 @@ public class InMemorySignalProtocolStore implements SignalProtocolStore {
   @Override
   public SessionRecord loadSession(SignalProtocolAddress address) {
     return sessionStore.loadSession(address);
+  }
+
+  @Override
+  public List<SessionRecord> loadExistingSessions(List<SignalProtocolAddress> addresses) throws NoSessionException {
+    return sessionStore.loadExistingSessions(addresses);
   }
 
   @Override

--- a/node/Native.d.ts
+++ b/node/Native.d.ts
@@ -99,7 +99,7 @@ export function SealedSenderDecryptionResult_Message(obj: Wrapper<SealedSenderDe
 export function SealedSender_DecryptMessage(message: Buffer, trustRoot: Wrapper<PublicKey>, timestamp: number, localE164: string | null, localUuid: string, localDeviceId: number, sessionStore: SessionStore, identityStore: IdentityKeyStore, prekeyStore: PreKeyStore, signedPrekeyStore: SignedPreKeyStore): Promise<SealedSenderDecryptionResult>;
 export function SealedSender_DecryptToUsmc(ctext: Buffer, identityStore: IdentityKeyStore, ctx: null): Promise<UnidentifiedSenderMessageContent>;
 export function SealedSender_Encrypt(destination: Wrapper<ProtocolAddress>, content: Wrapper<UnidentifiedSenderMessageContent>, identityKeyStore: IdentityKeyStore, ctx: null): Promise<Buffer>;
-export function SealedSender_MultiRecipientEncrypt(recipients: Wrapper<ProtocolAddress>[], content: Wrapper<UnidentifiedSenderMessageContent>, identityKeyStore: IdentityKeyStore, ctx: null): Promise<Buffer>;
+export function SealedSender_MultiRecipientEncrypt(recipients: Wrapper<ProtocolAddress>[], recipientSessions: Wrapper<SessionRecord>[], content: Wrapper<UnidentifiedSenderMessageContent>, identityKeyStore: IdentityKeyStore, ctx: null): Promise<Buffer>;
 export function SealedSender_MultiRecipientMessageForSingleRecipient(encodedMultiRecipientMessage: Buffer): Buffer;
 export function SenderCertificate_Deserialize(buffer: Buffer): SenderCertificate;
 export function SenderCertificate_GetCertificate(obj: Wrapper<SenderCertificate>): Buffer;

--- a/node/index.ts
+++ b/node/index.ts
@@ -1008,6 +1008,9 @@ export abstract class SessionStore implements Native.SessionStore {
     record: SessionRecord
   ): Promise<void>;
   abstract getSession(name: ProtocolAddress): Promise<SessionRecord | null>;
+  abstract getExistingSessions(
+    addresses: ProtocolAddress[]
+  ): Promise<SessionRecord[]>;
 }
 
 export abstract class IdentityKeyStore implements Native.IdentityKeyStore {
@@ -1316,13 +1319,16 @@ export function sealedSenderEncrypt(
   return NativeImpl.SealedSender_Encrypt(address, content, identityStore, null);
 }
 
-export function sealedSenderMultiRecipientEncrypt(
+export async function sealedSenderMultiRecipientEncrypt(
   content: UnidentifiedSenderMessageContent,
   recipients: ProtocolAddress[],
-  identityStore: IdentityKeyStore
+  identityStore: IdentityKeyStore,
+  sessionStore: SessionStore
 ): Promise<Buffer> {
-  return NativeImpl.SealedSender_MultiRecipientEncrypt(
+  const recipientSessions = await sessionStore.getExistingSessions(recipients);
+  return await NativeImpl.SealedSender_MultiRecipientEncrypt(
     recipients,
+    recipientSessions,
     content,
     identityStore,
     null

--- a/rust/bridge/node/bin/gen_ts_decl.py
+++ b/rust/bridge/node/bin/gen_ts_decl.py
@@ -49,6 +49,10 @@ def translate_to_ts(typ):
         assert(typ.endswith(']'))
         return 'Wrapper<' + translate_to_ts(typ[3:-1]) + '>[]'
 
+    if typ.startswith('&['):
+        assert(typ.endswith(']'))
+        return 'Wrapper<' + translate_to_ts(typ[2:-1]) + '>[]'
+
     if typ.startswith('&'):
         return 'Wrapper<' + typ[1:] + '>'
 

--- a/rust/protocol/src/storage/inmem.rs
+++ b/rust/protocol/src/storage/inmem.rs
@@ -195,6 +195,23 @@ impl InMemSessionStore {
             sessions: HashMap::new(),
         }
     }
+
+    /// Bulk version of [SessionStore::load_session]
+    ///
+    /// Useful for [crate::sealed_sender_multi_recipient_encrypt].
+    pub fn load_existing_sessions(
+        &self,
+        addresses: &[&ProtocolAddress],
+    ) -> Result<Vec<&SessionRecord>> {
+        addresses
+            .iter()
+            .map(|address| {
+                self.sessions
+                    .get(address)
+                    .ok_or_else(|| SignalProtocolError::SessionNotFound(address.to_string()))
+            })
+            .collect()
+    }
 }
 
 impl Default for InMemSessionStore {

--- a/rust/protocol/tests/groups.rs
+++ b/rust/protocol/tests/groups.rs
@@ -328,8 +328,12 @@ fn group_sealed_sender() -> Result<(), SignalProtocolError> {
             Some([42].to_vec()),
         )?;
 
+        let recipients = [&bob_uuid_address, &carol_uuid_address];
         let alice_ctext = sealed_sender_multi_recipient_encrypt(
-            &[&bob_uuid_address, &carol_uuid_address],
+            &recipients,
+            &alice_store
+                .session_store
+                .load_existing_sessions(&recipients)?,
             &alice_usmc,
             &mut alice_store.identity_store,
             None,

--- a/rust/protocol/tests/sealed_sender.rs
+++ b/rust/protocol/tests/sealed_sender.rs
@@ -496,8 +496,12 @@ fn test_sealed_sender_multi_recipient() -> Result<(), SignalProtocolError> {
             None,
         )?;
 
+        let recipients = [&bob_uuid_address];
         let alice_ctext = sealed_sender_multi_recipient_encrypt(
-            &[&bob_uuid_address],
+            &recipients,
+            &alice_store
+                .session_store
+                .load_existing_sessions(&recipients)?,
             &alice_usmc,
             &mut alice_store.identity_store,
             None,
@@ -546,8 +550,12 @@ fn test_sealed_sender_multi_recipient() -> Result<(), SignalProtocolError> {
             None,
         )?;
 
+        let recipients = [&bob_uuid_address];
         let alice_ctext = sealed_sender_multi_recipient_encrypt(
-            &[&bob_uuid_address],
+            &recipients,
+            &alice_store
+                .session_store
+                .load_existing_sessions(&recipients)?,
             &alice_usmc,
             &mut alice_store.identity_store,
             None,
@@ -602,8 +610,12 @@ fn test_sealed_sender_multi_recipient() -> Result<(), SignalProtocolError> {
             None,
         )?;
 
+        let recipients = [&bob_uuid_address];
         let alice_ctext = sealed_sender_multi_recipient_encrypt(
-            &[&bob_uuid_address],
+            &recipients,
+            &alice_store
+                .session_store
+                .load_existing_sessions(&recipients)?,
             &alice_usmc,
             &mut alice_store.identity_store,
             None,

--- a/swift/Sources/SignalClient/DataStoreInMemory.swift
+++ b/swift/Sources/SignalClient/DataStoreInMemory.swift
@@ -94,6 +94,15 @@ public class InMemorySignalProtocolStore: IdentityKeyStore, PreKeyStore, SignedP
         return sessionMap[address]
     }
 
+    public func loadExistingSessions(for addresses: [ProtocolAddress], context: StoreContext) throws -> [SessionRecord] {
+        return try addresses.map { address in
+            if let session = sessionMap[address] {
+                return session
+            }
+            throw SignalError.sessionNotFound("\(address)")
+        }
+    }
+
     public func storeSession(_ record: SessionRecord, for address: ProtocolAddress, context: StoreContext) throws {
         sessionMap[address] = record
     }

--- a/swift/Sources/SignalClient/DataStoreProtocols.swift
+++ b/swift/Sources/SignalClient/DataStoreProtocols.swift
@@ -37,6 +37,7 @@ public protocol SignedPreKeyStore: AnyObject {
 
 public protocol SessionStore: AnyObject {
     func loadSession(for address: ProtocolAddress, context: StoreContext) throws -> SessionRecord?
+    func loadExistingSessions(for addresses: [ProtocolAddress], context: StoreContext) throws -> [SessionRecord]
     func storeSession(_ record: SessionRecord, for address: ProtocolAddress, context: StoreContext) throws
 }
 

--- a/swift/Sources/SignalClient/SealedSender.swift
+++ b/swift/Sources/SignalClient/SealedSender.swift
@@ -150,13 +150,17 @@ public func sealedSenderEncrypt(_ content: UnidentifiedSenderMessageContent,
 public func sealedSenderMultiRecipientEncrypt(_ content: UnidentifiedSenderMessageContent,
                                               for recipients: [ProtocolAddress],
                                               identityStore: IdentityKeyStore,
+                                              sessionStore: SessionStore,
                                               context: StoreContext) throws -> [UInt8] {
+    let sessions = try sessionStore.loadExistingSessions(for: recipients, context: context)
     return try context.withOpaquePointer { context in
         try withIdentityKeyStore(identityStore) { ffiIdentityStore in
             try invokeFnReturningArray {
                 signal_sealed_sender_multi_recipient_encrypt($0, $1,
                                                              recipients.map { $0.nativeHandle },
                                                              recipients.count,
+                                                             sessions.map { $0.nativeHandle },
+                                                             sessions.count,
                                                              content.nativeHandle,
                                                              ffiIdentityStore, context)
             }

--- a/swift/Sources/SignalFfi/signal_ffi.h
+++ b/swift/Sources/SignalFfi/signal_ffi.h
@@ -899,6 +899,8 @@ SignalFfiError *signal_sealed_sender_multi_recipient_encrypt(const unsigned char
                                                              size_t *out_len,
                                                              const SignalProtocolAddress *const *recipients,
                                                              size_t recipients_len,
+                                                             const SignalSessionRecord *const *recipient_sessions,
+                                                             size_t recipient_sessions_len,
                                                              const SignalUnidentifiedSenderMessageContent *content,
                                                              const SignalIdentityKeyStore *identity_key_store,
                                                              void *ctx);

--- a/swift/Tests/SignalClientTests/SessionTests.swift
+++ b/swift/Tests/SignalClientTests/SessionTests.swift
@@ -283,6 +283,7 @@ class SessionTests: TestCaseBase {
         let a_ctext = try! sealedSenderMultiRecipientEncrypt(a_usmc,
                                                              for: [bob_address],
                                                              identityStore: alice_store,
+                                                             sessionStore: alice_store,
                                                              context: NullContext())
 
         let b_ctext = try! sealedSenderMultiRecipientMessageForSingleRecipient(a_ctext)


### PR DESCRIPTION
The app-visible change is that `sealedSenderMultiRecipientEncrypt` now takes a SessionStore as well. Sessions will be looked up in bulk using a new SessionStore API, `loadExistingSessions` or `getExistingSessions` (just slightly different names across the different app languages). The registration ID is then loaded from each session and included in the resulting SSv2 payload.

The implementation is a bit of a divergence from some other APIs in libsignal-client in that the "look up in bulk" step is performed in the Java, Swift, or TypeScript layer, with the resulting sessions passed down to Rust. Why? Because otherwise we'd pass a list of addresses into Rust, which would have to turn them back into a Java, Swift, or TypeScript array to call the SessionStore method. This would be (1) a bunch of extra work to implement, and (2) a waste of CPU when we already *have* a list of addresses in the correct format: the argument to `sealedSenderMultiRecipientEncrypt`.

This is an example of "the boundaries between the Rust and Java/Swift/TypeScript parts of the library don't have to be perfect; they're internal to the overall product". In this case, we've taken that a little further than usual: usually we try to make the libsignal-protocol API as convenient as possible as well, but here it had to be a bit lower-level to satisfy the needs of the app language wrappers. (Specifically, Rust callers need to fetch the list of SessionRecords themselves.)

P.S. Why doesn't v1 of sealed sender include registration IDs? Because for SSv1, libsignal-client isn't producing the entire request body to upload to the server; it's only producing the message content that will be decrypted by the recipient. With SSv2, the serialized message the recipient downloads has both shared and per-recipient data in it, which the server must assemble from the uploaded request. Because of this, SSv2's encrypt API might as well produce the entire request.