### PR TITLE
Replace block_on and expect_ready with FutureExt::now_or_never

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,52 +484,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
-name = "futures"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
 
 [[package]]
 name = "futures-macro"
@@ -544,12 +502,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-sink"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
-
-[[package]]
 name = "futures-task"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,13 +513,9 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "proc-macro-hack",
@@ -789,7 +737,7 @@ dependencies = [
  "aes-gcm-siv",
  "async-trait",
  "device-transfer",
- "futures",
+ "futures-util",
  "jni",
  "libc",
  "libsignal-bridge-macros",
@@ -825,6 +773,7 @@ dependencies = [
  "async-trait",
  "cpufeatures",
  "device-transfer",
+ "futures-util",
  "libc",
  "libsignal-bridge",
  "libsignal-protocol",
@@ -873,7 +822,7 @@ dependencies = [
  "block-modes",
  "criterion",
  "curve25519-dalek",
- "futures",
+ "futures-util",
  "hex",
  "hmac",
  "log",
@@ -1761,7 +1710,7 @@ dependencies = [
 name = "signal-neon-futures"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures-util",
  "neon",
  "signal-neon-futures-tests",
 ]
@@ -1770,7 +1719,7 @@ dependencies = [
 name = "signal-neon-futures-tests"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures-util",
  "neon",
  "signal-neon-futures",
 ]

--- a/rust/bridge/ffi/Cargo.toml
+++ b/rust/bridge/ffi/Cargo.toml
@@ -21,6 +21,7 @@ signal-crypto = { path = "../../crypto" }
 libsignal-bridge = { path = "../shared", features = ["ffi"] }
 async-trait = "0.1.41"
 cpufeatures = "0.1.5" # Make sure iOS gets optimized crypto.
+futures-util = "0.3"
 libc = "0.2"
 rand = "0.7.3"
 log = "0.4"

--- a/rust/bridge/node/futures/Cargo.toml
+++ b/rust/bridge/node/futures/Cargo.toml
@@ -22,7 +22,7 @@ harness = false
 
 [dependencies]
 neon = { version = "0.8", default-features = false, features = ["napi-4", "try-catch-api", "event-queue-api"] }
-futures = "0.3.7"
+futures-util = "0.3.7"
 
 [dev-dependencies]
 signal-neon-futures-tests = { path = "tests-node-module" }

--- a/rust/bridge/node/futures/src/promise.rs
+++ b/rust/bridge/node/futures/src/promise.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use futures::FutureExt;
+use futures_util::FutureExt;
 use neon::prelude::*;
 use std::future::Future;
 use std::panic::{catch_unwind, AssertUnwindSafe, UnwindSafe};

--- a/rust/bridge/node/futures/tests-node-module/Cargo.toml
+++ b/rust/bridge/node/futures/tests-node-module/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib"]
 [dependencies]
 signal-neon-futures = { path = ".." }
 neon = { version = "0.8", default-features = false, features = ["napi-1"] }
-futures = "0.3.7"
+futures-util = "0.3.7"
 
 [features]
 # Enable default-panic-hook to get backtraces of panics.

--- a/rust/bridge/node/futures/tests-node-module/src/store_like.rs
+++ b/rust/bridge/node/futures/tests-node-module/src/store_like.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use futures::try_join;
+use futures_util::try_join;
 use neon::prelude::*;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;

--- a/rust/bridge/shared/Cargo.toml
+++ b/rust/bridge/shared/Cargo.toml
@@ -16,7 +16,7 @@ signal-crypto = { path = "../../crypto" }
 device-transfer = { path = "../../device-transfer" }
 libsignal-bridge-macros = { path = "macros" }
 aes-gcm-siv = { version = "0.10.1", features = ["armv8"] }
-futures = "0.3.7"
+futures-util = "0.3.7"
 log = "0.4"
 paste = "1.0"
 rand = "0.7.3"

--- a/rust/bridge/shared/macros/src/ffi.rs
+++ b/rust/bridge/shared/macros/src/ffi.rs
@@ -49,7 +49,7 @@ pub(crate) fn bridge_fn(name: String, sig: &Signature, result_kind: ResultKind) 
 
     let await_if_needed = sig.asyncness.map(|_| {
         quote! {
-            let __result = expect_ready(__result);
+            let __result = __result.now_or_never().unwrap();
         }
     });
 

--- a/rust/bridge/shared/macros/src/jni.rs
+++ b/rust/bridge/shared/macros/src/jni.rs
@@ -33,7 +33,7 @@ pub(crate) fn bridge_fn(name: String, sig: &Signature, result_kind: ResultKind) 
 
     let await_if_needed = sig.asyncness.map(|_| {
         quote! {
-            let __result = expect_ready(__result);
+            let __result = __result.now_or_never().unwrap();
         }
     });
 

--- a/rust/bridge/shared/src/ffi/mod.rs
+++ b/rust/bridge/shared/src/ffi/mod.rs
@@ -17,8 +17,6 @@ pub use error::*;
 mod storage;
 pub use storage::*;
 
-pub use crate::support::expect_ready;
-
 pub fn run_ffi_safe<F: FnOnce() -> Result<(), SignalFfiError> + std::panic::UnwindSafe>(
     f: F,
 ) -> *mut SignalFfiError {

--- a/rust/bridge/shared/src/jni/mod.rs
+++ b/rust/bridge/shared/src/jni/mod.rs
@@ -64,8 +64,6 @@ pub use error::*;
 mod storage;
 pub use storage::*;
 
-pub use crate::support::expect_ready;
-
 /// The type of boxed Rust values, as surfaced in JavaScript.
 pub type ObjectHandle = jlong;
 

--- a/rust/bridge/shared/src/protocol.rs
+++ b/rust/bridge/shared/src/protocol.rs
@@ -10,6 +10,10 @@ use static_assertions::const_assert_eq;
 use std::convert::TryFrom;
 use uuid::Uuid;
 
+// Will be unused when building for Node only.
+#[allow(unused_imports)]
+use futures_util::FutureExt;
+
 use crate::support::*;
 use crate::*;
 

--- a/rust/bridge/shared/src/support/mod.rs
+++ b/rust/bridge/shared/src/support/mod.rs
@@ -3,27 +3,12 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use futures::pin_mut;
-use futures::task::noop_waker_ref;
 use std::borrow::Cow;
-use std::future::Future;
-use std::task::{self, Poll};
 
 pub(crate) use paste::paste;
 
 mod transform_helper;
 pub(crate) use transform_helper::*;
-
-/// Polls a future once; panics if it is not Ready.
-#[allow(dead_code)] // not used in Node-only builds
-#[track_caller]
-pub fn expect_ready<F: Future>(future: F) -> F::Output {
-    pin_mut!(future);
-    match future.poll(&mut task::Context::from_waker(noop_waker_ref())) {
-        Poll::Ready(result) => result,
-        Poll::Pending => panic!("future was not ready"),
-    }
-}
 
 /// Used for returning newly-allocated buffers as efficiently as possible.
 ///

--- a/rust/protocol/Cargo.toml
+++ b/rust/protocol/Cargo.toml
@@ -43,7 +43,7 @@ nightly = ["curve25519-dalek/nightly"]
 
 [dev-dependencies]
 criterion = "0.3"
-futures = "0.3.7"
+futures-util = "0.3.7"
 
 [build-dependencies]
 prost-build = "0.7"

--- a/rust/protocol/benches/session.rs
+++ b/rust/protocol/benches/session.rs
@@ -4,7 +4,7 @@
 //
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use futures::executor::block_on;
+use futures_util::FutureExt;
 use libsignal_protocol::*;
 
 #[path = "../tests/support/mod.rs"]
@@ -19,57 +19,51 @@ pub fn session_encrypt_result(c: &mut Criterion) -> Result<(), SignalProtocolErr
     let mut alice_store = support::test_in_memory_protocol_store()?;
     let mut bob_store = support::test_in_memory_protocol_store()?;
 
-    block_on(alice_store.store_session(&bob_address, &alice_session_record, None))?;
-    block_on(bob_store.store_session(&alice_address, &bob_session_record, None))?;
+    alice_store
+        .store_session(&bob_address, &alice_session_record, None)
+        .now_or_never()
+        .expect("sync")?;
+    bob_store
+        .store_session(&alice_address, &bob_session_record, None)
+        .now_or_never()
+        .expect("sync")?;
 
-    let message_to_decrypt = block_on(support::encrypt(
-        &mut alice_store,
-        &bob_address,
-        "a short message",
-    ))?;
+    let message_to_decrypt = support::encrypt(&mut alice_store, &bob_address, "a short message")
+        .now_or_never()
+        .expect("sync")?;
 
     c.bench_function("session decrypt first message", |b| {
         b.iter(|| {
             let mut bob_store = bob_store.clone();
-            block_on(support::decrypt(
-                &mut bob_store,
-                &alice_address,
-                &message_to_decrypt,
-            ))
-            .expect("success");
+            support::decrypt(&mut bob_store, &alice_address, &message_to_decrypt)
+                .now_or_never()
+                .expect("sync")
+                .expect("success");
         })
     });
 
-    let _ = block_on(support::decrypt(
-        &mut bob_store,
-        &alice_address,
-        &message_to_decrypt,
-    ))?;
-    let message_to_decrypt = block_on(support::encrypt(
-        &mut alice_store,
-        &bob_address,
-        "a short message",
-    ))?;
+    let _ = support::decrypt(&mut bob_store, &alice_address, &message_to_decrypt)
+        .now_or_never()
+        .expect("sync")?;
+    let message_to_decrypt = support::encrypt(&mut alice_store, &bob_address, "a short message")
+        .now_or_never()
+        .expect("sync")?;
 
     c.bench_function("session encrypt", |b| {
         b.iter(|| {
-            block_on(support::encrypt(
-                &mut alice_store,
-                &bob_address,
-                "a short message",
-            ))
-            .expect("success");
+            support::encrypt(&mut alice_store, &bob_address, "a short message")
+                .now_or_never()
+                .expect("sync")
+                .expect("success");
         })
     });
     c.bench_function("session decrypt", |b| {
         b.iter(|| {
             let mut bob_store = bob_store.clone();
-            block_on(support::decrypt(
-                &mut bob_store,
-                &alice_address,
-                &message_to_decrypt,
-            ))
-            .expect("success");
+            support::decrypt(&mut bob_store, &alice_address, &message_to_decrypt)
+                .now_or_never()
+                .expect("sync")
+                .expect("success");
         })
     });
 
@@ -85,40 +79,46 @@ pub fn session_encrypt_decrypt_result(c: &mut Criterion) -> Result<(), SignalPro
     let mut alice_store = support::test_in_memory_protocol_store()?;
     let mut bob_store = support::test_in_memory_protocol_store()?;
 
-    block_on(alice_store.store_session(&bob_address, &alice_session_record, None))?;
-    block_on(bob_store.store_session(&alice_address, &bob_session_record, None))?;
+    alice_store
+        .store_session(&bob_address, &alice_session_record, None)
+        .now_or_never()
+        .expect("sync")?;
+    bob_store
+        .store_session(&alice_address, &bob_session_record, None)
+        .now_or_never()
+        .expect("sync")?;
 
     c.bench_function("session encrypt+decrypt 1 way", |b| {
         b.iter(|| {
-            let ctext = block_on(support::encrypt(
-                &mut alice_store,
-                &bob_address,
-                "a short message",
-            ))
-            .expect("success");
-            let _ptext = block_on(support::decrypt(&mut bob_store, &alice_address, &ctext))
+            let ctext = support::encrypt(&mut alice_store, &bob_address, "a short message")
+                .now_or_never()
+                .expect("sync")
+                .expect("success");
+            let _ptext = support::decrypt(&mut bob_store, &alice_address, &ctext)
+                .now_or_never()
+                .expect("sync")
                 .expect("success");
         })
     });
 
     c.bench_function("session encrypt+decrypt ping pong", |b| {
         b.iter(|| {
-            let ctext = block_on(support::encrypt(
-                &mut alice_store,
-                &bob_address,
-                "a short message",
-            ))
-            .expect("success");
-            let _ptext = block_on(support::decrypt(&mut bob_store, &alice_address, &ctext))
+            let ctext = support::encrypt(&mut alice_store, &bob_address, "a short message")
+                .now_or_never()
+                .expect("sync")
+                .expect("success");
+            let _ptext = support::decrypt(&mut bob_store, &alice_address, &ctext)
+                .now_or_never()
+                .expect("sync")
                 .expect("success");
 
-            let ctext = block_on(support::encrypt(
-                &mut bob_store,
-                &alice_address,
-                "a short message",
-            ))
-            .expect("success");
-            let _ptext = block_on(support::decrypt(&mut alice_store, &bob_address, &ctext))
+            let ctext = support::encrypt(&mut bob_store, &alice_address, "a short message")
+                .now_or_never()
+                .expect("sync")
+                .expect("success");
+            let _ptext = support::decrypt(&mut alice_store, &bob_address, &ctext)
+                .now_or_never()
+                .expect("sync")
                 .expect("success");
         })
     });

--- a/rust/protocol/tests/groups.rs
+++ b/rust/protocol/tests/groups.rs
@@ -6,7 +6,7 @@
 mod support;
 
 use async_trait::async_trait;
-use futures::executor::block_on;
+use futures_util::FutureExt;
 use libsignal_protocol::*;
 use rand::rngs::OsRng;
 use rand::seq::SliceRandom;
@@ -24,14 +24,16 @@ fn group_no_send_session() -> Result<(), SignalProtocolError> {
 
     let mut alice_store = test_in_memory_protocol_store()?;
 
-    assert!(block_on(group_encrypt(
+    assert!(group_encrypt(
         &mut alice_store,
         &sender_address,
         distribution_id,
         "space camp?".as_bytes(),
         &mut csprng,
         None,
-    ))
+    )
+    .now_or_never()
+    .expect("sync")
     .is_err());
 
     Ok(())
@@ -81,7 +83,7 @@ impl SenderKeyStore for ContextUsingSenderKeyStore {
 
 #[test]
 fn group_using_context_arg() -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         let mut csprng = OsRng;
 
         let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1);
@@ -103,12 +105,14 @@ fn group_using_context_arg() -> Result<(), SignalProtocolError> {
         .await?;
 
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }
 
 #[test]
 fn group_no_recv_session() -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         let mut csprng = OsRng;
 
         let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1);
@@ -150,12 +154,14 @@ fn group_no_recv_session() -> Result<(), SignalProtocolError> {
         assert!(bob_plaintext.is_err());
 
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }
 
 #[test]
 fn group_basic_encrypt_decrypt() -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         let mut csprng = OsRng;
 
         let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1);
@@ -208,12 +214,14 @@ fn group_basic_encrypt_decrypt() -> Result<(), SignalProtocolError> {
         );
 
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }
 
 #[test]
 fn group_sealed_sender() -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         let mut csprng = OsRng;
 
         let alice_device_id = 23;
@@ -386,12 +394,14 @@ fn group_sealed_sender() -> Result<(), SignalProtocolError> {
         );
 
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }
 
 #[test]
 fn group_large_messages() -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         let mut csprng = OsRng;
 
         let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1);
@@ -446,12 +456,14 @@ fn group_large_messages() -> Result<(), SignalProtocolError> {
         assert_eq!(bob_plaintext, large_message);
 
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }
 
 #[test]
 fn group_basic_ratchet() -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         let mut csprng = OsRng;
 
         let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1);
@@ -556,12 +568,14 @@ fn group_basic_ratchet() -> Result<(), SignalProtocolError> {
         );
 
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }
 
 #[test]
 fn group_late_join() -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         let mut csprng = OsRng;
 
         let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1);
@@ -626,12 +640,14 @@ fn group_late_join() -> Result<(), SignalProtocolError> {
         );
 
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }
 
 #[test]
 fn group_out_of_order() -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         let mut csprng = OsRng;
 
         let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1);
@@ -702,13 +718,15 @@ fn group_out_of_order() -> Result<(), SignalProtocolError> {
         }
 
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }
 
 #[test]
 #[ignore = "slow to run locally"]
 fn group_too_far_in_the_future() -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         let mut csprng = OsRng;
 
         let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1);
@@ -769,12 +787,14 @@ fn group_too_far_in_the_future() -> Result<(), SignalProtocolError> {
         .is_err());
 
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }
 
 #[test]
 fn group_message_key_limit() -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         let mut csprng = OsRng;
 
         let sender_address = ProtocolAddress::new("+14159999111".to_owned(), 1);
@@ -848,5 +868,7 @@ fn group_message_key_limit() -> Result<(), SignalProtocolError> {
         );
 
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }

--- a/rust/protocol/tests/sealed_sender.rs
+++ b/rust/protocol/tests/sealed_sender.rs
@@ -6,7 +6,7 @@
 mod support;
 use support::*;
 
-use futures::executor::block_on;
+use futures_util::FutureExt;
 use libsignal_protocol::*;
 use rand::rngs::OsRng;
 use std::convert::TryFrom;
@@ -136,7 +136,7 @@ fn test_sender_cert() -> Result<(), SignalProtocolError> {
 
 #[test]
 fn test_sealed_sender() -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         let mut rng = OsRng;
 
         let alice_device_id = 23;
@@ -297,12 +297,14 @@ fn test_sealed_sender() -> Result<(), SignalProtocolError> {
         }
 
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }
 
 #[test]
 fn test_sender_key_in_sealed_sender() -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         let mut rng = OsRng;
 
         let alice_device_id = 23;
@@ -420,12 +422,14 @@ fn test_sender_key_in_sealed_sender() -> Result<(), SignalProtocolError> {
         );
 
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }
 
 #[test]
 fn test_sealed_sender_multi_recipient() -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         let mut rng = OsRng;
 
         let alice_device_id = 23;
@@ -651,12 +655,14 @@ fn test_sealed_sender_multi_recipient() -> Result<(), SignalProtocolError> {
         }
 
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }
 
 #[test]
 fn test_decryption_error_in_sealed_sender() -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         let mut rng = OsRng;
 
         let alice_device_id = 23;
@@ -791,5 +797,7 @@ fn test_decryption_error_in_sealed_sender() -> Result<(), SignalProtocolError> {
         assert_eq!(bob_error_message.device_id(), 5);
 
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }

--- a/rust/protocol/tests/session.rs
+++ b/rust/protocol/tests/session.rs
@@ -5,7 +5,7 @@
 
 mod support;
 
-use futures::executor::block_on;
+use futures_util::FutureExt;
 use libsignal_protocol::*;
 use rand::rngs::OsRng;
 use std::convert::TryFrom;
@@ -14,7 +14,7 @@ use support::*;
 #[test]
 #[allow(clippy::eval_order_dependence)]
 fn test_basic_prekey_v3() -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         let mut csprng = OsRng;
 
         let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1);
@@ -250,14 +250,16 @@ fn test_basic_prekey_v3() -> Result<(), SignalProtocolError> {
         .is_err());
 
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }
 
 #[test]
 #[ignore = "slow to run locally"]
 #[allow(clippy::eval_order_dependence)]
 fn chain_jump_over_limit() -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         let mut csprng = OsRng;
 
         let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1);
@@ -337,14 +339,16 @@ fn chain_jump_over_limit() -> Result<(), SignalProtocolError> {
             .await
             .is_err());
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }
 
 #[test]
 #[ignore = "slow to run locally"]
 #[allow(clippy::eval_order_dependence)]
 fn chain_jump_over_limit_with_self() -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         let mut csprng = OsRng;
 
         let a1_address = ProtocolAddress::new("+14151111111".to_owned(), 1);
@@ -432,13 +436,15 @@ fn chain_jump_over_limit_with_self() -> Result<(), SignalProtocolError> {
         );
 
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }
 
 #[test]
 #[allow(clippy::eval_order_dependence)]
 fn test_bad_signed_pre_key_signature() -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         let bob_address = ProtocolAddress::new("+14151111112".to_owned(), 1);
 
         let mut alice_store = support::test_in_memory_protocol_store()?;
@@ -509,7 +515,9 @@ fn test_bad_signed_pre_key_signature() -> Result<(), SignalProtocolError> {
         .await?;
 
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }
 
 // testRepeatBundleMessageV2 cannot be represented
@@ -517,7 +525,7 @@ fn test_bad_signed_pre_key_signature() -> Result<(), SignalProtocolError> {
 #[test]
 #[allow(clippy::eval_order_dependence)]
 fn repeat_bundle_message_v3() -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1);
         let bob_address = ProtocolAddress::new("+14151111112".to_owned(), 1);
 
@@ -643,13 +651,15 @@ fn repeat_bundle_message_v3() -> Result<(), SignalProtocolError> {
         );
 
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }
 
 #[test]
 #[allow(clippy::eval_order_dependence)]
 fn bad_message_bundle() -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         let mut csprng = OsRng;
 
         let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1);
@@ -764,13 +774,15 @@ fn bad_message_bundle() -> Result<(), SignalProtocolError> {
         ));
 
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }
 
 #[test]
 #[allow(clippy::eval_order_dependence)]
 fn optional_one_time_prekey() -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1);
         let bob_address = ProtocolAddress::new("+14151111112".to_owned(), 1);
 
@@ -852,7 +864,9 @@ fn optional_one_time_prekey() -> Result<(), SignalProtocolError> {
         );
 
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }
 
 #[test]
@@ -864,7 +878,7 @@ fn basic_session_v3() -> Result<(), SignalProtocolError> {
 
 #[test]
 fn message_key_limits() -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         let (alice_session_record, bob_session_record) = initialize_sessions_v3()?;
 
         let alice_address = ProtocolAddress::new("+14159999999".to_owned(), 1);
@@ -916,7 +930,9 @@ fn message_key_limits() -> Result<(), SignalProtocolError> {
             SignalProtocolError::DuplicatedMessage(2300, 5)
         ));
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }
 
 #[allow(clippy::needless_range_loop)]
@@ -924,7 +940,7 @@ fn run_session_interaction(
     alice_session: SessionRecord,
     bob_session: SessionRecord,
 ) -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         use rand::seq::SliceRandom;
 
         let alice_address = ProtocolAddress::new("+14159999999".to_owned(), 1);
@@ -1015,7 +1031,9 @@ fn run_session_interaction(
         }
 
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }
 
 async fn run_interaction(
@@ -1128,7 +1146,7 @@ async fn is_session_id_equal(
 
 #[test]
 fn basic_simultaneous_initiate() -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         let mut csprng = OsRng;
 
         let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1);
@@ -1261,12 +1279,14 @@ fn basic_simultaneous_initiate() -> Result<(), SignalProtocolError> {
         assert!(is_session_id_equal(&bob_store, &bob_address, &alice_store, &alice_address).await?);
 
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }
 
 #[test]
 fn simultaneous_initiate_with_lossage() -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         let mut csprng = OsRng;
 
         let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1);
@@ -1381,12 +1401,14 @@ fn simultaneous_initiate_with_lossage() -> Result<(), SignalProtocolError> {
         assert!(is_session_id_equal(&bob_store, &bob_address, &alice_store, &alice_address).await?);
 
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }
 
 #[test]
 fn simultaneous_initiate_lost_message() -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         let mut csprng = OsRng;
 
         let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1);
@@ -1510,12 +1532,14 @@ fn simultaneous_initiate_lost_message() -> Result<(), SignalProtocolError> {
         assert!(is_session_id_equal(&bob_store, &bob_address, &alice_store, &alice_address).await?);
 
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }
 
 #[test]
 fn simultaneous_initiate_repeated_messages() -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         let mut csprng = OsRng;
 
         let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1);
@@ -1710,12 +1734,14 @@ fn simultaneous_initiate_repeated_messages() -> Result<(), SignalProtocolError> 
         assert!(is_session_id_equal(&bob_store, &bob_address, &alice_store, &alice_address).await?);
 
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }
 
 #[test]
 fn simultaneous_initiate_lost_message_repeated_messages() -> Result<(), SignalProtocolError> {
-    block_on(async {
+    async {
         let mut csprng = OsRng;
 
         let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1);
@@ -1958,5 +1984,7 @@ fn simultaneous_initiate_lost_message_repeated_messages() -> Result<(), SignalPr
         assert!(is_session_id_equal(&bob_store, &bob_address, &alice_store, &alice_address).await?);
 
         Ok(())
-    })
+    }
+    .now_or_never()
+    .expect("sync")
 }


### PR DESCRIPTION
Both `futures::executor::block_on` and our own `expect_ready` were being used to resolve futures that were, in practice, known to be non-blocking. `FutureExt::now_or_never` handles that case more lightly than `block_on` and more uniformly than `expect_ready`.

This lets us drop the dependency on the full 'futures' crate down to just futures-util, which should help with compile time.