### PR TITLE
Java: put the UnidentifiedSenderMessageContent in a ProtocolException

### DIFF
--- a/java/java/src/main/java/org/signal/libsignal/metadata/ProtocolDuplicateMessageException.java
+++ b/java/java/src/main/java/org/signal/libsignal/metadata/ProtocolDuplicateMessageException.java
@@ -1,5 +1,6 @@
 package org.signal.libsignal.metadata;
 
+import org.signal.libsignal.metadata.protocol.UnidentifiedSenderMessageContent;
 import org.whispersystems.libsignal.util.guava.Optional;
 
 public class ProtocolDuplicateMessageException extends ProtocolException {
@@ -7,7 +8,7 @@ public class ProtocolDuplicateMessageException extends ProtocolException {
     super(e, sender, senderDevice);
   }
 
-  public ProtocolDuplicateMessageException(Exception e, String sender, int senderDevice, int contentHint, Optional<byte[]> groupId) {
-    super(e, sender, senderDevice, contentHint, groupId);
+  ProtocolDuplicateMessageException(Exception e, UnidentifiedSenderMessageContent content) {
+    super(e, content);
   }
 }

--- a/java/java/src/main/java/org/signal/libsignal/metadata/ProtocolException.java
+++ b/java/java/src/main/java/org/signal/libsignal/metadata/ProtocolException.java
@@ -5,20 +5,24 @@ import org.whispersystems.libsignal.util.guava.Optional;
 
 public abstract class ProtocolException extends Exception {
 
+  private final Optional<UnidentifiedSenderMessageContent> content;
   private final String sender;
   private final int senderDevice;
-  private final int contentHint;
-  private final Optional<byte[]> groupId;
 
   public ProtocolException(Exception e, String sender, int senderDevice) {
-    this(e, sender, senderDevice, UnidentifiedSenderMessageContent.CONTENT_HINT_DEFAULT, Optional.<byte[]>absent());
-  }
-
-  public ProtocolException(Exception e, String sender, int senderDevice, int contentHint, Optional<byte[]> groupId) {
+    this.content      = Optional.absent();
     this.sender       = sender;
     this.senderDevice = senderDevice;
-    this.contentHint  = contentHint;
-    this.groupId      = groupId;
+  }
+
+  ProtocolException(Exception e, UnidentifiedSenderMessageContent content) {
+    this.content      = Optional.of(content);
+    this.sender       = content.getSenderCertificate().getSender();
+    this.senderDevice = content.getSenderCertificate().getSenderDeviceId();
+  }
+
+  public Optional<UnidentifiedSenderMessageContent> getUnidentifiedSenderMessageContent() {
+    return content;
   }
 
   public String getSender() {
@@ -30,10 +34,16 @@ public abstract class ProtocolException extends Exception {
   }
 
   public int getContentHint() {
-    return contentHint;
+    if (content.isPresent()) {
+      return content.get().getContentHint();
+    }
+    return UnidentifiedSenderMessageContent.CONTENT_HINT_DEFAULT;
   }
 
   public Optional<byte[]> getGroupId() {
-    return groupId;
+    if (content.isPresent()) {
+      return content.get().getGroupId();
+    }
+    return Optional.<byte[]>absent();
   }
 }

--- a/java/java/src/main/java/org/signal/libsignal/metadata/ProtocolInvalidKeyException.java
+++ b/java/java/src/main/java/org/signal/libsignal/metadata/ProtocolInvalidKeyException.java
@@ -1,6 +1,6 @@
 package org.signal.libsignal.metadata;
 
-
+import org.signal.libsignal.metadata.protocol.UnidentifiedSenderMessageContent;
 import org.whispersystems.libsignal.InvalidKeyException;
 import org.whispersystems.libsignal.util.guava.Optional;
 
@@ -9,7 +9,7 @@ public class ProtocolInvalidKeyException extends ProtocolException {
     super(e, sender, senderDevice);
   }
 
-  public ProtocolInvalidKeyException(InvalidKeyException e, String sender, int senderDevice, int contentHint, Optional<byte[]> groupId) {
-    super(e, sender, senderDevice, contentHint, groupId);
+  ProtocolInvalidKeyException(InvalidKeyException e, UnidentifiedSenderMessageContent content) {
+    super(e, content);
   }
 }

--- a/java/java/src/main/java/org/signal/libsignal/metadata/ProtocolInvalidKeyIdException.java
+++ b/java/java/src/main/java/org/signal/libsignal/metadata/ProtocolInvalidKeyIdException.java
@@ -1,5 +1,6 @@
 package org.signal.libsignal.metadata;
 
+import org.signal.libsignal.metadata.protocol.UnidentifiedSenderMessageContent;
 import org.whispersystems.libsignal.util.guava.Optional;
 
 public class ProtocolInvalidKeyIdException extends ProtocolException {
@@ -7,7 +8,7 @@ public class ProtocolInvalidKeyIdException extends ProtocolException {
     super(e, sender, senderDevice);
   }
 
-  public ProtocolInvalidKeyIdException(Exception e, String sender, int senderDevice, int contentHint, Optional<byte[]> groupId) {
-    super(e, sender, senderDevice, contentHint, groupId);
+  ProtocolInvalidKeyIdException(Exception e, UnidentifiedSenderMessageContent content) {
+    super(e, content);
   }
 }

--- a/java/java/src/main/java/org/signal/libsignal/metadata/ProtocolInvalidMessageException.java
+++ b/java/java/src/main/java/org/signal/libsignal/metadata/ProtocolInvalidMessageException.java
@@ -1,6 +1,6 @@
 package org.signal.libsignal.metadata;
 
-
+import org.signal.libsignal.metadata.protocol.UnidentifiedSenderMessageContent;
 import org.whispersystems.libsignal.InvalidMessageException;
 import org.whispersystems.libsignal.util.guava.Optional;
 
@@ -9,6 +9,7 @@ public class ProtocolInvalidMessageException extends ProtocolException {
     super(e, sender, senderDevice);
   }
 
-  public ProtocolInvalidMessageException(InvalidMessageException e, String sender, int senderDevice, int contentHint, Optional<byte[]> groupId) {
-    super(e, sender, senderDevice, contentHint, groupId);
-  }}
+  ProtocolInvalidMessageException(InvalidMessageException e, UnidentifiedSenderMessageContent content) {
+    super(e, content);
+  }
+}

--- a/java/java/src/main/java/org/signal/libsignal/metadata/ProtocolInvalidVersionException.java
+++ b/java/java/src/main/java/org/signal/libsignal/metadata/ProtocolInvalidVersionException.java
@@ -1,6 +1,6 @@
 package org.signal.libsignal.metadata;
 
-
+import org.signal.libsignal.metadata.protocol.UnidentifiedSenderMessageContent;
 import org.whispersystems.libsignal.InvalidVersionException;
 import org.whispersystems.libsignal.util.guava.Optional;
 
@@ -9,7 +9,7 @@ public class ProtocolInvalidVersionException extends ProtocolException {
     super(e, sender, senderDevice);
   }
 
-  public ProtocolInvalidVersionException(InvalidVersionException e, String sender, int senderDevice, int contentHint, Optional<byte[]> groupId) {
-    super(e, sender, senderDevice, contentHint, groupId);
+  ProtocolInvalidVersionException(InvalidVersionException e, UnidentifiedSenderMessageContent content) {
+    super(e, content);
   }
 }

--- a/java/java/src/main/java/org/signal/libsignal/metadata/ProtocolLegacyMessageException.java
+++ b/java/java/src/main/java/org/signal/libsignal/metadata/ProtocolLegacyMessageException.java
@@ -1,6 +1,6 @@
 package org.signal.libsignal.metadata;
 
-
+import org.signal.libsignal.metadata.protocol.UnidentifiedSenderMessageContent;
 import org.whispersystems.libsignal.LegacyMessageException;
 import org.whispersystems.libsignal.util.guava.Optional;
 
@@ -9,7 +9,7 @@ public class ProtocolLegacyMessageException extends ProtocolException {
     super(e, sender, senderDeviceId);
   }
 
-  public ProtocolLegacyMessageException(LegacyMessageException e, String sender, int senderDeviceId, int contentHint, Optional<byte[]> groupId) {
-    super(e, sender, senderDeviceId, contentHint, groupId);
+  ProtocolLegacyMessageException(LegacyMessageException e, UnidentifiedSenderMessageContent content) {
+    super(e, content);
   }
 }

--- a/java/java/src/main/java/org/signal/libsignal/metadata/ProtocolNoSessionException.java
+++ b/java/java/src/main/java/org/signal/libsignal/metadata/ProtocolNoSessionException.java
@@ -1,6 +1,6 @@
 package org.signal.libsignal.metadata;
 
-
+import org.signal.libsignal.metadata.protocol.UnidentifiedSenderMessageContent;
 import org.whispersystems.libsignal.NoSessionException;
 import org.whispersystems.libsignal.util.guava.Optional;
 
@@ -9,7 +9,7 @@ public class ProtocolNoSessionException extends ProtocolException {
     super(e, sender, senderDevice);
   }
 
-  public ProtocolNoSessionException(NoSessionException e, String sender, int senderDevice, int contentHint, Optional<byte[]> groupId) {
-    super(e, sender, senderDevice, contentHint, groupId);
+  ProtocolNoSessionException(NoSessionException e, UnidentifiedSenderMessageContent content) {
+    super(e, content);
   }
 }

--- a/java/java/src/main/java/org/signal/libsignal/metadata/ProtocolUntrustedIdentityException.java
+++ b/java/java/src/main/java/org/signal/libsignal/metadata/ProtocolUntrustedIdentityException.java
@@ -1,6 +1,6 @@
 package org.signal.libsignal.metadata;
 
-
+import org.signal.libsignal.metadata.protocol.UnidentifiedSenderMessageContent;
 import org.whispersystems.libsignal.UntrustedIdentityException;
 import org.whispersystems.libsignal.util.guava.Optional;
 
@@ -9,7 +9,7 @@ public class ProtocolUntrustedIdentityException extends ProtocolException {
     super(e, sender, senderDevice);
   }
 
-  public ProtocolUntrustedIdentityException(UntrustedIdentityException e, String sender, int senderDevice, int contentHint, Optional<byte[]> groupId) {
-    super(e, sender, senderDevice, contentHint, groupId);
+  ProtocolUntrustedIdentityException(UntrustedIdentityException e, UnidentifiedSenderMessageContent content) {
+    super(e, content);
   }
 }

--- a/java/java/src/main/java/org/signal/libsignal/metadata/SealedSessionCipher.java
+++ b/java/java/src/main/java/org/signal/libsignal/metadata/SealedSessionCipher.java
@@ -142,21 +142,21 @@ public class SealedSessionCipher {
                                   content.getSenderCertificate().getSenderDeviceId(),
                                   decrypt(content));
     } catch (InvalidMessageException e) {
-      throw new ProtocolInvalidMessageException(e, content.getSenderCertificate().getSender(), content.getSenderCertificate().getSenderDeviceId(), content.getContentHint(), content.getGroupId());
+      throw new ProtocolInvalidMessageException(e, content);
     } catch (InvalidKeyException e) {
-      throw new ProtocolInvalidKeyException(e, content.getSenderCertificate().getSender(), content.getSenderCertificate().getSenderDeviceId(), content.getContentHint(), content.getGroupId());
+      throw new ProtocolInvalidKeyException(e, content);
     } catch (NoSessionException e) {
-      throw new ProtocolNoSessionException(e, content.getSenderCertificate().getSender(), content.getSenderCertificate().getSenderDeviceId(), content.getContentHint(), content.getGroupId());
+      throw new ProtocolNoSessionException(e, content);
     } catch (LegacyMessageException e) {
-      throw new ProtocolLegacyMessageException(e, content.getSenderCertificate().getSender(), content.getSenderCertificate().getSenderDeviceId(), content.getContentHint(), content.getGroupId());
+      throw new ProtocolLegacyMessageException(e, content);
     } catch (InvalidVersionException e) {
-      throw new ProtocolInvalidVersionException(e, content.getSenderCertificate().getSender(), content.getSenderCertificate().getSenderDeviceId(), content.getContentHint(), content.getGroupId());
+      throw new ProtocolInvalidVersionException(e, content);
     } catch (DuplicateMessageException e) {
-      throw new ProtocolDuplicateMessageException(e, content.getSenderCertificate().getSender(), content.getSenderCertificate().getSenderDeviceId(), content.getContentHint(), content.getGroupId());
+      throw new ProtocolDuplicateMessageException(e, content);
     } catch (InvalidKeyIdException e) {
-      throw new ProtocolInvalidKeyIdException(e, content.getSenderCertificate().getSender(), content.getSenderCertificate().getSenderDeviceId(), content.getContentHint(), content.getGroupId());
+      throw new ProtocolInvalidKeyIdException(e, content);
     } catch (UntrustedIdentityException e) {
-      throw new ProtocolUntrustedIdentityException(e, content.getSenderCertificate().getSender(), content.getSenderCertificate().getSenderDeviceId(), content.getContentHint(), content.getGroupId());
+      throw new ProtocolUntrustedIdentityException(e, content);
     }
   }
 


### PR DESCRIPTION
That is, when there's an error decrypting the inner payload of a sealed sender message, instead of just saving the sender (and more recently the content hint and group ID), save the whole decrypted contents of the sealed sender message. This is necessary so that the app can make a DecryptedErrorMessage from that failed payload.

This is complicated somewhat by the fact that the app also uses the "short" constructor for the various Protocol*Exceptions, so we have to keep those working.