### PR TITLE
Finalize ContentHint design

### DIFF
--- a/java/java/src/main/java/org/signal/libsignal/metadata/protocol/UnidentifiedSenderMessageContent.java
+++ b/java/java/src/main/java/org/signal/libsignal/metadata/protocol/UnidentifiedSenderMessageContent.java
@@ -10,9 +10,9 @@ import org.whispersystems.libsignal.util.guava.Optional;
 
 public class UnidentifiedSenderMessageContent {
   // Must be kept in sync with sealed_sender.proto.
-  public static final int CONTENT_HINT_DEFAULT       = 0;
-  public static final int CONTENT_HINT_SUPPLEMENTARY = 1;
-  public static final int CONTENT_HINT_RETRY         = 2;
+  public static final int CONTENT_HINT_DEFAULT    = 0;
+  public static final int CONTENT_HINT_RESENDABLE = 1;
+  public static final int CONTENT_HINT_IMPLICIT   = 2;
 
   private final long handle;
 

--- a/java/tests/src/test/java/org/signal/libsignal/metadata/SealedSessionCipherTest.java
+++ b/java/tests/src/test/java/org/signal/libsignal/metadata/SealedSessionCipherTest.java
@@ -170,7 +170,7 @@ public class SealedSessionCipherTest extends TestCase {
 
     CiphertextMessage ciphertextFromAlice = aliceGroupCipher.encrypt(distributionId, "smert ze smert".getBytes());
 
-    UnidentifiedSenderMessageContent usmcFromAlice = new UnidentifiedSenderMessageContent(ciphertextFromAlice, senderCertificate, UnidentifiedSenderMessageContent.CONTENT_HINT_SUPPLEMENTARY, Optional.of(new byte[]{42}));
+    UnidentifiedSenderMessageContent usmcFromAlice = new UnidentifiedSenderMessageContent(ciphertextFromAlice, senderCertificate, UnidentifiedSenderMessageContent.CONTENT_HINT_IMPLICIT, Optional.of(new byte[]{42}));
 
     byte[] aliceMessage = aliceCipher.multiRecipientEncrypt(Arrays.asList(bobAddress), usmcFromAlice);
     byte[] bobMessage = SealedSessionCipher.multiRecipientMessageForSingleRecipient(aliceMessage);
@@ -209,7 +209,7 @@ public class SealedSessionCipherTest extends TestCase {
     aliceSessionBuilder.create(senderAddress, distributionId);
     CiphertextMessage ciphertextFromAlice = aliceGroupCipher.encrypt(distributionId, "smert ze smert".getBytes());
 
-    UnidentifiedSenderMessageContent usmcFromAlice = new UnidentifiedSenderMessageContent(ciphertextFromAlice, senderCertificate, UnidentifiedSenderMessageContent.CONTENT_HINT_SUPPLEMENTARY, Optional.of(new byte[]{42, 1}));
+    UnidentifiedSenderMessageContent usmcFromAlice = new UnidentifiedSenderMessageContent(ciphertextFromAlice, senderCertificate, UnidentifiedSenderMessageContent.CONTENT_HINT_RESENDABLE, Optional.of(new byte[]{42, 1}));
 
     byte[] aliceMessage = aliceCipher.multiRecipientEncrypt(Arrays.asList(bobAddress), usmcFromAlice);
     byte[] bobMessage = SealedSessionCipher.multiRecipientMessageForSingleRecipient(aliceMessage);
@@ -219,7 +219,7 @@ public class SealedSessionCipherTest extends TestCase {
     } catch (ProtocolNoSessionException e) {
       assertEquals(e.getSender(), "+14151111111");
       assertEquals(e.getSenderDevice(), 1);
-      assertEquals(e.getContentHint(), UnidentifiedSenderMessageContent.CONTENT_HINT_SUPPLEMENTARY);
+      assertEquals(e.getContentHint(), UnidentifiedSenderMessageContent.CONTENT_HINT_RESENDABLE);
       assertEquals(Hex.toHexString(e.getGroupId().get()), Hex.toHexString(new byte[]{42, 1}));
     }
   }

--- a/node/index.ts
+++ b/node/index.ts
@@ -34,8 +34,8 @@ export const enum Direction {
 // This enum must be kept in sync with sealed_sender.proto.
 export const enum ContentHint {
   Default = 0,
-  Supplementary = 1,
-  Retry = 2,
+  Resendable = 1,
+  Implicit = 2,
 }
 
 export type Uuid = string;

--- a/node/test/PublicAPITest.ts
+++ b/node/test/PublicAPITest.ts
@@ -999,8 +999,8 @@ describe('SignalClient', () => {
       for (const hint of [
         200,
         SignalClient.ContentHint.Default,
-        SignalClient.ContentHint.Supplementary,
-        SignalClient.ContentHint.Retry,
+        SignalClient.ContentHint.Resendable,
+        SignalClient.ContentHint.Implicit,
       ]) {
         const content = SignalClient.UnidentifiedSenderMessageContent.new(
           innerMessage,
@@ -1257,7 +1257,7 @@ describe('SignalClient', () => {
       const aUsmc = SignalClient.UnidentifiedSenderMessageContent.new(
         aCtext,
         senderCert,
-        SignalClient.ContentHint.Supplementary,
+        SignalClient.ContentHint.Implicit,
         Buffer.from([42])
       );
 
@@ -1280,10 +1280,7 @@ describe('SignalClient', () => {
       assert.deepEqual(bUsmc.senderCertificate().senderE164(), aE164);
       assert.deepEqual(bUsmc.senderCertificate().senderUuid(), aUuid);
       assert.deepEqual(bUsmc.senderCertificate().senderDeviceId(), aDeviceId);
-      assert.deepEqual(
-        bUsmc.contentHint(),
-        SignalClient.ContentHint.Supplementary
-      );
+      assert.deepEqual(bUsmc.contentHint(), SignalClient.ContentHint.Implicit);
       assert.deepEqual(bUsmc.groupId(), Buffer.from([42]));
 
       const bPtext = await SignalClient.groupDecrypt(

--- a/rust/bridge/shared/src/protocol.rs
+++ b/rust/bridge/shared/src/protocol.rs
@@ -635,8 +635,8 @@ fn UnidentifiedSenderMessageContent_GetMsgType(m: &UnidentifiedSenderMessageCont
 #[repr(C)]
 pub enum FfiContentHint {
     Default = 0,
-    Supplementary = 1,
-    Retry = 2,
+    Resendable = 1,
+    Implicit = 2,
 }
 
 const_assert_eq!(
@@ -644,10 +644,13 @@ const_assert_eq!(
     ContentHint::Default.to_u32(),
 );
 const_assert_eq!(
-    FfiContentHint::Supplementary as u32,
-    ContentHint::Supplementary.to_u32(),
+    FfiContentHint::Resendable as u32,
+    ContentHint::Resendable.to_u32(),
 );
-const_assert_eq!(FfiContentHint::Retry as u32, ContentHint::Retry.to_u32());
+const_assert_eq!(
+    FfiContentHint::Implicit as u32,
+    ContentHint::Implicit.to_u32()
+);
 
 #[bridge_fn]
 fn UnidentifiedSenderMessageContent_GetContentHint(

--- a/rust/protocol/src/proto/sealed_sender.proto
+++ b/rust/protocol/src/proto/sealed_sender.proto
@@ -43,9 +43,9 @@ message UnidentifiedSenderMessage {
         }
 
         enum ContentHint {
-            reserved 0; // A content hint of "default" should never be encoded.
-            SUPPLEMENTARY = 1;
-            RETRY         = 2;
+            reserved     0; // Default: sender will not resend; an error should be shown immediately
+            RESENDABLE = 1; // Sender will try to resend; delay any error UI if possible
+            IMPLICIT   = 2; // Don't show any error UI at all; this is something sent implicitly like a typing message or a receipt
         }
 
         optional Type              type              = 1;

--- a/rust/protocol/src/sealed_sender.rs
+++ b/rust/protocol/src/sealed_sender.rs
@@ -358,8 +358,8 @@ impl From<CiphertextMessageType> for ProtoMessageType {
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum ContentHint {
     Default,
-    Supplementary,
-    Retry,
+    Resendable,
+    Implicit,
     Unknown(u32),
 }
 
@@ -376,8 +376,8 @@ impl ContentHint {
         use proto::sealed_sender::unidentified_sender_message::message::ContentHint as ProtoContentHint;
         match self {
             ContentHint::Default => 0,
-            ContentHint::Supplementary => ProtoContentHint::Supplementary as u32,
-            ContentHint::Retry => ProtoContentHint::Retry as u32,
+            ContentHint::Resendable => ProtoContentHint::Resendable as u32,
+            ContentHint::Implicit => ProtoContentHint::Implicit as u32,
             ContentHint::Unknown(value) => value,
         }
     }
@@ -390,8 +390,8 @@ impl From<u32> for ContentHint {
         match ProtoContentHint::from_i32(raw_value as i32) {
             None if raw_value == 0 => ContentHint::Default,
             None => ContentHint::Unknown(raw_value),
-            Some(ProtoContentHint::Supplementary) => ContentHint::Supplementary,
-            Some(ProtoContentHint::Retry) => ContentHint::Retry,
+            Some(ProtoContentHint::Resendable) => ContentHint::Resendable,
+            Some(ProtoContentHint::Implicit) => ContentHint::Implicit,
         }
     }
 }

--- a/rust/protocol/tests/groups.rs
+++ b/rust/protocol/tests/groups.rs
@@ -324,7 +324,7 @@ fn group_sealed_sender() -> Result<(), SignalProtocolError> {
             CiphertextMessageType::SenderKey,
             sender_cert.clone(),
             alice_message.serialized().to_vec(),
-            ContentHint::Supplementary,
+            ContentHint::Implicit,
             Some([42].to_vec()),
         )?;
 
@@ -350,7 +350,7 @@ fn group_sealed_sender() -> Result<(), SignalProtocolError> {
         assert_eq!(bob_usmc.sender()?.sender_uuid()?, alice_uuid);
         assert_eq!(bob_usmc.sender()?.sender_e164()?, Some(alice_e164.as_ref()));
         assert_eq!(bob_usmc.sender()?.sender_device_id()?, alice_device_id);
-        assert_eq!(bob_usmc.content_hint()?, ContentHint::Supplementary);
+        assert_eq!(bob_usmc.content_hint()?, ContentHint::Implicit);
         assert_eq!(bob_usmc.group_id()?, Some(&[42][..]));
 
         let bob_plaintext = group_decrypt(

--- a/swift/Sources/SignalClient/SealedSender.swift
+++ b/swift/Sources/SignalClient/SealedSender.swift
@@ -41,11 +41,11 @@ public class UnidentifiedSenderMessageContent: ClonableHandleOwner {
         public static var `default`: Self {
             return Self(SignalContentHint_Default)
         }
-        public static var supplementary: Self {
-            return Self(SignalContentHint_Supplementary)
+        public static var resendable: Self {
+            return Self(SignalContentHint_Resendable)
         }
-        public static var retry: Self {
-            return Self(SignalContentHint_Retry)
+        public static var implicit: Self {
+            return Self(SignalContentHint_Implicit)
         }
     }
 

--- a/swift/Sources/SignalFfi/signal_ffi.h
+++ b/swift/Sources/SignalFfi/signal_ffi.h
@@ -22,8 +22,8 @@ typedef enum {
 
 typedef enum {
   SignalContentHint_Default = 0,
-  SignalContentHint_Supplementary = 1,
-  SignalContentHint_Retry = 2,
+  SignalContentHint_Resendable = 1,
+  SignalContentHint_Implicit = 2,
 } SignalContentHint;
 
 typedef enum {

--- a/swift/Tests/SignalClientTests/SessionTests.swift
+++ b/swift/Tests/SignalClientTests/SessionTests.swift
@@ -197,7 +197,7 @@ class SessionTests: TestCaseBase {
                                              identityStore: alice_store,
                                              context: NullContext())
 
-        for hint in [UnidentifiedSenderMessageContent.ContentHint(rawValue: 200), .default, .supplementary, .retry] {
+        for hint in [UnidentifiedSenderMessageContent.ContentHint(rawValue: 200), .default, .resendable, .implicit] {
             let content = try UnidentifiedSenderMessageContent(innerMessage,
                                                                from: sender_cert,
                                                                contentHint: hint,


### PR DESCRIPTION
- Default: sender will not resend; an error should be shown immediately
- Resendable: sender will try to resend; delay any error UI if possible
- Implicit: don't show any error UI at all; this is something sent implicitly like a typing message or a receipt