### PR TITLE
Upgrade prost to 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,9 +1306,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
+checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1316,13 +1316,13 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
+checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
 dependencies = [
  "bytes",
  "heck",
- "itertools 0.9.0",
+ "itertools 0.10.0",
  "log",
  "multimap",
  "petgraph",
@@ -1334,12 +1334,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
+checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
- "itertools 0.9.0",
+ "itertools 0.10.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1347,9 +1347,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
+checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
  "bytes",
  "prost",

--- a/rust/protocol/Cargo.toml
+++ b/rust/protocol/Cargo.toml
@@ -18,7 +18,7 @@ arrayref = "0.3.6"
 async-trait = "0.1.41"
 block-modes = "0.8"
 hmac = "0.9.0"
-prost = "0.7"
+prost = "0.8"
 rand = "0.7.3"
 sha2 = "0.9"
 subtle = "2.2.3"
@@ -46,7 +46,7 @@ criterion = "0.3"
 futures-util = "0.3.7"
 
 [build-dependencies]
-prost-build = "0.7"
+prost-build = "0.8"
 
 [[bench]]
 name = "session"

--- a/rust/protocol/src/fingerprint.rs
+++ b/rust/protocol/src/fingerprint.rs
@@ -110,9 +110,7 @@ impl ScannableFingerprint {
             }),
         };
 
-        let mut buf = Vec::new();
-        combined_fingerprints.encode(&mut buf)?;
-        Ok(buf)
+        Ok(combined_fingerprints.encode_to_vec())
     }
 
     pub fn compare(&self, combined: &[u8]) -> Result<bool> {

--- a/rust/protocol/src/identity_key.rs
+++ b/rust/protocol/src/identity_key.rs
@@ -94,11 +94,8 @@ impl IdentityKeyPair {
             public_key: self.identity_key.serialize().to_vec(),
             private_key: self.private_key.serialize().to_vec(),
         };
-        let mut result = Vec::new();
 
-        // prost documents the only possible encoding error is if there is insufficient
-        // space, which is not a problem when it is allowed to encode into a Vec
-        structure.encode(&mut result).expect("No encoding error");
+        let result = structure.encode_to_vec();
         result.into_boxed_slice()
     }
 }

--- a/rust/protocol/src/sealed_sender.rs
+++ b/rust/protocol/src/sealed_sender.rs
@@ -87,17 +87,15 @@ impl ServerCertificate {
             key: Some(key.serialize().to_vec()),
         };
 
-        let mut certificate = vec![];
-        certificate_pb.encode(&mut certificate)?;
+        let certificate = certificate_pb.encode_to_vec();
 
         let signature = trust_root.calculate_signature(&certificate, rng)?.to_vec();
 
-        let mut serialized = vec![];
-        let pb = proto::sealed_sender::ServerCertificate {
+        let serialized = proto::sealed_sender::ServerCertificate {
             certificate: Some(certificate.clone()),
             signature: Some(signature.clone()),
-        };
-        pb.encode(&mut serialized)?;
+        }
+        .encode_to_vec();
 
         Ok(Self {
             serialized,
@@ -192,8 +190,7 @@ impl SenderCertificate {
                 .ok_or(SignalProtocolError::InvalidProtobufEncoding)?[..],
         )?;
 
-        let mut signer_bits = vec![];
-        signer_pb.encode(&mut signer_bits)?;
+        let signer_bits = signer_pb.encode_to_vec();
         let signer = ServerCertificate::deserialize(&signer_bits)?;
 
         Ok(Self {
@@ -228,17 +225,15 @@ impl SenderCertificate {
             signer: Some(signer.to_protobuf()?),
         };
 
-        let mut certificate = vec![];
-        certificate_pb.encode(&mut certificate)?;
+        let certificate = certificate_pb.encode_to_vec();
 
         let signature = signer_key.calculate_signature(&certificate, rng)?.to_vec();
 
-        let pb = proto::sealed_sender::SenderCertificate {
+        let serialized = proto::sealed_sender::SenderCertificate {
             certificate: Some(certificate.clone()),
             signature: Some(signature.clone()),
-        };
-        let mut serialized = vec![];
-        pb.encode(&mut serialized)?;
+        }
+        .encode_to_vec();
 
         Ok(Self {
             signer,
@@ -477,8 +472,7 @@ impl UnidentifiedSenderMessageContent {
             }),
         };
 
-        let mut serialized = vec![];
-        msg.encode(&mut serialized)?;
+        let serialized = msg.encode_to_vec();
 
         Ok(Self {
             serialized,
@@ -1273,8 +1267,7 @@ fn test_lossless_round_trip() -> Result<()> {
     // };
     //
     // eprintln!("<SNIP>");
-    // let mut serialized_certificate_data = vec![];
-    // sender_cert.encode(&mut serialized_certificate_data).expect("can't fail encoding to Vec");
+    // let serialized_certificate_data = sender_cert.encode_to_vec();
     // let certificate_data_encoded = hex::encode(&serialized_certificate_data);
     // eprintln!("let certificate_data_encoded = \"{}\";", certificate_data_encoded);
     //

--- a/rust/protocol/src/sender_keys.rs
+++ b/rust/protocol/src/sender_keys.rs
@@ -161,9 +161,7 @@ impl SenderKeyState {
     }
 
     pub fn serialize(&self) -> Result<Vec<u8>> {
-        let mut buf = vec![];
-        self.state.encode(&mut buf)?;
-        Ok(buf)
+        Ok(self.state.encode_to_vec())
     }
 
     pub fn message_version(&self) -> Result<u32> {
@@ -359,8 +357,6 @@ impl SenderKeyRecord {
     }
 
     pub fn serialize(&self) -> Result<Vec<u8>> {
-        let mut buf = vec![];
-        self.as_protobuf()?.encode(&mut buf)?;
-        Ok(buf)
+        Ok(self.as_protobuf()?.encode_to_vec())
     }
 }

--- a/rust/protocol/src/state/prekey.rs
+++ b/rust/protocol/src/state/prekey.rs
@@ -50,8 +50,6 @@ impl PreKeyRecord {
     }
 
     pub fn serialize(&self) -> Result<Vec<u8>> {
-        let mut buf = vec![];
-        self.pre_key.encode(&mut buf)?;
-        Ok(buf)
+        Ok(self.pre_key.encode_to_vec())
     }
 }

--- a/rust/protocol/src/state/session.rs
+++ b/rust/protocol/src/state/session.rs
@@ -585,14 +585,11 @@ impl SessionRecord {
     }
 
     pub fn serialize(&self) -> Result<Vec<u8>> {
-        let mut buf = vec![];
-
         let record = RecordStructure {
             current_session: self.current_session.as_ref().map(|s| s.into()),
             previous_sessions: self.previous_sessions.iter().map(|s| s.into()).collect(),
         };
-        record.encode(&mut buf)?;
-        Ok(buf)
+        Ok(record.encode_to_vec())
     }
 
     pub fn remote_registration_id(&self) -> Result<u32> {

--- a/rust/protocol/src/state/signed_prekey.rs
+++ b/rust/protocol/src/state/signed_prekey.rs
@@ -64,8 +64,6 @@ impl SignedPreKeyRecord {
     }
 
     pub fn serialize(&self) -> Result<Vec<u8>> {
-        let mut buf = vec![];
-        self.signed_pre_key.encode(&mut buf)?;
-        Ok(buf)
+        Ok(self.signed_pre_key.encode_to_vec())
     }
 }


### PR DESCRIPTION
The dreaded https://github.com/tokio-rs/prost/issues/154 (Prost Message `vec![]` + `encode` + `expect`) can now be get rid of in most places, thanks to https://github.com/tokio-rs/prost/pull/378. In some places, I've left the `.encode` call because it's doing some prepending of magic bytes.