### PR TITLE
Java: don't eagerly strip libsignal_client.so; let gradle do it for us

### DIFF
--- a/java/build_jni.sh
+++ b/java/build_jni.sh
@@ -15,7 +15,6 @@ cd "${SCRIPT_DIR}"/..
 ANDROID_LIB_DIR=java/android/src/main/jniLibs
 DESKTOP_LIB_DIR=java/java/src/main/resources
 
-export RUSTFLAGS="-C link-args=-s"
 export CARGO_PROFILE_RELEASE_DEBUG=1 # enable line tables
 # On Linux, cdylibs don't include public symbols from their dependencies,
 # even if those symbols have been re-exported in the Rust source.

--- a/java/check_code_size.py
+++ b/java/check_code_size.py
@@ -20,7 +20,8 @@ def warn(message):
 our_abs_dir = os.path.dirname(os.path.realpath(__file__))
 
 lib_size = os.path.getsize(os.path.join(
-    our_abs_dir, 'android', 'src', 'main', 'jniLibs', 'arm64-v8a', 'libsignal_jni.so'))
+    our_abs_dir, 'android', 'build', 'intermediates', 'stripped_native_libs', 'release', 'out',
+    'lib', 'arm64-v8a', 'libsignal_jni.so'))
 
 with open(os.path.join(our_abs_dir, 'code_size.json')) as old_sizes_file:
     old_sizes = json.load(old_sizes_file)


### PR DESCRIPTION
This is a step towards saving the debug info somewhere for the builds we actually ship on Android, but for now it's enough to have the unstripped libraries *available* for testing purposes.