### PR TITLE
protocol: Add a fuzz target that runs interactions between two clients

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -160,6 +160,12 @@ jobs:
     - name: Clippy
       run: cargo clippy --workspace --all-targets -- -D warnings
 
+    - name: Clippy (protocol fuzzing)
+      run: cargo clippy --all-targets -- -D warnings
+      working-directory: rust/protocol/fuzz
+      env:
+        RUSTFLAGS: --cfg fuzzing
+
   java:
     name: Java
 

--- a/rust/protocol/fuzz/.gitignore
+++ b/rust/protocol/fuzz/.gitignore
@@ -1,0 +1,5 @@
+Cargo.lock
+target
+corpus
+artifacts
+coverage

--- a/rust/protocol/fuzz/Cargo.toml
+++ b/rust/protocol/fuzz/Cargo.toml
@@ -1,0 +1,30 @@
+
+[package]
+name = "libsignal-protocol-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+env_logger = { version = "0.8.1" }
+futures-util = "0.3.7"
+libfuzzer-sys = "0.4"
+log = "0.4"
+rand = "0.7.3"
+
+[dependencies.libsignal-protocol]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "interaction"
+path = "fuzz_targets/interaction.rs"
+test = false
+doc = false

--- a/rust/protocol/fuzz/README.md
+++ b/rust/protocol/fuzz/README.md
@@ -1,0 +1,13 @@
+This directory contains fuzz targets used with `cargo fuzz`.
+
+```
+// In the parent directory (rust/protocol)
+cargo install cargo-fuzz
+cargo fuzz list
+cargo fuzz run <fuzz-target>
+
+// If you find a crash
+RUST_BACKTRACE=1 cargo fuzz run -D <fuzz-target> <crash-artifact>
+```
+
+For more information, including how to check the coverage of the explored corpus, see <https://rust-fuzz.github.io>.

--- a/rust/protocol/fuzz/fuzz_targets/interaction.rs
+++ b/rust/protocol/fuzz/fuzz_targets/interaction.rs
@@ -1,0 +1,271 @@
+//
+// Copyright 2021 Signal Messenger, LLC.
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+#![no_main]
+
+use std::convert::TryFrom;
+
+use futures_util::FutureExt;
+use libfuzzer_sys::fuzz_target;
+use libsignal_protocol::*;
+use log::*;
+use rand::prelude::*;
+
+async fn process_pre_key(
+    my_name: &str,
+    my_store: &mut InMemSignalProtocolStore,
+    their_store: &mut InMemSignalProtocolStore,
+    their_address: &ProtocolAddress,
+    use_one_time_pre_key: bool,
+    rng: &mut (impl Rng + CryptoRng),
+) {
+    info!("{}:   processing a new pre-key bundle", my_name);
+    let their_signed_pre_key_pair = KeyPair::generate(rng);
+    let their_signed_pre_key_public = their_signed_pre_key_pair.public_key.serialize();
+    let their_signed_pre_key_signature = their_store
+        .get_identity_key_pair(None)
+        .await
+        .unwrap()
+        .private_key()
+        .calculate_signature(&their_signed_pre_key_public, rng)
+        .unwrap();
+
+    let signed_pre_key_id = rng.gen_range(0, 0xFF_FFFF);
+
+    their_store
+        .save_signed_pre_key(
+            signed_pre_key_id,
+            &SignedPreKeyRecord::new(
+                signed_pre_key_id,
+                /*timestamp*/ 42,
+                &their_signed_pre_key_pair,
+                &their_signed_pre_key_signature,
+            ),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let pre_key_info = if use_one_time_pre_key {
+        let pre_key_id = rng.gen_range(0, 0xFF_FFFF);
+        let one_time_pre_key = KeyPair::generate(rng);
+
+        their_store
+            .save_pre_key(
+                pre_key_id,
+                &PreKeyRecord::new(pre_key_id, &one_time_pre_key),
+                None,
+            )
+            .await
+            .unwrap();
+        Some((pre_key_id, one_time_pre_key.public_key))
+    } else {
+        None
+    };
+
+    let their_pre_key_bundle = PreKeyBundle::new(
+        their_store.get_local_registration_id(None).await.unwrap(),
+        1, // device id
+        pre_key_info,
+        signed_pre_key_id,
+        their_signed_pre_key_pair.public_key,
+        their_signed_pre_key_signature.into_vec(),
+        *their_store
+            .get_identity_key_pair(None)
+            .await
+            .unwrap()
+            .identity_key(),
+    )
+    .unwrap();
+
+    process_prekey_bundle(
+        their_address,
+        &mut my_store.session_store,
+        &mut my_store.identity_store,
+        &their_pre_key_bundle,
+        rng,
+        None,
+    )
+    .await
+    .unwrap();
+}
+
+async fn send_message(
+    my_name: &str,
+    my_store: &mut InMemSignalProtocolStore,
+    their_store: &mut InMemSignalProtocolStore,
+    their_address: &ProtocolAddress,
+    their_message_queue: &mut Vec<(CiphertextMessage, Box<[u8]>)>,
+    rng: &mut (impl Rng + CryptoRng),
+) {
+    info!("{}: sending message", my_name);
+    if my_store
+        .load_session(their_address, None)
+        .await
+        .unwrap()
+        .map(|session| !session.has_current_session_state())
+        .unwrap_or(true)
+    {
+        process_pre_key(
+            my_name,
+            my_store,
+            their_store,
+            their_address,
+            rng.gen_bool(0.75),
+            rng,
+        )
+        .await;
+    }
+
+    let length = rng.gen_range(0, 140);
+    let mut buffer = vec![0; length];
+    rng.fill_bytes(&mut buffer);
+
+    let outgoing_message = message_encrypt(
+        &buffer,
+        their_address,
+        &mut my_store.session_store,
+        &mut my_store.identity_store,
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Test serialization ahead of time.
+    let incoming_message = match outgoing_message.message_type() {
+        CiphertextMessageType::PreKey => CiphertextMessage::PreKeySignalMessage(
+            PreKeySignalMessage::try_from(outgoing_message.serialize()).unwrap(),
+        ),
+        CiphertextMessageType::Whisper => CiphertextMessage::SignalMessage(
+            SignalMessage::try_from(outgoing_message.serialize()).unwrap(),
+        ),
+        other_type => panic!("unexpected type {:?}", other_type),
+    };
+
+    their_message_queue.push((incoming_message, buffer.into()));
+}
+
+async fn receive_messages(
+    my_name: &str,
+    my_store: &mut InMemSignalProtocolStore,
+    my_message_queue: &mut Vec<(CiphertextMessage, Box<[u8]>)>,
+    their_address: &ProtocolAddress,
+    rng: &mut (impl Rng + CryptoRng),
+) {
+    info!("{}: receiving messages", my_name);
+    for (incoming_message, expected) in my_message_queue.drain(..) {
+        let decrypted = message_decrypt(
+            &incoming_message,
+            their_address,
+            &mut my_store.session_store,
+            &mut my_store.identity_store,
+            &mut my_store.pre_key_store,
+            &mut my_store.signed_pre_key_store,
+            rng,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(expected, decrypted.into());
+    }
+}
+
+async fn archive_session(
+    my_name: &str,
+    my_store: &mut InMemSignalProtocolStore,
+    their_address: &ProtocolAddress,
+) {
+    if let Some(mut session) = my_store.load_session(their_address, None).await.unwrap() {
+        info!("{}: archiving session", my_name);
+        session.archive_current_state().unwrap();
+        my_store
+            .store_session(their_address, &session, None)
+            .await
+            .unwrap()
+    }
+}
+
+fuzz_target!(|data: (u64, &[u8])| {
+    let _ = env_logger::try_init();
+
+    let (seed, actions) = data;
+    async {
+        let mut csprng = StdRng::seed_from_u64(seed);
+
+        let alice_address = ProtocolAddress::new("+14151111111".to_owned(), 1);
+        let bob_address = ProtocolAddress::new("+14151111112".to_owned(), 1);
+
+        let mut alice_store =
+            InMemSignalProtocolStore::new(IdentityKeyPair::generate(&mut csprng), csprng.gen())
+                .unwrap();
+        let mut bob_store =
+            InMemSignalProtocolStore::new(IdentityKeyPair::generate(&mut csprng), csprng.gen())
+                .unwrap();
+
+        let mut alice_queue = Vec::new();
+        let mut bob_queue = Vec::new();
+
+        for action in actions {
+            let (my_name, my_store, my_queue, their_store, their_address, their_queue) =
+                match action & 1 {
+                    0 => (
+                        "alice",
+                        &mut alice_store,
+                        &mut alice_queue,
+                        &mut bob_store,
+                        &bob_address,
+                        &mut bob_queue,
+                    ),
+                    1 => (
+                        "bob",
+                        &mut bob_store,
+                        &mut bob_queue,
+                        &mut alice_store,
+                        &alice_address,
+                        &mut alice_queue,
+                    ),
+                    _ => unreachable!(),
+                };
+            match action >> 1 {
+                0 => {
+                    if my_queue.len() < 40 && their_queue.len() < 40 {
+                        // Only archive if it can't result in old sessions getting expired.
+                        // We're not testing that.
+                        archive_session(my_name, my_store, their_address).await
+                    }
+                },
+                1..=32 => {
+                    receive_messages(my_name, my_store, my_queue, their_address, &mut csprng).await
+                }
+                33..=48 => {
+                    info!("{}: drop an incoming message", my_name);
+                    my_queue.pop();
+                }
+                49..=56 => {
+                    info!("{}: shuffle incoming messages", my_name);
+                    my_queue.shuffle(&mut csprng);
+                }
+                _ => {
+                    if their_queue.len() < 1_500 {
+                        // Only send if it can't result in a too-long chain.
+                        // We're not testing that.
+                        send_message(
+                            my_name,
+                            my_store,
+                            their_store,
+                            their_address,
+                            their_queue,
+                            &mut csprng,
+                        )
+                        .await
+                    }
+                }
+            }
+        }
+    }
+    .now_or_never()
+    .expect("sync");
+});

--- a/rust/protocol/src/protocol.rs
+++ b/rust/protocol/src/protocol.rs
@@ -146,7 +146,8 @@ impl SignalMessage {
         let their_mac = &self.serialized[self.serialized.len() - Self::MAC_LENGTH..];
         let result: bool = our_mac.ct_eq(their_mac).into();
         if !result {
-            log::error!(
+            // A warning instead of an error because we try multiple sessions.
+            log::warn!(
                 "Bad Mac! Their Mac: {} Our Mac: {}",
                 hex::encode(their_mac),
                 hex::encode(our_mac)

--- a/rust/protocol/src/session_cipher.rs
+++ b/rust/protocol/src/session_cipher.rs
@@ -344,7 +344,8 @@ fn decrypt_message_with_record<R: Rng + CryptoRng>(
     csprng: &mut R,
 ) -> Result<Vec<u8>> {
     let log_decryption_failure = |state: &SessionState, error: &SignalProtocolError| {
-        log::error!(
+        // A warning rather than an error because we try multiple sessions.
+        log::warn!(
             "Failed to decrypt whisper message with ratchet key: {} and counter: {}. \
              Session loaded for {}. Local session has base key: {} and counter: {}. {}",
             ciphertext
@@ -372,11 +373,9 @@ fn decrypt_message_with_record<R: Rng + CryptoRng>(
             Ok(ptext) => {
                 log::debug!(
                     "successfully decrypted with current session state (base key {})",
-                    hex::encode(
-                        current_state
-                            .sender_ratchet_key_for_logging()
-                            .expect("successful decrypt always has a valid base key")
-                    ),
+                    current_state
+                        .sender_ratchet_key_for_logging()
+                        .expect("successful decrypt always has a valid base key"),
                 );
                 record.set_session_state(current_state)?; // update the state
                 return Ok(ptext);
@@ -403,11 +402,9 @@ fn decrypt_message_with_record<R: Rng + CryptoRng>(
             Ok(ptext) => {
                 log::info!(
                     "successfully decrypted with PREVIOUS session state (base key {})",
-                    hex::encode(
-                        previous
-                            .sender_ratchet_key_for_logging()
-                            .expect("successful decrypt always has a valid base key")
-                    ),
+                    previous
+                        .sender_ratchet_key_for_logging()
+                        .expect("successful decrypt always has a valid base key"),
                 );
                 updated_session = Some((ptext, idx, updated));
                 break;


### PR DESCRIPTION
Based on the fuzzing input (provided by [cargo-fuzz](https://rust-fuzz.github.io/book/cargo-fuzz.html)), this simulates message sends and receives, out-of-order delivery, dropped messages, and session resets, solely to find bugs in happy-path interaction between two clients.

While here, improve the logging of 1:1 decryption:

- Downgrade per-session decryption errors to warnings, because we try multiple sessions for each decryption and emit a roll-up error at the end.

- Remove some accidental double hex-encoding (as in, we were hex-encoding the ASCII hex representation of a slice).
