### PR TITLE
protocol: More logging for successful decryption of 1:1 messages

### DIFF
--- a/rust/protocol/src/sealed_sender.rs
+++ b/rust/protocol/src/sealed_sender.rs
@@ -535,7 +535,7 @@ impl UnidentifiedSenderMessage {
             ));
         }
         let version = data[0] >> 4;
-        log::info!(
+        log::debug!(
             "deserializing UnidentifiedSenderMessage with version {}",
             version
         );

--- a/rust/protocol/src/session.rs
+++ b/rust/protocol/src/session.rs
@@ -49,6 +49,7 @@ pub async fn process_prekey(
 
     let unsigned_pre_key_id = process_prekey_v3(
         message,
+        remote_address,
         session_record,
         signed_prekey_store,
         pre_key_store,
@@ -66,6 +67,7 @@ pub async fn process_prekey(
 
 async fn process_prekey_v3(
     message: &PreKeySignalMessage,
+    remote_address: &ProtocolAddress,
     session_record: &mut SessionRecord,
     signed_prekey_store: &mut dyn SignedPreKeyStore,
     pre_key_store: &mut dyn PreKeyStore,
@@ -86,6 +88,7 @@ async fn process_prekey_v3(
         .key_pair()?;
 
     let our_one_time_pre_key_pair = if let Some(pre_key_id) = message.pre_key_id() {
+        log::info!("processing PreKey message from {}", remote_address);
         Some(
             pre_key_store
                 .get_pre_key(pre_key_id, ctx)
@@ -93,7 +96,10 @@ async fn process_prekey_v3(
                 .key_pair()?,
         )
     } else {
-        log::warn!("Processing PreKey message which had no one-time prekey");
+        log::warn!(
+            "processing PreKey message from {} which had no one-time prekey",
+            remote_address
+        );
         None
     };
 

--- a/rust/protocol/src/session_cipher.rs
+++ b/rust/protocol/src/session_cipher.rs
@@ -371,8 +371,9 @@ fn decrypt_message_with_record<R: Rng + CryptoRng>(
 
         match result {
             Ok(ptext) => {
-                log::debug!(
-                    "successfully decrypted with current session state (base key {})",
+                log::info!(
+                    "decrypted message from {} with current session state (base key {})",
+                    remote_address,
                     current_state
                         .sender_ratchet_key_for_logging()
                         .expect("successful decrypt always has a valid base key"),
@@ -401,7 +402,8 @@ fn decrypt_message_with_record<R: Rng + CryptoRng>(
         match result {
             Ok(ptext) => {
                 log::info!(
-                    "successfully decrypted with PREVIOUS session state (base key {})",
+                    "decrypted message from {} with PREVIOUS session state (base key {})",
+                    remote_address,
                     previous
                         .sender_ratchet_key_for_logging()
                         .expect("successful decrypt always has a valid base key"),


### PR DESCRIPTION
- Log on every successful decryption, including the session base key. (Previously this was just a debug-level log.)
- Log the sender for sucessful decryptions.
- Log when we process a pre-key message.
- To balance this out, don't log "we're about to deserialize a sealed sender message" (downgrade it to debug).