### PR TITLE
Add a deviceId field to DecryptionErrorMessage

### DIFF
--- a/java/java/src/main/java/org/signal/internal/Native.java
+++ b/java/java/src/main/java/org/signal/internal/Native.java
@@ -104,7 +104,8 @@ public final class Native {
   public static native long DecryptionErrorMessage_Deserialize(byte[] data);
   public static native void DecryptionErrorMessage_Destroy(long handle);
   public static native long DecryptionErrorMessage_ExtractFromSerializedContent(byte[] bytes);
-  public static native long DecryptionErrorMessage_ForOriginalMessage(byte[] originalBytes, int originalType, long originalTimestamp);
+  public static native long DecryptionErrorMessage_ForOriginalMessage(byte[] originalBytes, int originalType, long originalTimestamp, int originalSenderDeviceId);
+  public static native int DecryptionErrorMessage_GetDeviceId(long obj);
   public static native long DecryptionErrorMessage_GetRatchetKey(long m);
   public static native byte[] DecryptionErrorMessage_GetSerialized(long obj);
   public static native long DecryptionErrorMessage_GetTimestamp(long obj);

--- a/java/java/src/main/java/org/whispersystems/libsignal/protocol/DecryptionErrorMessage.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/protocol/DecryptionErrorMessage.java
@@ -28,9 +28,9 @@ public final class DecryptionErrorMessage {
     handle = Native.DecryptionErrorMessage_Deserialize(serialized);
   }
 
-  public static DecryptionErrorMessage forOriginalMessage(byte[] originalBytes, int messageType, long timestamp) {
+  public static DecryptionErrorMessage forOriginalMessage(byte[] originalBytes, int messageType, long timestamp, int originalSenderDeviceId) {
     return new DecryptionErrorMessage(
-      Native.DecryptionErrorMessage_ForOriginalMessage(originalBytes, messageType, timestamp));
+      Native.DecryptionErrorMessage_ForOriginalMessage(originalBytes, messageType, timestamp, originalSenderDeviceId));
   }
 
   public byte[] serialize() {
@@ -48,6 +48,10 @@ public final class DecryptionErrorMessage {
 
   public long getTimestamp() {
     return Native.DecryptionErrorMessage_GetTimestamp(this.handle);
+  }
+
+  public int getDeviceId() {
+    return Native.DecryptionErrorMessage_GetDeviceId(this.handle);
   }
 
   /// For testing only

--- a/java/tests/src/test/java/org/signal/libsignal/metadata/SealedSessionCipherTest.java
+++ b/java/tests/src/test/java/org/signal/libsignal/metadata/SealedSessionCipherTest.java
@@ -252,7 +252,7 @@ public class SealedSessionCipherTest extends TestCase {
     SessionCipher bobUnsealedCipher = new SessionCipher(bobStore, aliceAddress);
     CiphertextMessage bobMessage = bobUnsealedCipher.encrypt("reply".getBytes());
 
-    DecryptionErrorMessage errorMessage = DecryptionErrorMessage.forOriginalMessage(bobMessage.serialize(), bobMessage.getType(), 408);
+    DecryptionErrorMessage errorMessage = DecryptionErrorMessage.forOriginalMessage(bobMessage.serialize(), bobMessage.getType(), 408, bobAddress.getDeviceId());
     PlaintextContent errorMessageContent = new PlaintextContent(errorMessage);
     UnidentifiedSenderMessageContent errorMessageUsmc = new UnidentifiedSenderMessageContent(errorMessageContent, senderCertificate, UnidentifiedSenderMessageContent.CONTENT_HINT_IMPLICIT, Optional.<byte[]>absent());
     byte[] errorMessageCiphertext = aliceCipher.encrypt(bobAddress, errorMessageUsmc);
@@ -260,6 +260,7 @@ public class SealedSessionCipherTest extends TestCase {
     DecryptionResult result = bobCipher.decrypt(certificateValidator, errorMessageCiphertext, 31335);
     DecryptionErrorMessage bobErrorMessage = DecryptionErrorMessage.extractFromSerializedContent(result.getPaddedMessage());
     assertEquals(bobErrorMessage.getTimestamp(), 408);
+    assertEquals(bobErrorMessage.getDeviceId(), bobAddress.getDeviceId());
 
     SessionRecord bobSessionWithAlice = bobStore.loadSession(aliceAddress);
     assert(bobSessionWithAlice.currentRatchetKeyMatches(bobErrorMessage.getRatchetKey().get()));

--- a/node/Native.d.ts
+++ b/node/Native.d.ts
@@ -51,7 +51,8 @@ export function CiphertextMessage_Serialize(obj: Wrapper<CiphertextMessage>): Bu
 export function CiphertextMessage_Type(msg: Wrapper<CiphertextMessage>): number;
 export function DecryptionErrorMessage_Deserialize(buffer: Buffer): DecryptionErrorMessage;
 export function DecryptionErrorMessage_ExtractFromSerializedContent(bytes: Buffer): DecryptionErrorMessage;
-export function DecryptionErrorMessage_ForOriginalMessage(originalBytes: Buffer, originalType: number, originalTimestamp: number): DecryptionErrorMessage;
+export function DecryptionErrorMessage_ForOriginalMessage(originalBytes: Buffer, originalType: number, originalTimestamp: number, originalSenderDeviceId: number): DecryptionErrorMessage;
+export function DecryptionErrorMessage_GetDeviceId(obj: Wrapper<DecryptionErrorMessage>): number;
 export function DecryptionErrorMessage_GetRatchetKey(m: Wrapper<DecryptionErrorMessage>): PublicKey | null;
 export function DecryptionErrorMessage_GetTimestamp(obj: Wrapper<DecryptionErrorMessage>): number;
 export function DecryptionErrorMessage_Serialize(obj: Wrapper<DecryptionErrorMessage>): Buffer;

--- a/node/index.ts
+++ b/node/index.ts
@@ -1286,13 +1286,15 @@ export class DecryptionErrorMessage {
   static forOriginal(
     bytes: Buffer,
     type: CiphertextMessageType,
-    timestamp: number
+    timestamp: number,
+    originalSenderDeviceId: number
   ): DecryptionErrorMessage {
     return new DecryptionErrorMessage(
       NativeImpl.DecryptionErrorMessage_ForOriginalMessage(
         bytes,
         type,
-        timestamp
+        timestamp,
+        originalSenderDeviceId
       )
     );
   }
@@ -1315,6 +1317,10 @@ export class DecryptionErrorMessage {
 
   timestamp(): number {
     return NativeImpl.DecryptionErrorMessage_GetTimestamp(this);
+  }
+
+  deviceId(): number {
+    return NativeImpl.DecryptionErrorMessage_GetDeviceId(this);
   }
 
   ratchetKey(): PublicKey | undefined {

--- a/node/test/PublicAPITest.ts
+++ b/node/test/PublicAPITest.ts
@@ -1430,7 +1430,8 @@ describe('SignalClient', () => {
     const errorMessage = SignalClient.DecryptionErrorMessage.forOriginal(
       bCiphertext.serialize(),
       bCiphertext.type(),
-      45 // timestamp
+      45, // timestamp
+      bAddress.deviceId()
     );
     const errorContent = SignalClient.PlaintextContent.from(errorMessage);
     const errorUSMC = SignalClient.UnidentifiedSenderMessageContent.new(
@@ -1460,6 +1461,7 @@ describe('SignalClient', () => {
       bErrorContent.body()
     );
     assert.equal(bErrorMessage.timestamp(), 45);
+    assert.equal(bErrorMessage.deviceId(), bAddress.deviceId());
 
     const bSessionWithA = await bSess.getSession(aAddress);
     assert(

--- a/rust/bridge/shared/src/protocol.rs
+++ b/rust/bridge/shared/src/protocol.rs
@@ -447,6 +447,7 @@ fn SenderKeyDistributionMessage_GetSignatureKey(
 
 bridge_deserialize!(DecryptionErrorMessage::try_from);
 bridge_get!(DecryptionErrorMessage::timestamp -> u64);
+bridge_get!(DecryptionErrorMessage::device_id -> u32);
 bridge_get_bytearray!(
     DecryptionErrorMessage::serialized as Serialize,
     jni = "DecryptionErrorMessage_1GetSerialized"
@@ -462,6 +463,7 @@ fn DecryptionErrorMessage_ForOriginalMessage(
     original_bytes: &[u8],
     original_type: u8,
     original_timestamp: u64,
+    original_sender_device_id: u32,
 ) -> Result<DecryptionErrorMessage> {
     let original_type = CiphertextMessageType::try_from(original_type).map_err(|_| {
         SignalProtocolError::InvalidArgument(format!("unknown message type {}", original_type))
@@ -470,6 +472,7 @@ fn DecryptionErrorMessage_ForOriginalMessage(
         original_bytes,
         original_type,
         original_timestamp,
+        original_sender_device_id,
     )?)
 }
 

--- a/rust/protocol/src/proto/service.proto
+++ b/rust/protocol/src/proto/service.proto
@@ -20,4 +20,5 @@ message Content {
 message DecryptionErrorMessage {
     optional bytes ratchet_key = 1;  // set to the public ratchet key from the SignalMessage if a 1-1 payload fails to decrypt
     optional uint64 timestamp = 2;
+    optional uint32 device_id = 3;
 }

--- a/rust/protocol/tests/sealed_sender.rs
+++ b/rust/protocol/tests/sealed_sender.rs
@@ -755,6 +755,7 @@ fn test_decryption_error_in_sealed_sender() -> Result<(), SignalProtocolError> {
             bob_message.serialize(),
             bob_message.message_type(),
             408,
+            5,
         )?;
         let error_message_content = PlaintextContent::from(error_message);
         let error_message_usmc = UnidentifiedSenderMessageContent::new(
@@ -790,6 +791,7 @@ fn test_decryption_error_in_sealed_sender() -> Result<(), SignalProtocolError> {
 
         assert_eq!(bob_error_message.ratchet_key(), Some(original_ratchet_key));
         assert_eq!(bob_error_message.timestamp(), 408);
+        assert_eq!(bob_error_message.device_id(), 5);
 
         Ok(())
     })

--- a/swift/Sources/SignalClient/messages/PlaintextContent.swift
+++ b/swift/Sources/SignalClient/messages/PlaintextContent.swift
@@ -63,10 +63,10 @@ public class DecryptionErrorMessage {
         }!
     }
 
-    public init<Bytes: ContiguousBytes>(originalMessageBytes bytes: Bytes, type: CiphertextMessage.MessageType, timestamp: UInt64) throws {
+    public init<Bytes: ContiguousBytes>(originalMessageBytes bytes: Bytes, type: CiphertextMessage.MessageType, timestamp: UInt64, originalSenderDeviceId: UInt32) throws {
         nativeHandle = try bytes.withUnsafeBytes {
             var result: OpaquePointer?
-            try checkError(signal_decryption_error_message_for_original_message(&result, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count, type.rawValue, timestamp))
+            try checkError(signal_decryption_error_message_for_original_message(&result, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count, type.rawValue, timestamp, originalSenderDeviceId))
             return result
         }!
     }
@@ -100,6 +100,14 @@ public class DecryptionErrorMessage {
         return failOnError {
             try invokeFnReturningInteger {
                 signal_decryption_error_message_get_timestamp($0, nativeHandle)
+            }
+        }
+    }
+
+    public var deviceId: UInt32 {
+        return failOnError {
+            try invokeFnReturningInteger {
+                signal_decryption_error_message_get_device_id($0, nativeHandle)
             }
         }
     }

--- a/swift/Sources/SignalFfi/signal_ffi.h
+++ b/swift/Sources/SignalFfi/signal_ffi.h
@@ -650,6 +650,9 @@ SignalFfiError *signal_decryption_error_message_deserialize(SignalDecryptionErro
 SignalFfiError *signal_decryption_error_message_get_timestamp(uint64_t *out,
                                                               const SignalDecryptionErrorMessage *obj);
 
+SignalFfiError *signal_decryption_error_message_get_device_id(uint32_t *out,
+                                                              const SignalDecryptionErrorMessage *obj);
+
 SignalFfiError *signal_decryption_error_message_serialize(const unsigned char **out,
                                                           size_t *out_len,
                                                           const SignalDecryptionErrorMessage *obj);
@@ -661,7 +664,8 @@ SignalFfiError *signal_decryption_error_message_for_original_message(SignalDecry
                                                                      const unsigned char *original_bytes,
                                                                      size_t original_bytes_len,
                                                                      uint8_t original_type,
-                                                                     uint64_t original_timestamp);
+                                                                     uint64_t original_timestamp,
+                                                                     uint32_t original_sender_device_id);
 
 SignalFfiError *signal_decryption_error_message_extract_from_serialized_content(SignalDecryptionErrorMessage **out,
                                                                                 const unsigned char *bytes,

--- a/swift/Tests/SignalClientTests/SessionTests.swift
+++ b/swift/Tests/SignalClientTests/SessionTests.swift
@@ -335,7 +335,8 @@ class SessionTests: TestCaseBase {
                                             context: NullContext())
         let error_message = try DecryptionErrorMessage(originalMessageBytes: bob_message.serialize(),
                                                        type: bob_message.messageType,
-                                                       timestamp: 408)
+                                                       timestamp: 408,
+                                                       originalSenderDeviceId: bob_address.deviceId)
 
         let trust_root = IdentityKeyPair.generate()
         let server_keys = IdentityKeyPair.generate()
@@ -366,6 +367,7 @@ class SessionTests: TestCaseBase {
         let bob_content = try PlaintextContent(bytes: bob_usmc.contents)
         let bob_error_message = try DecryptionErrorMessage.extractFromSerializedContent(bob_content.body)
         XCTAssertEqual(bob_error_message.timestamp, 408)
+        XCTAssertEqual(bob_error_message.deviceId, bob_address.deviceId)
 
         let bob_session_with_alice = try XCTUnwrap(bob_store.loadSession(for: alice_address, context: NullContext()))
         XCTAssert(try bob_session_with_alice.currentRatchetKeyMatches(XCTUnwrap(bob_error_message.ratchetKey)))


### PR DESCRIPTION
This allows a device to know whether it's the one that sent a bad message, and take action accordingly.

We could have a slightly more typesafe API here by using ProtocolAddress and extracting the device ID, but that doesn't match up with getting the device ID out of a sealed sender certificate (which provides separate "sender UUID", "sender phone number", and "sender device ID" fields).