### PR TITLE
Tweak the build to be more friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ To build the Java/Android ``jar`` and ``aar``, and run the tests:
 ```shell
 $ cd java
 $ ./gradlew test
+$ ./gradlew build # if you need AAR outputs
 ```
 
 Alternately, a build system using Docker is available:
@@ -64,9 +65,6 @@ Alternately, a build system using Docker is available:
 $ cd java
 $ make java_test
 ```
-
-Local Java testing is also supported with `gradlew test` if none of the `ANDROID_*` environment
-variables are set.
 
 When exposing new APIs to Java, you will need to run `rust/bridge/jni/bin/gen_java_decl.py` in
 addition to rebuilding.

--- a/java/Makefile
+++ b/java/Makefile
@@ -18,12 +18,12 @@ java_build: DOCKER_EXTRA=$(shell [ -L build ] && P=$$(readlink build) && echo -v
 java_build: docker_image
 	$(DOCKER) run --rm --user $$(id -u):$$(id -g) \
 	  -v `cd .. && pwd`/:/home/libsignal/src $(DOCKER_EXTRA) $(DOCKER_IMAGE) \
-		sh -c "cd src/java; ./gradlew clean build"
+		sh -c "cd src/java; ./gradlew build"
 
 java_test: java_build
 	$(DOCKER) run --rm --user $$(id -u):$$(id -g) \
 	  -v `cd .. && pwd`/:/home/libsignal/src $(DOCKER_EXTRA) $(DOCKER_IMAGE) \
-		sh -c "cd src/java; ./gradlew clean test"
+		sh -c "cd src/java; ./gradlew test"
 
 SONATYPE_USERNAME     ?=
 SONATYPE_PASSWORD     ?=

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -25,6 +25,11 @@ task makeJniLibrariesDesktop(type:Exec) {
   commandLine './build_jni.sh', 'desktop'
 }
 
+task cargoClean(type:Exec) {
+  group 'Rust'
+  commandLine 'cargo', 'clean'
+}
+
 task clean(type: Delete) {
   description 'Clean JNI libs'
   delete fileTree('./android/src/main/jniLibs') {
@@ -36,6 +41,7 @@ task clean(type: Delete) {
     include '**/*.dll'
   }
 }
+clean.dependsOn(cargoClean)
 
 task makeAll() {
   group 'Rust'

--- a/swift/README.md
+++ b/swift/README.md
@@ -7,11 +7,12 @@ This is a binding to the Signal client code in rust/, implemented on top of the 
 
 1. Make sure you are using `use_frameworks!` in your Podfile. SignalClient is a Swift pod and as such cannot be compiled as a plain library.
 
-2. Add 'SignalClient' as a dependency in your Podfile:
+2. Add 'SignalClient' and 'SignalCoreKit' as dependencies in your Podfile:
 
         pod 'SignalClient', git: 'https://github.com/signalapp/libsignal-client.git'
+        pod 'SignalCoreKit', git: 'https://github.com/signalapp/SignalCoreKit.git'
 
-3. Use `pod install` or `pod update` to build the Rust library for both iOS simulator and iOS device
+3. Use `pod install` or `pod update` to build the Rust library for all targets. You may be prompted to install Rust dependencies (`cbindgen`, `rust-src`, `xargo`).
 
 4. Build as usual. The Rust library will automatically be linked into the built SignalClient.framework.
 

--- a/swift/build_ffi.sh
+++ b/swift/build_ffi.sh
@@ -99,6 +99,13 @@ if [[ -n "${USE_XARGO:-}" ]]; then
     printf "\n\t%s\n\n" "cargo install xargo" >&2
     exit 1
   fi
+  RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN:-$(cat ./rust-toolchain)}
+  if ! rustup "+${RUSTUP_TOOLCHAIN}" component list --installed | grep -q rust-src; then
+    echo 'error: rust-src component not installed' >&2
+    echo 'note: get it by running' >&2
+    printf "\n\t%s\n\n" "rustup +${RUSTUP_TOOLCHAIN} component add rust-src" >&2
+    exit 1
+  fi
   BUILD_CMD=xargo
 fi
 


### PR DESCRIPTION
- Add an error message for missing rust-src when using xargo (addresses #361)
- Update build instructions for Java and for Swift (addresses #363, among other improvements)
- Run `cargo clean` as part of `gradlew clean`, but don't clean every time when using the Docker build (addresses https://community.signalusers.org/t/build-libsignal-client-to-produce-signal-client-android-aar/36045/5)