### PR TITLE
SSv2: when fetching a registration ID fails, mention the recipient

### DIFF
--- a/rust/protocol/src/sealed_sender.rs
+++ b/rust/protocol/src/sealed_sender.rs
@@ -919,7 +919,18 @@ pub async fn sealed_sender_multi_recipient_encrypt<R: Rng + CryptoRng>(
             .await?
             .ok_or_else(|| SignalProtocolError::SessionNotFound(format!("{}", destination)))?;
 
-        let their_registration_id = session.remote_registration_id()?;
+        let their_registration_id = session.remote_registration_id().map_err(|_| {
+            SignalProtocolError::InvalidState(
+                "sealed_sender_multi_recipient_encrypt",
+                format!(
+                    concat!(
+                        "cannot get registration ID from session with {} ",
+                        "(maybe it was recently archived)"
+                    ),
+                    destination
+                ),
+            )
+        })?;
         let their_registration_id = u16::try_from(their_registration_id).map_err(|_| {
             SignalProtocolError::InvalidState(
                 "remote_registration_id",

--- a/rust/protocol/tests/sealed_sender.rs
+++ b/rust/protocol/tests/sealed_sender.rs
@@ -661,6 +661,111 @@ fn test_sealed_sender_multi_recipient() -> Result<(), SignalProtocolError> {
 }
 
 #[test]
+fn test_sealed_sender_multi_recipient_encrypt_with_archived_session(
+) -> Result<(), SignalProtocolError> {
+    async {
+        let mut rng = OsRng;
+
+        let alice_device_id = 23;
+        let bob_device_id = 42;
+
+        let alice_e164 = "+14151111111".to_owned();
+
+        let alice_uuid = "9d0652a3-dcc3-4d11-975f-74d61598733f".to_string();
+        let bob_uuid = "796abedb-ca4e-4f18-8803-1fde5b921f9f".to_string();
+
+        let bob_uuid_address = ProtocolAddress::new(bob_uuid.clone(), bob_device_id);
+
+        let mut alice_store = support::test_in_memory_protocol_store()?;
+        let mut bob_store = support::test_in_memory_protocol_store()?;
+
+        let alice_pubkey = *alice_store.get_identity_key_pair(None).await?.public_key();
+
+        let bob_pre_key_bundle = create_pre_key_bundle(&mut bob_store, &mut rng).await?;
+
+        process_prekey_bundle(
+            &bob_uuid_address,
+            &mut alice_store.session_store,
+            &mut alice_store.identity_store,
+            &bob_pre_key_bundle,
+            &mut rng,
+            None,
+        )
+        .await?;
+
+        let trust_root = KeyPair::generate(&mut rng);
+        let server_key = KeyPair::generate(&mut rng);
+
+        let server_cert =
+            ServerCertificate::new(1, server_key.public_key, &trust_root.private_key, &mut rng)?;
+
+        let expires = 1605722925;
+
+        let sender_cert = SenderCertificate::new(
+            alice_uuid.clone(),
+            Some(alice_e164.clone()),
+            alice_pubkey,
+            alice_device_id,
+            expires,
+            server_cert,
+            &server_key.private_key,
+            &mut rng,
+        )?;
+
+        let alice_ptext = vec![1, 2, 3, 23, 99];
+        let alice_message = message_encrypt(
+            &alice_ptext,
+            &bob_uuid_address,
+            &mut alice_store.session_store,
+            &mut alice_store.identity_store,
+            None,
+        )
+        .await?;
+
+        let alice_usmc = UnidentifiedSenderMessageContent::new(
+            alice_message.message_type(),
+            sender_cert.clone(),
+            alice_message.serialize().to_vec(),
+            ContentHint::Default,
+            None,
+        )?;
+
+        let recipients = [&bob_uuid_address];
+        let mut session = alice_store
+            .session_store
+            .load_session(&bob_uuid_address, None)
+            .await?
+            .expect("present");
+        session.archive_current_state()?;
+        match sealed_sender_multi_recipient_encrypt(
+            &recipients,
+            &[&session],
+            &alice_usmc,
+            &mut alice_store.identity_store,
+            None,
+            &mut rng,
+        )
+        .await
+        {
+            Ok(_) => panic!("should have failed"),
+            Err(e) => {
+                // Make sure we mention *which* recipient's session failed.
+                let description = e.to_string();
+                assert!(
+                    description.contains(&bob_uuid_address.to_string()),
+                    "should mention recipient in message \"{}\"",
+                    description
+                );
+            }
+        }
+
+        Ok(())
+    }
+    .now_or_never()
+    .expect("sync")
+}
+
+#[test]
 fn test_decryption_error_in_sealed_sender() -> Result<(), SignalProtocolError> {
     async {
         let mut rng = OsRng;


### PR DESCRIPTION
...in the error. This should help apps debug when a session is archived but they still think a recipient is prepared to receive sender-key messages. (If they were sending 1:1 messages, they would have caught this earlier.)