### PR TITLE
Put aes' armv8 feature behind nightly feature

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -77,8 +77,40 @@ jobs:
       run: echo "::error file=.github/workflows/build_and_test.yml::File not included in any filter" && false
       if: ${{ !contains(steps.filter.outputs.*, 'true') }}
 
-  rust:
-    name: Rust
+  rust-stable:
+    name: Rust stable
+
+    runs-on: ubuntu-latest
+
+    needs: changes
+
+    if: ${{ needs.changes.outputs.rust == 'true' }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - run: sudo apt-get install gcc-multilib
+
+    - name: Install Rust
+      run: rustup +stable target add i686-unknown-linux-gnu
+
+    - name: Build
+      run: cargo +stable build --verbose
+
+    - name: Run tests
+      run: cargo +stable test --workspace --verbose -- --include-ignored
+
+    - name: Run tests (32-bit)
+      # Exclude device-transfer because OpenSSL, used for reference results,
+      # doesn't support the --target option.
+      # Exclude signal-neon-futures because those tests run Node
+      run: cargo +stable test --workspace --verbose --target i686-unknown-linux-gnu --exclude device-transfer --exclude signal-neon-futures -- --include-ignored
+
+    - name: Build benches
+      run: cargo +stable build --workspace --benches --verbose
+
+  rust-nightly:
+    name: Rust nightly
 
     runs-on: ubuntu-latest
 

--- a/rust/bridge/ffi/Cargo.toml
+++ b/rust/bridge/ffi/Cargo.toml
@@ -14,6 +14,9 @@ license = "AGPL-3.0-only"
 name = "signal_ffi"
 crate-type = ["staticlib"]
 
+[features]
+armv8 = ["libsignal-protocol/armv8", "signal-crypto/armv8"]
+
 [dependencies]
 libsignal-protocol = { path = "../../protocol" }
 device-transfer = { path = "../../device-transfer" }

--- a/rust/bridge/ffi/Cargo.toml
+++ b/rust/bridge/ffi/Cargo.toml
@@ -15,6 +15,7 @@ name = "signal_ffi"
 crate-type = ["staticlib"]
 
 [features]
+default = ["armv8"]
 armv8 = ["libsignal-protocol/armv8", "signal-crypto/armv8"]
 
 [dependencies]

--- a/rust/bridge/jni/Cargo.toml
+++ b/rust/bridge/jni/Cargo.toml
@@ -15,6 +15,7 @@ name = "signal_jni"
 crate-type = ["cdylib"]
 
 [features]
+default = ["armv8"]
 armv8 = ["libsignal-protocol/armv8", "signal-crypto/armv8"]
 
 [dependencies]

--- a/rust/bridge/jni/Cargo.toml
+++ b/rust/bridge/jni/Cargo.toml
@@ -14,6 +14,9 @@ license = "AGPL-3.0-only"
 name = "signal_jni"
 crate-type = ["cdylib"]
 
+[features]
+armv8 = ["libsignal-protocol/armv8", "signal-crypto/armv8"]
+
 [dependencies]
 libsignal-protocol = { path = "../../protocol" }
 signal-crypto = { path = "../../crypto" }

--- a/rust/bridge/node/Cargo.toml
+++ b/rust/bridge/node/Cargo.toml
@@ -14,6 +14,9 @@ edition = "2018"
 name = "signal_node"
 crate-type = ["cdylib"]
 
+[features]
+armv8 = ["libsignal-protocol/armv8", "libsignal-bridge/armv8"]
+
 [dependencies]
 libsignal-protocol = { path = "../../protocol" }
 libsignal-bridge = { path = "../shared", features = ["node"] }

--- a/rust/bridge/node/Cargo.toml
+++ b/rust/bridge/node/Cargo.toml
@@ -15,6 +15,7 @@ name = "signal_node"
 crate-type = ["cdylib"]
 
 [features]
+default = ["armv8"]
 armv8 = ["libsignal-protocol/armv8", "libsignal-bridge/armv8"]
 
 [dependencies]

--- a/rust/bridge/shared/Cargo.toml
+++ b/rust/bridge/shared/Cargo.toml
@@ -15,7 +15,7 @@ libsignal-protocol = { path = "../../protocol" }
 signal-crypto = { path = "../../crypto" }
 device-transfer = { path = "../../device-transfer" }
 libsignal-bridge-macros = { path = "macros" }
-aes-gcm-siv = { version = "0.10.1", features = ["armv8"] }
+aes-gcm-siv = "0.10.1"
 futures-util = "0.3.7"
 log = "0.4"
 paste = "1.0"
@@ -35,3 +35,4 @@ signal-neon-futures = { path = "../node/futures", optional = true }
 ffi = ["libc", "libsignal-bridge-macros/ffi"]
 jni = ["jni_crate", "libsignal-bridge-macros/jni"]
 node = ["neon", "linkme", "signal-neon-futures", "libsignal-bridge-macros/node"]
+armv8 = ["aes-gcm-siv/armv8", "libsignal-protocol/armv8", "signal-crypto/armv8"]

--- a/rust/bridge/shared/Cargo.toml
+++ b/rust/bridge/shared/Cargo.toml
@@ -32,6 +32,7 @@ linkme = { version = "0.2.4", optional = true }
 signal-neon-futures = { path = "../node/futures", optional = true }
 
 [features]
+default = ["armv8"]
 ffi = ["libc", "libsignal-bridge-macros/ffi"]
 jni = ["jni_crate", "libsignal-bridge-macros/jni"]
 node = ["neon", "linkme", "signal-neon-futures", "libsignal-bridge-macros/node"]

--- a/rust/crypto/Cargo.toml
+++ b/rust/crypto/Cargo.toml
@@ -25,6 +25,9 @@ serde_json = "1.0"
 hex = "0.4"
 criterion = "0.3"
 
+[features]
+armv8 = ["aes/armv8"]
+
 [[bench]]
 name = "aes_gcm"
 harness = false

--- a/rust/protocol/Cargo.toml
+++ b/rust/protocol/Cargo.toml
@@ -12,8 +12,8 @@ license = "AGPL-3.0-only"
 repository = "https://github.com/signalapp/libsignal-client"
 
 [dependencies]
-aes = { version = "0.7.4", features = ["armv8", "ctr"] }
-aes-gcm-siv = { version = "0.10.1", features = ["armv8"] }
+aes = { version = "0.7.4", features = ["ctr"] }
+aes-gcm-siv = "0.10.1"
 arrayref = "0.3.6"
 async-trait = "0.1.41"
 block-modes = "0.8"
@@ -40,6 +40,7 @@ u32_backend = ["curve25519-dalek/u32_backend"]
 u64_backend = ["curve25519-dalek/u64_backend"]
 simd_backend = ["curve25519-dalek/simd_backend"]
 nightly = ["curve25519-dalek/nightly"]
+armv8 = ["aes/armv8", "aes-gcm-siv/armv8"]
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
Follow-up from #284, as promised. As you said, it became a lot easier :-)

Would you like me to make the armv8 feature default in the jni/node/native ffi crates? Maybe it makes sense there. Otherwise, you'll have to supply the armv8 feature flag from the build system in Signal-Android and Signal-iOS

(off topic: re NEON and Dalek, we have something upcoming!)