### PR TITLE
Sealed sender v2: add an InvalidRegistrationId exception/error

### DIFF
--- a/java/java/src/main/java/org/signal/libsignal/metadata/ProtocolException.java
+++ b/java/java/src/main/java/org/signal/libsignal/metadata/ProtocolException.java
@@ -10,12 +10,14 @@ public abstract class ProtocolException extends Exception {
   private final int senderDevice;
 
   public ProtocolException(Exception e, String sender, int senderDevice) {
+    super(e);
     this.content      = Optional.absent();
     this.sender       = sender;
     this.senderDevice = senderDevice;
   }
 
   ProtocolException(Exception e, UnidentifiedSenderMessageContent content) {
+    super(e);
     this.content      = Optional.of(content);
     this.sender       = content.getSenderCertificate().getSender();
     this.senderDevice = content.getSenderCertificate().getSenderDeviceId();

--- a/java/java/src/main/java/org/signal/libsignal/metadata/SealedSessionCipher.java
+++ b/java/java/src/main/java/org/signal/libsignal/metadata/SealedSessionCipher.java
@@ -10,6 +10,7 @@ import org.whispersystems.libsignal.InvalidKeyException;
 import org.whispersystems.libsignal.InvalidKeyIdException;
 import org.whispersystems.libsignal.InvalidMacException;
 import org.whispersystems.libsignal.InvalidMessageException;
+import org.whispersystems.libsignal.InvalidRegistrationIdException;
 import org.whispersystems.libsignal.InvalidVersionException;
 import org.whispersystems.libsignal.LegacyMessageException;
 import org.whispersystems.libsignal.NoSessionException;
@@ -79,7 +80,9 @@ public class SealedSessionCipher {
   }
 
   public byte[] multiRecipientEncrypt(List<SignalProtocolAddress> recipients, UnidentifiedSenderMessageContent content)
-      throws InvalidKeyException, NoSessionException, UntrustedIdentityException
+      throws
+      InvalidKeyException, InvalidRegistrationIdException, NoSessionException,
+      UntrustedIdentityException
   {
     List<SessionRecord> recipientSessions =
       this.signalProtocolStore.loadExistingSessions(recipients);

--- a/java/java/src/main/java/org/whispersystems/libsignal/InvalidRegistrationIdException.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/InvalidRegistrationIdException.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (C) 2021 Open Whisper Systems
+ *
+ * Licensed according to the LICENSE file in this repository.
+ */
+package org.whispersystems.libsignal;
+
+public class InvalidRegistrationIdException extends Exception {
+
+  private final SignalProtocolAddress address;
+
+  public InvalidRegistrationIdException(SignalProtocolAddress address, String message) {
+    super(message);
+    this.address = address;
+  }
+
+  public SignalProtocolAddress getAddress() {
+    return address;
+  }
+}

--- a/java/tests/src/test/java/org/signal/libsignal/metadata/SealedSessionCipherTest.java
+++ b/java/tests/src/test/java/org/signal/libsignal/metadata/SealedSessionCipherTest.java
@@ -11,6 +11,7 @@ import org.signal.libsignal.metadata.certificate.ServerCertificate;
 import org.whispersystems.libsignal.IdentityKeyPair;
 import org.whispersystems.libsignal.InvalidKeyException;
 import org.whispersystems.libsignal.InvalidMessageException;
+import org.whispersystems.libsignal.InvalidRegistrationIdException;
 import org.whispersystems.libsignal.LegacyMessageException;
 import org.whispersystems.libsignal.NoSessionException;
 import org.whispersystems.libsignal.SessionBuilder;
@@ -146,7 +147,7 @@ public class SealedSessionCipherTest extends TestCase {
     }
   }
 
-  public void testEncryptDecryptGroup() throws UntrustedIdentityException, InvalidKeyException, InvalidCertificateException, InvalidMessageException, InvalidMetadataMessageException, LegacyMessageException, NoSessionException, ProtocolDuplicateMessageException, ProtocolUntrustedIdentityException, ProtocolLegacyMessageException, ProtocolInvalidKeyException, InvalidMetadataVersionException, ProtocolInvalidVersionException, ProtocolInvalidMessageException, ProtocolInvalidKeyIdException, ProtocolNoSessionException, SelfSendException {
+  public void testEncryptDecryptGroup() throws UntrustedIdentityException, InvalidKeyException, InvalidCertificateException, InvalidMessageException, InvalidMetadataMessageException, InvalidRegistrationIdException, LegacyMessageException, NoSessionException, ProtocolDuplicateMessageException, ProtocolUntrustedIdentityException, ProtocolLegacyMessageException, ProtocolInvalidKeyException, InvalidMetadataVersionException, ProtocolInvalidVersionException, ProtocolInvalidMessageException, ProtocolInvalidKeyIdException, ProtocolNoSessionException, SelfSendException {
     TestInMemorySignalProtocolStore aliceStore = new TestInMemorySignalProtocolStore();
     TestInMemorySignalProtocolStore bobStore   = new TestInMemorySignalProtocolStore();
     SignalProtocolAddress bobAddress           = new SignalProtocolAddress("e80f7bbe-5b94-471e-bd8c-2173654ea3d1", 1);
@@ -188,7 +189,44 @@ public class SealedSessionCipherTest extends TestCase {
     assertTrue(Arrays.equals(plaintext.getGroupId().get(), new byte[]{42, 43}));
   }
 
-  public void testProtocolException() throws UntrustedIdentityException, InvalidKeyException, InvalidCertificateException, InvalidMessageException, InvalidMetadataMessageException, LegacyMessageException, NoSessionException, ProtocolDuplicateMessageException, ProtocolUntrustedIdentityException, ProtocolLegacyMessageException, ProtocolInvalidKeyException, InvalidMetadataVersionException, ProtocolInvalidVersionException, ProtocolInvalidMessageException, ProtocolInvalidKeyIdException, ProtocolNoSessionException, SelfSendException {
+
+  public void testEncryptGroupWithBadRegistrationId() throws UntrustedIdentityException, InvalidKeyException, InvalidCertificateException, InvalidMessageException, InvalidMetadataMessageException, InvalidRegistrationIdException, LegacyMessageException, NoSessionException, ProtocolDuplicateMessageException, ProtocolUntrustedIdentityException, ProtocolLegacyMessageException, ProtocolInvalidKeyException, InvalidMetadataVersionException, ProtocolInvalidVersionException, ProtocolInvalidMessageException, ProtocolInvalidKeyIdException, ProtocolNoSessionException, SelfSendException {
+    TestInMemorySignalProtocolStore aliceStore = new TestInMemorySignalProtocolStore();
+    TestInMemorySignalProtocolStore bobStore   = new TestInMemorySignalProtocolStore();
+    SignalProtocolAddress bobAddress           = new SignalProtocolAddress("e80f7bbe-5b94-471e-bd8c-2173654ea3d1", 1);
+
+    ECKeyPair          bobPreKey       = Curve.generateKeyPair();
+    IdentityKeyPair    bobIdentityKey  = bobStore.getIdentityKeyPair();
+    SignedPreKeyRecord bobSignedPreKey = generateSignedPreKey(bobIdentityKey, 2);
+
+    PreKeyBundle bobBundle = new PreKeyBundle(0x4000, 1, 1, bobPreKey.getPublicKey(), 2, bobSignedPreKey.getKeyPair().getPublicKey(), bobSignedPreKey.getSignature(), bobIdentityKey.getPublicKey());
+    SessionBuilder aliceSessionBuilder = new SessionBuilder(aliceStore, bobAddress);
+    aliceSessionBuilder.process(bobBundle);
+
+    ECKeyPair           trustRoot         = Curve.generateKeyPair();
+    SenderCertificate   senderCertificate = createCertificateFor(trustRoot, UUID.fromString("9d0652a3-dcc3-4d11-975f-74d61598733f"), "+14151111111", 1, aliceStore.getIdentityKeyPair().getPublicKey().getPublicKey(), 31337);
+    SealedSessionCipher aliceCipher       = new SealedSessionCipher(aliceStore, UUID.fromString("9d0652a3-dcc3-4d11-975f-74d61598733f"), "+14151111111", 1);
+
+    SignalProtocolAddress senderAddress = new SignalProtocolAddress("9d0652a3-dcc3-4d11-975f-74d61598733f", 1);
+    UUID distributionId = UUID.fromString("d1d1d1d1-7000-11eb-b32a-33b8a8a487a6");
+
+    GroupSessionBuilder aliceGroupSessionBuilder = new GroupSessionBuilder(aliceStore);
+    SenderKeyDistributionMessage sentAliceDistributionMessage = aliceGroupSessionBuilder.create(senderAddress, distributionId);
+
+    GroupCipher aliceGroupCipher = new GroupCipher(aliceStore, senderAddress);
+    CiphertextMessage ciphertextFromAlice = aliceGroupCipher.encrypt(distributionId, "smert ze smert".getBytes());
+
+    UnidentifiedSenderMessageContent usmcFromAlice = new UnidentifiedSenderMessageContent(ciphertextFromAlice, senderCertificate, UnidentifiedSenderMessageContent.CONTENT_HINT_IMPLICIT, Optional.of(new byte[]{42, 43}));
+
+    try {
+      byte[] aliceMessage = aliceCipher.multiRecipientEncrypt(Arrays.asList(bobAddress), usmcFromAlice);
+      fail("should have thrown");
+    } catch (InvalidRegistrationIdException e) {
+      assertEquals(e.getAddress(), bobAddress);
+    }
+  }
+
+  public void testProtocolException() throws UntrustedIdentityException, InvalidKeyException, InvalidCertificateException, InvalidMessageException, InvalidMetadataMessageException, InvalidRegistrationIdException, LegacyMessageException, NoSessionException, ProtocolDuplicateMessageException, ProtocolUntrustedIdentityException, ProtocolLegacyMessageException, ProtocolInvalidKeyException, InvalidMetadataVersionException, ProtocolInvalidVersionException, ProtocolInvalidMessageException, ProtocolInvalidKeyIdException, ProtocolNoSessionException, SelfSendException {
     TestInMemorySignalProtocolStore aliceStore = new TestInMemorySignalProtocolStore();
     TestInMemorySignalProtocolStore bobStore   = new TestInMemorySignalProtocolStore();
     SignalProtocolAddress bobAddress           = new SignalProtocolAddress("e80f7bbe-5b94-471e-bd8c-2173654ea3d1", 1);
@@ -221,6 +259,7 @@ public class SealedSessionCipherTest extends TestCase {
 
     try {
       bobCipher.decrypt(new CertificateValidator(trustRoot.getPublicKey()), bobMessage, 31335);
+      fail("should have thrown");
     } catch (ProtocolNoSessionException e) {
       assertEquals(e.getSender(), "+14151111111");
       assertEquals(e.getSenderDevice(), 1);

--- a/node/Address.ts
+++ b/node/Address.ts
@@ -1,0 +1,34 @@
+//
+// Copyright 2021 Signal Messenger, LLC.
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import * as Native from './Native';
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+const NativeImpl = require('node-gyp-build')(
+  __dirname + '/../..'
+) as typeof Native;
+
+export class ProtocolAddress {
+  readonly _nativeHandle: Native.ProtocolAddress;
+
+  private constructor(handle: Native.ProtocolAddress) {
+    this._nativeHandle = handle;
+  }
+
+  static _fromNativeHandle(handle: Native.ProtocolAddress): ProtocolAddress {
+    return new ProtocolAddress(handle);
+  }
+
+  static new(name: string, deviceId: number): ProtocolAddress {
+    return new ProtocolAddress(NativeImpl.ProtocolAddress_New(name, deviceId));
+  }
+
+  name(): string {
+    return NativeImpl.ProtocolAddress_Name(this);
+  }
+
+  deviceId(): number {
+    return NativeImpl.ProtocolAddress_DeviceId(this);
+  }
+}

--- a/node/index.ts
+++ b/node/index.ts
@@ -8,6 +8,9 @@ import * as uuid from 'uuid';
 import * as Errors from './Errors';
 export * from './Errors';
 
+import { ProtocolAddress } from './Address';
+export * from './Address';
+
 import * as Native from './Native';
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
 const NativeImpl = require('node-gyp-build')(
@@ -174,30 +177,6 @@ export class Aes256GcmSiv {
       nonce,
       associated_data
     );
-  }
-}
-
-export class ProtocolAddress {
-  readonly _nativeHandle: Native.ProtocolAddress;
-
-  private constructor(handle: Native.ProtocolAddress) {
-    this._nativeHandle = handle;
-  }
-
-  static _fromNativeHandle(handle: Native.ProtocolAddress): ProtocolAddress {
-    return new ProtocolAddress(handle);
-  }
-
-  static new(name: string, deviceId: number): ProtocolAddress {
-    return new ProtocolAddress(NativeImpl.ProtocolAddress_New(name, deviceId));
-  }
-
-  name(): string {
-    return NativeImpl.ProtocolAddress_Name(this);
-  }
-
-  deviceId(): number {
-    return NativeImpl.ProtocolAddress_DeviceId(this);
   }
 }
 

--- a/node/test/PublicAPITest.ts
+++ b/node/test/PublicAPITest.ts
@@ -61,10 +61,10 @@ class InMemoryIdentityKeyStore extends SignalClient.IdentityKeyStore {
   private localRegistrationId: number;
   private identityKey: SignalClient.PrivateKey;
 
-  constructor() {
+  constructor(localRegistrationId?: number) {
     super();
     this.identityKey = SignalClient.PrivateKey.generate();
-    this.localRegistrationId = 5;
+    this.localRegistrationId = localRegistrationId ?? 5;
   }
 
   async getIdentityKey(): Promise<SignalClient.PrivateKey> {
@@ -1303,6 +1303,119 @@ describe('SignalClient', () => {
       );
 
       assert.deepEqual(message, bPtext);
+    });
+
+    it('rejects invalid registration IDs', async () => {
+      const aKeys = new InMemoryIdentityKeyStore();
+      const bKeys = new InMemoryIdentityKeyStore(0x4000);
+
+      const aSess = new InMemorySessionStore();
+
+      const bPreKey = SignalClient.PrivateKey.generate();
+      const bSPreKey = SignalClient.PrivateKey.generate();
+
+      const aIdentityKey = await aKeys.getIdentityKey();
+      const bIdentityKey = await bKeys.getIdentityKey();
+
+      const aE164 = '+14151111111';
+
+      const aDeviceId = 1;
+      const bDeviceId = 3;
+
+      const aUuid = '9d0652a3-dcc3-4d11-975f-74d61598733f';
+      const bUuid = '796abedb-ca4e-4f18-8803-1fde5b921f9f';
+
+      const trustRoot = SignalClient.PrivateKey.generate();
+      const serverKey = SignalClient.PrivateKey.generate();
+
+      const serverCert = SignalClient.ServerCertificate.new(
+        1,
+        serverKey.getPublicKey(),
+        trustRoot
+      );
+
+      const expires = 1605722925;
+      const senderCert = SignalClient.SenderCertificate.new(
+        aUuid,
+        aE164,
+        aDeviceId,
+        aIdentityKey.getPublicKey(),
+        expires,
+        serverCert,
+        serverKey
+      );
+
+      const bPreKeyId = 31337;
+      const bSignedPreKeyId = 22;
+
+      const bSignedPreKeySig = bIdentityKey.sign(
+        bSPreKey.getPublicKey().serialize()
+      );
+
+      const bPreKeyBundle = SignalClient.PreKeyBundle.new(
+        0x4000,
+        bDeviceId,
+        bPreKeyId,
+        bPreKey.getPublicKey(),
+        bSignedPreKeyId,
+        bSPreKey.getPublicKey(),
+        bSignedPreKeySig,
+        bIdentityKey.getPublicKey()
+      );
+
+      const bAddress = SignalClient.ProtocolAddress.new(bUuid, bDeviceId);
+      await SignalClient.processPreKeyBundle(
+        bPreKeyBundle,
+        bAddress,
+        aSess,
+        aKeys
+      );
+
+      const aAddress = SignalClient.ProtocolAddress.new(aUuid, aDeviceId);
+
+      const distributionId = 'd1d1d1d1-7000-11eb-b32a-33b8a8a487a6';
+      const aSenderKeyStore = new InMemorySenderKeyStore();
+      await SignalClient.SenderKeyDistributionMessage.create(
+        aAddress,
+        distributionId,
+        aSenderKeyStore
+      );
+
+      const message = Buffer.from('0a0b0c', 'hex');
+
+      const aCtext = await SignalClient.groupEncrypt(
+        aAddress,
+        distributionId,
+        aSenderKeyStore,
+        message
+      );
+
+      const aUsmc = SignalClient.UnidentifiedSenderMessageContent.new(
+        aCtext,
+        senderCert,
+        SignalClient.ContentHint.Implicit,
+        Buffer.from([42])
+      );
+
+      try {
+        await SignalClient.sealedSenderMultiRecipientEncrypt(
+          aUsmc,
+          [bAddress],
+          aKeys,
+          aSess
+        );
+        assert.fail('should have thrown');
+      } catch (e) {
+        assert.instanceOf(e, Error);
+        assert.instanceOf(e, SignalClient.SignalClientErrorBase);
+        const err = e as SignalClient.SignalClientError;
+        assert.equal(err.name, 'InvalidRegistrationId');
+        assert.equal(err.code, SignalClient.ErrorCode.InvalidRegistrationId);
+        assert.exists(err.stack); // Make sure we're still getting the benefits of Error.
+        const registrationIdErr = err as SignalClient.InvalidRegistrationIdError;
+        assert.equal(registrationIdErr.addr.name(), bAddress.name());
+        assert.equal(registrationIdErr.addr.deviceId(), bAddress.deviceId());
+      }
     });
   });
 

--- a/rust/bridge/ffi/src/util.rs
+++ b/rust/bridge/ffi/src/util.rs
@@ -44,6 +44,7 @@ pub enum SignalErrorCode {
     InvalidKeyIdentifier = 70,
 
     SessionNotFound = 80,
+    InvalidRegistrationId = 81,
 
     DuplicatedMessage = 90,
 
@@ -105,6 +106,10 @@ impl From<&SignalFfiError> for SignalErrorCode {
 
             SignalFfiError::Signal(SignalProtocolError::SessionNotFound(_)) => {
                 SignalErrorCode::SessionNotFound
+            }
+
+            SignalFfiError::Signal(SignalProtocolError::InvalidRegistrationId(..)) => {
+                SignalErrorCode::InvalidRegistrationId
             }
 
             SignalFfiError::Signal(SignalProtocolError::FingerprintIdentifierMismatch) => {

--- a/rust/bridge/shared/src/jni/storage.rs
+++ b/rust/bridge/shared/src/jni/storage.rs
@@ -13,21 +13,6 @@ pub type JavaSignedPreKeyStore<'a> = JObject<'a>;
 pub type JavaSessionStore<'a> = JObject<'a>;
 pub type JavaSenderKeyStore<'a> = JObject<'a>;
 
-fn protocol_address_to_jobject<'a>(
-    env: &'a JNIEnv,
-    address: &ProtocolAddress,
-) -> Result<JObject<'a>, SignalJniError> {
-    let address_class = env.find_class("org/whispersystems/libsignal/SignalProtocolAddress")?;
-    let address_ctor_args = [
-        JObject::from(env.new_string(address.name())?).into(),
-        JValue::from(address.device_id().convert_into(env)?),
-    ];
-
-    let address_ctor_sig = jni_signature!((java.lang.String, int) -> void);
-    let address_jobject = env.new_object(address_class, address_ctor_sig, &address_ctor_args)?;
-    Ok(address_jobject)
-}
-
 pub struct JniIdentityKeyStore<'a> {
     env: &'a JNIEnv<'a>,
     store: JObject<'a>,

--- a/rust/bridge/shared/src/node/error.rs
+++ b/rust/bridge/shared/src/node/error.rs
@@ -125,11 +125,24 @@ impl SignalNodeError for SignalProtocolError {
             SignalProtocolError::UntrustedIdentity(addr) => {
                 let props = cx.empty_object();
                 let addr_string = cx.string(addr.name());
-                props.set(cx, "addr", addr_string)?;
+                props.set(cx, "_addr", addr_string)?;
                 new_js_error(
                     cx,
                     module,
                     Some("UntrustedIdentity"),
+                    &self.to_string(),
+                    operation_name,
+                    Some(props),
+                )
+            }
+            SignalProtocolError::InvalidRegistrationId(addr, _value) => {
+                let props = cx.empty_object();
+                let addr = addr.clone().convert_into(cx)?;
+                props.set(cx, "_addr", addr)?;
+                new_js_error(
+                    cx,
+                    module,
+                    Some("InvalidRegistrationId"),
                     &self.to_string(),
                     operation_name,
                     Some(props),

--- a/rust/protocol/src/error.rs
+++ b/rust/protocol/src/error.rs
@@ -51,6 +51,7 @@ pub enum SignalProtocolError {
 
     SessionNotFound(String),
     InvalidSessionStructure,
+    InvalidRegistrationId(crate::ProtocolAddress, u32),
 
     DuplicatedMessage(u32, u32),
     InvalidMessage(&'static str),
@@ -164,6 +165,13 @@ impl fmt::Display for SignalProtocolError {
                 write!(f, "session with '{}' not found", who)
             }
             SignalProtocolError::InvalidSessionStructure => write!(f, "invalid session structure"),
+            SignalProtocolError::InvalidRegistrationId(addr, value) => {
+                write!(
+                    f,
+                    "session for {} has invalid registration ID {:X}",
+                    addr, value
+                )
+            }
             SignalProtocolError::DuplicatedMessage(i, c) => {
                 write!(f, "message with old counter {} / {}", i, c)
             }

--- a/swift/Sources/SignalClient/DataStoreInMemory.swift
+++ b/swift/Sources/SignalClient/DataStoreInMemory.swift
@@ -18,7 +18,7 @@ private struct SenderKeyName: Hashable {
 public class InMemorySignalProtocolStore: IdentityKeyStore, PreKeyStore, SignedPreKeyStore, SessionStore, SenderKeyStore {
     private var publicKeys: [ProtocolAddress: IdentityKey] = [:]
     private var privateKey: IdentityKeyPair
-    private var deviceId: UInt32
+    private var registrationId: UInt32
     private var prekeyMap: [UInt32: PreKeyRecord] = [:]
     private var signedPrekeyMap: [UInt32: SignedPreKeyRecord] = [:]
     private var sessionMap: [ProtocolAddress: SessionRecord] = [:]
@@ -26,12 +26,12 @@ public class InMemorySignalProtocolStore: IdentityKeyStore, PreKeyStore, SignedP
 
     public init() {
         privateKey = IdentityKeyPair.generate()
-        deviceId = UInt32.random(in: 0...65535)
+        registrationId = UInt32.random(in: 0...0x3FFF)
     }
 
-    public init(identity: IdentityKeyPair, deviceId: UInt32) {
+    public init(identity: IdentityKeyPair, registrationId: UInt32) {
         self.privateKey = identity
-        self.deviceId = deviceId
+        self.registrationId = registrationId
     }
 
     public func identityKeyPair(context: StoreContext) throws -> IdentityKeyPair {
@@ -39,7 +39,7 @@ public class InMemorySignalProtocolStore: IdentityKeyStore, PreKeyStore, SignedP
     }
 
     public func localRegistrationId(context: StoreContext) throws -> UInt32 {
-        return deviceId
+        return registrationId
     }
 
     public func saveIdentity(_ identity: IdentityKey, for address: ProtocolAddress, context: StoreContext) throws -> Bool {

--- a/swift/Sources/SignalClient/Utils.swift
+++ b/swift/Sources/SignalClient/Utils.swift
@@ -73,6 +73,12 @@ internal func invokeFnReturningCiphertextMessage(fn: (UnsafeMutablePointer<Opaqu
     return CiphertextMessage(owned: handle)
 }
 
+internal func invokeFnReturningProtocolAddress(fn: (UnsafeMutablePointer<OpaquePointer?>?) -> SignalFfiErrorRef?) throws -> ProtocolAddress {
+    var handle: OpaquePointer?
+    try checkError(fn(&handle))
+    return ProtocolAddress(owned: handle!)
+}
+
 extension StoreContext {
     internal func withOpaquePointer<Result>(_ body: (UnsafeMutablePointer<StoreContext>) throws -> Result) rethrows -> Result {
         var selfAsPointer: StoreContext = self

--- a/swift/Sources/SignalFfi/signal_ffi.h
+++ b/swift/Sources/SignalFfi/signal_ffi.h
@@ -64,6 +64,7 @@ typedef enum {
   SignalErrorCode_UntrustedIdentity = 60,
   SignalErrorCode_InvalidKeyIdentifier = 70,
   SignalErrorCode_SessionNotFound = 80,
+  SignalErrorCode_InvalidRegistrationId = 81,
   SignalErrorCode_DuplicatedMessage = 90,
   SignalErrorCode_CallbackError = 100,
 } SignalErrorCode;
@@ -206,6 +207,8 @@ void signal_free_string(const char *buf);
 void signal_free_buffer(const unsigned char *buf, size_t buf_len);
 
 SignalFfiError *signal_error_get_message(const SignalFfiError *err, const char **out);
+
+SignalFfiError *signal_error_get_address(const SignalFfiError *err, SignalProtocolAddress **out);
 
 uint32_t signal_error_get_type(const SignalFfiError *err);
 

--- a/swift/Tests/.swiftlint.yml
+++ b/swift/Tests/.swiftlint.yml
@@ -1,0 +1,4 @@
+# Allow longer test files
+file_length:
+  warning: 1000
+  error: 1000


### PR DESCRIPTION
This dedicated error is thrown when a recipient has a registration ID that's out of the range used by Signal [0, 0x3FFF]. These IDs cannot be encoded in the sealed sender v2 format and are not supported, even though they don't cause any problems for 1:1 messages.