### PR TITLE
crypto: Fix a 32-bit overflow in AES-256-CTR

### DIFF
--- a/rust/crypto/src/aes_ctr.rs
+++ b/rust/crypto/src/aes_ctr.rs
@@ -22,7 +22,7 @@ impl Aes256Ctr32 {
         nonce_block[0..Self::NONCE_SIZE].copy_from_slice(nonce);
 
         let mut ctr = aes::Aes256Ctr::from_block_cipher(aes256, &nonce_block.into());
-        ctr.seek(aes::BLOCK_SIZE * (init_ctr as usize));
+        ctr.seek((aes::BLOCK_SIZE as u64) * (init_ctr as u64));
 
         Ok(Self(ctr))
     }


### PR DESCRIPTION
Very large initial counter values would overflow the computation of the initial offset. Use u64 even on 32-bit platforms to avoid this.

This was introduced in #328, so it's not a problem in any shipping versions of libsignal-client.