### PR TITLE
Update to Neon 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,8 +919,9 @@ checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
 
 [[package]]
 name = "neon"
-version = "0.8.3"
-source = "git+https://github.com/signalapp/neon?tag=signal-2021-06-02#6d0dbd13286e5b3f9d95d8e16499cba95c8e5885"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "158d44fdd9cc93d5051c15e970727e94e4440c3c585c77b2f482df397a661fcf"
 dependencies = [
  "cslice",
  "neon-build",
@@ -932,13 +933,15 @@ dependencies = [
 
 [[package]]
 name = "neon-build"
-version = "0.8.3"
-source = "git+https://github.com/signalapp/neon?tag=signal-2021-06-02#6d0dbd13286e5b3f9d95d8e16499cba95c8e5885"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "067f30e1bb8bec9a0f2be115fd54430dd66472872c7c1491473618a405c1daac"
 
 [[package]]
 name = "neon-macros"
-version = "0.8.3"
-source = "git+https://github.com/signalapp/neon?tag=signal-2021-06-02#6d0dbd13286e5b3f9d95d8e16499cba95c8e5885"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72adff7fd8a79dc3a18e565086179fa7608c555dd0e553e4eafebf9033b6a01c"
 dependencies = [
  "quote",
  "syn",
@@ -946,8 +949,9 @@ dependencies = [
 
 [[package]]
 name = "neon-runtime"
-version = "0.8.3"
-source = "git+https://github.com/signalapp/neon?tag=signal-2021-06-02#6d0dbd13286e5b3f9d95d8e16499cba95c8e5885"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be066c504047007b93709dc164c42f9f19c2ff365e7bf71240c8f88c92f2e687"
 dependencies = [
  "cfg-if 1.0.0",
  "libloading",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ default-members = [
 
 [patch.crates-io]
 curve25519-dalek = { git = 'https://github.com/signalapp/curve25519-dalek', branch = '3.0.0-lizard2' }
-neon = { git = 'https://github.com/signalapp/neon', tag = 'signal-2021-06-02' }
 
 [profile.dev.package.num-bigint-dig]
 opt-level = 2 # too slow otherwise!

--- a/rust/bridge/node/Cargo.toml
+++ b/rust/bridge/node/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib"]
 libsignal-protocol = { path = "../../protocol" }
 libsignal-bridge = { path = "../shared", features = ["node"] }
 signal-neon-futures = { path = "futures" }
-neon = { version = "0.8", default-features = false, features = ["napi-6", "event-queue-api"] }
+neon = { version = "0.9", default-features = false, features = ["napi-6", "channel-api"] }
 rand = "0.7.3"
 log = "0.4"
 log-panics = { version = "2.0.0", features = ["with-backtrace"] }

--- a/rust/bridge/node/futures/Cargo.toml
+++ b/rust/bridge/node/futures/Cargo.toml
@@ -21,8 +21,11 @@ path = "benches/node.rs"
 harness = false
 
 [dependencies]
-neon = { version = "0.8", default-features = false, features = ["napi-4", "try-catch-api", "event-queue-api"] }
+neon = { version = "0.9", default-features = false, features = ["napi-4", "try-catch-api", "channel-api"] }
 futures-util = "0.3.7"
 
 [dev-dependencies]
 signal-neon-futures-tests = { path = "tests-node-module" }
+
+[features]
+napi-6 = ["neon/napi-6"]

--- a/rust/bridge/node/futures/src/exception.rs
+++ b/rust/bridge/node/futures/src/exception.rs
@@ -23,7 +23,7 @@ enum PersistentExceptionValue {
 /// or [into_inner][PersistentException::into_inner], like Root.
 /// This is because it must be unregistered with the JavaScript garbage collector.
 ///
-/// [root]: https://docs.rs/neon/0.7.0-napi.3/neon/handle/struct.Root.html
+/// [root]: https://docs.rs/neon/0.9.0/neon/handle/struct.Root.html
 pub struct PersistentException {
     wrapped: PersistentExceptionValue,
 }

--- a/rust/bridge/node/futures/src/future.rs
+++ b/rust/bridge/node/futures/src/future.rs
@@ -185,16 +185,16 @@ impl<T: 'static + Send> JsFuture<T> {
 
     /// Creates a new JsFuture by calling the JavaScript method [`then`][then] on the result of `get_promise`.
     ///
-    /// `get_promise` will be run on the given EventQueue.
+    /// `get_promise` will be run on the given Channel.
     /// The future will not be ready until it is given a result `transform`. See [JsFutureBuilder].
     ///
     /// [then]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then
-    pub fn get_promise<F>(queue: &EventQueue, get_promise: F) -> JsFutureBuilder<F, T>
+    pub fn get_promise<F>(channel: &Channel, get_promise: F) -> JsFutureBuilder<F, T>
     where
         F: for<'a> FnOnce(&mut TaskContext<'a>) -> JsResult<'a, JsObject> + Send + 'static,
     {
         JsFutureBuilder {
-            queue,
+            channel,
             get_promise,
             result_type: PhantomData,
         }

--- a/rust/bridge/node/futures/src/future/builder.rs
+++ b/rust/bridge/node/futures/src/future/builder.rs
@@ -13,7 +13,7 @@ pub struct JsFutureBuilder<'a, F, T: 'static + Send>
 where
     F: for<'b> FnOnce(&mut TaskContext<'b>) -> JsResult<'b, JsObject> + 'static + Send,
 {
-    pub(super) queue: &'a EventQueue,
+    pub(super) channel: &'a Channel,
     pub(super) get_promise: F,
     pub(super) result_type: PhantomData<fn() -> T>,
 }
@@ -35,7 +35,7 @@ where
         let settle_token = WeakFutureToken::new(&future);
         let get_promise = self.get_promise;
 
-        self.queue.send(move |mut cx| {
+        self.channel.send(move |mut cx| {
             let mut maybe_bound_reject = None;
             let result = cx.try_catch(|cx| {
                 let bound_reject = settle_token.bind_settle_promise::<_, JsRejectedResult>(cx)?;

--- a/rust/bridge/node/futures/src/lib.rs
+++ b/rust/bridge/node/futures/src/lib.rs
@@ -22,7 +22,7 @@
 #![warn(clippy::unwrap_used)]
 
 mod executor;
-pub use executor::EventQueueEx;
+pub use executor::ChannelEx;
 
 mod exception;
 pub use exception::PersistentException;

--- a/rust/bridge/node/futures/tests-node-module/Cargo.toml
+++ b/rust/bridge/node/futures/tests-node-module/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 signal-neon-futures = { path = ".." }
-neon = { version = "0.8", default-features = false, features = ["napi-1"] }
+neon = { version = "0.9", default-features = false, features = ["napi-1"] }
 futures-util = "0.3.7"
 
 [features]

--- a/rust/bridge/node/futures/tests-node-module/src/store_like.rs
+++ b/rust/bridge/node/futures/tests-node-module/src/store_like.rs
@@ -11,21 +11,21 @@ use std::sync::Arc;
 use signal_neon_futures::*;
 
 struct NameStore {
-    js_queue: EventQueue,
+    js_channel: Channel,
     store_object: Arc<Root<JsObject>>,
 }
 
 impl NameStore {
     fn new<'a>(cx: &mut FunctionContext<'a>, store: Handle<'a, JsObject>) -> Self {
         Self {
-            js_queue: cx.queue(),
+            js_channel: cx.channel(),
             store_object: Arc::new(store.root(cx)),
         }
     }
 
     async fn get_name(&self) -> Result<String, String> {
         let store_object_shared = self.store_object.clone();
-        JsFuture::get_promise(&self.js_queue, move |cx| {
+        JsFuture::get_promise(&self.js_channel, move |cx| {
             let store_object = store_object_shared.to_inner(cx);
             let result = call_method(cx, store_object, "getName", std::iter::empty())?
                 .downcast_or_throw(cx)?;

--- a/rust/bridge/node/src/logging.rs
+++ b/rust/bridge/node/src/logging.rs
@@ -49,14 +49,14 @@ impl From<LogLevel> for u32 {
 }
 
 struct NodeLogger {
-    queue: EventQueue,
+    channel: Channel,
 }
 
 impl NodeLogger {
     fn new(cx: &mut FunctionContext) -> Self {
-        let mut queue = cx.queue();
-        queue.unref(cx);
-        Self { queue }
+        let mut channel = cx.channel();
+        channel.unref(cx);
+        Self { channel }
     }
 }
 
@@ -73,7 +73,7 @@ impl log::Log for NodeLogger {
         let line = record.line();
         let message = record.args().to_string();
         let level = record.level();
-        self.queue
+        self.channel
             .try_send(move |mut cx| {
                 let level_arg: Handle<JsValue> =
                     cx.number(u32::from(LogLevel::from(level))).upcast();

--- a/rust/bridge/shared/Cargo.toml
+++ b/rust/bridge/shared/Cargo.toml
@@ -27,7 +27,7 @@ uuid = "0.8"
 
 libc = { version = "0.2", optional = true }
 jni_crate = { version = "0.19", package = "jni", optional = true }
-neon = { version = "0.8", optional = true, default-features = false, features = ["napi-6"] }
+neon = { version = "0.9", optional = true, default-features = false, features = ["napi-6"] }
 linkme = { version = "0.2.4", optional = true }
 signal-neon-futures = { path = "../node/futures", optional = true }
 

--- a/rust/bridge/shared/src/node/storage.rs
+++ b/rust/bridge/shared/src/node/storage.rs
@@ -12,21 +12,21 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 pub struct NodePreKeyStore {
-    js_queue: EventQueue,
+    js_channel: Channel,
     store_object: Arc<Root<JsObject>>,
 }
 
 impl NodePreKeyStore {
     pub(crate) fn new(cx: &mut FunctionContext, store: Handle<JsObject>) -> Self {
         Self {
-            js_queue: cx.queue(),
+            js_channel: cx.channel(),
             store_object: Arc::new(store.root(cx)),
         }
     }
 
     async fn do_get_pre_key(&self, id: u32) -> Result<PreKeyRecord, String> {
         let store_object_shared = self.store_object.clone();
-        JsFuture::get_promise(&self.js_queue, move |cx| {
+        JsFuture::get_promise(&self.js_channel, move |cx| {
             let store_object = store_object_shared.to_inner(cx);
             let id = id.convert_into(cx)?;
             let result = call_method(cx, store_object, "_getPreKey", vec![id.upcast()])?;
@@ -49,7 +49,7 @@ impl NodePreKeyStore {
 
     async fn do_save_pre_key(&self, id: u32, record: PreKeyRecord) -> Result<(), String> {
         let store_object_shared = self.store_object.clone();
-        JsFuture::get_promise(&self.js_queue, move |cx| {
+        JsFuture::get_promise(&self.js_channel, move |cx| {
             let store_object = store_object_shared.to_inner(cx);
             let id: Handle<JsNumber> = id.convert_into(cx)?;
             let record: Handle<JsValue> = record.convert_into(cx)?;
@@ -73,7 +73,7 @@ impl NodePreKeyStore {
 
     async fn do_remove_pre_key(&self, id: u32) -> Result<(), String> {
         let store_object_shared = self.store_object.clone();
-        JsFuture::get_promise(&self.js_queue, move |cx| {
+        JsFuture::get_promise(&self.js_channel, move |cx| {
             let store_object = store_object_shared.to_inner(cx);
             let id: Handle<JsNumber> = id.convert_into(cx)?;
             let result = call_method(cx, store_object, "_removePreKey", vec![id.upcast()])?
@@ -136,21 +136,21 @@ impl PreKeyStore for NodePreKeyStore {
 }
 
 pub struct NodeSignedPreKeyStore {
-    js_queue: EventQueue,
+    js_channel: Channel,
     store_object: Arc<Root<JsObject>>,
 }
 
 impl NodeSignedPreKeyStore {
     pub(crate) fn new(cx: &mut FunctionContext, store: Handle<JsObject>) -> Self {
         Self {
-            js_queue: cx.queue(),
+            js_channel: cx.channel(),
             store_object: Arc::new(store.root(cx)),
         }
     }
 
     async fn do_get_signed_pre_key(&self, id: u32) -> Result<SignedPreKeyRecord, String> {
         let store_object_shared = self.store_object.clone();
-        JsFuture::get_promise(&self.js_queue, move |cx| {
+        JsFuture::get_promise(&self.js_channel, move |cx| {
             let store_object = store_object_shared.to_inner(cx);
             let id = id.convert_into(cx)?;
             let result = call_method(cx, store_object, "_getSignedPreKey", vec![id.upcast()])?;
@@ -177,7 +177,7 @@ impl NodeSignedPreKeyStore {
         record: SignedPreKeyRecord,
     ) -> Result<(), String> {
         let store_object_shared = self.store_object.clone();
-        JsFuture::get_promise(&self.js_queue, move |cx| {
+        JsFuture::get_promise(&self.js_channel, move |cx| {
             let store_object = store_object_shared.to_inner(cx);
             let id: Handle<JsNumber> = id.convert_into(cx)?;
             let record: Handle<JsValue> = record.convert_into(cx)?;
@@ -236,21 +236,21 @@ impl SignedPreKeyStore for NodeSignedPreKeyStore {
 }
 
 pub struct NodeSessionStore {
-    js_queue: EventQueue,
+    js_channel: Channel,
     store_object: Arc<Root<JsObject>>,
 }
 
 impl NodeSessionStore {
     pub(crate) fn new(cx: &mut FunctionContext, store: Handle<JsObject>) -> Self {
         Self {
-            js_queue: cx.queue(),
+            js_channel: cx.channel(),
             store_object: Arc::new(store.root(cx)),
         }
     }
 
     async fn do_get_session(&self, name: ProtocolAddress) -> Result<Option<SessionRecord>, String> {
         let store_object_shared = self.store_object.clone();
-        JsFuture::get_promise(&self.js_queue, move |cx| {
+        JsFuture::get_promise(&self.js_channel, move |cx| {
             let store_object = store_object_shared.to_inner(cx);
             let name: Handle<JsValue> = name.convert_into(cx)?;
             let result = call_method(cx, store_object, "_getSession", vec![name])?;
@@ -283,7 +283,7 @@ impl NodeSessionStore {
         record: SessionRecord,
     ) -> Result<(), String> {
         let store_object_shared = self.store_object.clone();
-        JsFuture::get_promise(&self.js_queue, move |cx| {
+        JsFuture::get_promise(&self.js_channel, move |cx| {
             let store_object = store_object_shared.to_inner(cx);
             let name = name.convert_into(cx)?;
             let record = record.convert_into(cx)?;
@@ -342,21 +342,21 @@ impl SessionStore for NodeSessionStore {
 }
 
 pub struct NodeIdentityKeyStore {
-    js_queue: EventQueue,
+    js_channel: Channel,
     store_object: Arc<Root<JsObject>>,
 }
 
 impl NodeIdentityKeyStore {
     pub(crate) fn new(cx: &mut FunctionContext, store: Handle<JsObject>) -> Self {
         Self {
-            js_queue: cx.queue(),
+            js_channel: cx.channel(),
             store_object: Arc::new(store.root(cx)),
         }
     }
 
     async fn do_get_identity_key(&self) -> Result<PrivateKey, String> {
         let store_object_shared = self.store_object.clone();
-        JsFuture::get_promise(&self.js_queue, move |cx| {
+        JsFuture::get_promise(&self.js_channel, move |cx| {
             let store_object = store_object_shared.to_inner(cx);
             let result = call_method(cx, store_object, "_getIdentityKey", vec![])?;
             let result = result.downcast_or_throw(cx)?;
@@ -378,7 +378,7 @@ impl NodeIdentityKeyStore {
 
     async fn do_get_local_registration_id(&self) -> Result<u32, String> {
         let store_object_shared = self.store_object.clone();
-        JsFuture::get_promise(&self.js_queue, move |cx| {
+        JsFuture::get_promise(&self.js_channel, move |cx| {
             let store_object = store_object_shared.to_inner(cx);
             let result = call_method(cx, store_object, "_getLocalRegistrationId", vec![])?
                 .downcast_or_throw(cx)?;
@@ -400,7 +400,7 @@ impl NodeIdentityKeyStore {
 
     async fn do_get_identity(&self, name: ProtocolAddress) -> Result<Option<PublicKey>, String> {
         let store_object_shared = self.store_object.clone();
-        JsFuture::get_promise(&self.js_queue, move |cx| {
+        JsFuture::get_promise(&self.js_channel, move |cx| {
             let store_object = store_object_shared.to_inner(cx);
             let name: Handle<JsValue> = name.convert_into(cx)?;
             let result = call_method(cx, store_object, "_getIdentity", vec![name])?;
@@ -433,7 +433,7 @@ impl NodeIdentityKeyStore {
         key: PublicKey,
     ) -> Result<bool, String> {
         let store_object_shared = self.store_object.clone();
-        JsFuture::get_promise(&self.js_queue, move |cx| {
+        JsFuture::get_promise(&self.js_channel, move |cx| {
             let store_object = store_object_shared.to_inner(cx);
             let name: Handle<JsValue> = name.convert_into(cx)?;
             let key: Handle<JsValue> = key.convert_into(cx)?;
@@ -462,7 +462,7 @@ impl NodeIdentityKeyStore {
         direction: Direction,
     ) -> Result<bool, String> {
         let store_object_shared = self.store_object.clone();
-        JsFuture::get_promise(&self.js_queue, move |cx| {
+        JsFuture::get_promise(&self.js_channel, move |cx| {
             let store_object = store_object_shared.to_inner(cx);
             let name: Handle<JsValue> = name.convert_into(cx)?;
             let key: Handle<JsValue> = key.convert_into(cx)?;
@@ -559,14 +559,14 @@ impl IdentityKeyStore for NodeIdentityKeyStore {
 }
 
 pub struct NodeSenderKeyStore {
-    js_queue: EventQueue,
+    js_channel: Channel,
     store_object: Arc<Root<JsObject>>,
 }
 
 impl NodeSenderKeyStore {
     pub(crate) fn new(cx: &mut FunctionContext, store: Handle<JsObject>) -> Self {
         Self {
-            js_queue: cx.queue(),
+            js_channel: cx.channel(),
             store_object: Arc::new(store.root(cx)),
         }
     }
@@ -577,7 +577,7 @@ impl NodeSenderKeyStore {
         distribution_id: Uuid,
     ) -> Result<Option<SenderKeyRecord>, String> {
         let store_object_shared = self.store_object.clone();
-        JsFuture::get_promise(&self.js_queue, move |cx| {
+        JsFuture::get_promise(&self.js_channel, move |cx| {
             let store_object = store_object_shared.to_inner(cx);
             let sender: Handle<JsValue> = sender.convert_into(cx)?;
             let distribution_id: Handle<JsValue> = distribution_id.convert_into(cx)?.upcast();
@@ -617,7 +617,7 @@ impl NodeSenderKeyStore {
         record: SenderKeyRecord,
     ) -> Result<(), String> {
         let store_object_shared = self.store_object.clone();
-        JsFuture::get_promise(&self.js_queue, move |cx| {
+        JsFuture::get_promise(&self.js_channel, move |cx| {
             let store_object = store_object_shared.to_inner(cx);
             let sender: Handle<JsValue> = sender.convert_into(cx)?;
             let distribution_id: Handle<JsValue> = distribution_id.convert_into(cx)?.upcast();


### PR DESCRIPTION
- Drop our fork of Neon now that our changes have been integrated
- Adopt rename of EventQueue to Channel
- Add a `napi-6` feature to signal-neon-futures to make it easier to test under the configuration we're actually shipping