### PR TITLE
Jrose/swift with native handle

### DIFF
--- a/swift/.swiftlint.yml
+++ b/swift/.swiftlint.yml
@@ -1,5 +1,6 @@
 disabled_rules:
 - cyclomatic_complexity
+- empty_enum_arguments
 - force_try
 - function_body_length
 - function_parameter_count

--- a/swift/Sources/SignalClient/Address.swift
+++ b/swift/Sources/SignalClient/Address.swift
@@ -6,20 +6,12 @@
 import SignalFfi
 
 public class ProtocolAddress: ClonableHandleOwner {
-    public init(name: String, deviceId: UInt32) throws {
+    public convenience init(name: String, deviceId: UInt32) throws {
         var handle: OpaquePointer?
         try checkError(signal_address_new(&handle,
                                           name,
                                           deviceId))
-        super.init(owned: handle!)
-    }
-
-    internal override init(borrowing handle: OpaquePointer?) {
-        super.init(borrowing: handle)
-    }
-
-    internal override init(owned handle: OpaquePointer) {
-        super.init(owned: handle)
+        self.init(owned: handle!)
     }
 
     internal override class func cloneNativeHandle(_ newHandle: inout OpaquePointer?, currentHandle: OpaquePointer?) -> SignalFfiErrorRef? {

--- a/swift/Sources/SignalClient/Address.swift
+++ b/swift/Sources/SignalClient/Address.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
@@ -23,17 +23,21 @@ public class ProtocolAddress: ClonableHandleOwner {
     }
 
     public var name: String {
-        return failOnError {
-            try invokeFnReturningString {
-                signal_address_get_name($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningString {
+                    signal_address_get_name($0, nativeHandle)
+                }
             }
         }
     }
 
     public var deviceId: UInt32 {
-        return failOnError {
-            try invokeFnReturningInteger {
-                signal_address_get_device_id($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningInteger {
+                    signal_address_get_device_id($0, nativeHandle)
+                }
             }
         }
     }

--- a/swift/Sources/SignalClient/Aes256GcmSiv.swift
+++ b/swift/Sources/SignalClient/Aes256GcmSiv.swift
@@ -1,19 +1,19 @@
 //
-// Copyright 2020 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
 import SignalFfi
 import Foundation
 
-public class Aes256GcmSiv: ClonableHandleOwner {
-    public init<Bytes: ContiguousBytes>(_ bytes: Bytes) throws {
+public class Aes256GcmSiv: NativeHandleOwner {
+    public convenience init<Bytes: ContiguousBytes>(_ bytes: Bytes) throws {
         let handle: OpaquePointer? = try bytes.withUnsafeBytes {
             var result: OpaquePointer?
             try checkError(signal_aes256_gcm_siv_new(&result, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count))
             return result
         }
-        super.init(owned: handle!)
+        self.init(owned: handle!)
     }
 
     internal override class func destroyNativeHandle(_ handle: OpaquePointer) -> SignalFfiErrorRef? {

--- a/swift/Sources/SignalClient/Aes256GcmSiv.swift
+++ b/swift/Sources/SignalClient/Aes256GcmSiv.swift
@@ -28,19 +28,21 @@ public class Aes256GcmSiv: NativeHandleOwner {
             NonceBytes: ContiguousBytes,
             AssociatedDataBytes: ContiguousBytes {
 
-        try message.withUnsafeBytes { messageBytes in
-            try nonce.withUnsafeBytes { nonceBytes in
-                try associated_data.withUnsafeBytes { adBytes in
-                    try invokeFnReturningArray {
-                        signal_aes256_gcm_siv_encrypt($0,
-                                                      $1,
-                                                      nativeHandle,
-                                                      messageBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
-                                                      messageBytes.count,
-                                                      nonceBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
-                                                      nonceBytes.count,
-                                                      adBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
-                                                      adBytes.count)
+        try withNativeHandle { nativeHandle in
+            try message.withUnsafeBytes { messageBytes in
+                try nonce.withUnsafeBytes { nonceBytes in
+                    try associated_data.withUnsafeBytes { adBytes in
+                        try invokeFnReturningArray {
+                            signal_aes256_gcm_siv_encrypt($0,
+                                                          $1,
+                                                          nativeHandle,
+                                                          messageBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                                                          messageBytes.count,
+                                                          nonceBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                                                          nonceBytes.count,
+                                                          adBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                                                          adBytes.count)
+                        }
                     }
                 }
             }
@@ -55,19 +57,21 @@ public class Aes256GcmSiv: NativeHandleOwner {
             NonceBytes: ContiguousBytes,
             AssociatedDataBytes: ContiguousBytes {
 
-        try message.withUnsafeBytes { messageBytes in
-            try nonce.withUnsafeBytes { nonceBytes in
-                try associated_data.withUnsafeBytes { adBytes in
-                    try invokeFnReturningArray {
-                        signal_aes256_gcm_siv_decrypt($0,
-                                                      $1,
-                                                      nativeHandle,
-                                                      messageBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
-                                                      messageBytes.count,
-                                                      nonceBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
-                                                      nonceBytes.count,
-                                                      adBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
-                                                      adBytes.count)
+        try withNativeHandle { nativeHandle in
+            try message.withUnsafeBytes { messageBytes in
+                try nonce.withUnsafeBytes { nonceBytes in
+                    try associated_data.withUnsafeBytes { adBytes in
+                        try invokeFnReturningArray {
+                            signal_aes256_gcm_siv_decrypt($0,
+                                                          $1,
+                                                          nativeHandle,
+                                                          messageBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                                                          messageBytes.count,
+                                                          nonceBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                                                          nonceBytes.count,
+                                                          adBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                                                          adBytes.count)
+                        }
                     }
                 }
             }

--- a/swift/Sources/SignalClient/Error.swift
+++ b/swift/Sources/SignalClient/Error.swift
@@ -96,7 +96,7 @@ internal func checkError(_ error: SignalFfiErrorRef?) throws {
     case SignalErrorCode_SessionNotFound:
         throw SignalError.sessionNotFound(errStr)
     case SignalErrorCode_InvalidRegistrationId:
-        let address = try invokeFnReturningProtocolAddress {
+        let address: ProtocolAddress = try invokeFnReturningNativeHandle {
             signal_error_get_address(error, $0)
         }
         throw SignalError.invalidRegistrationId(address: address, message: errStr)

--- a/swift/Sources/SignalClient/Fingerprint.swift
+++ b/swift/Sources/SignalClient/Fingerprint.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
@@ -53,13 +53,15 @@ public struct NumericFingerprintGenerator {
                                                 remoteKey: PublicKey) throws -> Fingerprint
     where LocalBytes: ContiguousBytes, RemoteBytes: ContiguousBytes {
         var obj: OpaquePointer?
-        try localIdentifier.withUnsafeBytes { localBytes in
-            try remoteIdentifier.withUnsafeBytes { remoteBytes in
-                try checkError(signal_fingerprint_new(&obj, UInt32(iterations), UInt32(version),
-                                                      localBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), localBytes.count,
-                                                      localKey.nativeHandle,
-                                                      remoteBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), remoteBytes.count,
-                                                      remoteKey.nativeHandle))
+        try withNativeHandles(localKey, remoteKey) { localKeyHandle, remoteKeyHandle in
+            try localIdentifier.withUnsafeBytes { localBytes in
+                try remoteIdentifier.withUnsafeBytes { remoteBytes in
+                    try checkError(signal_fingerprint_new(&obj, UInt32(iterations), UInt32(version),
+                                                          localBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), localBytes.count,
+                                                          localKeyHandle,
+                                                          remoteBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), remoteBytes.count,
+                                                          remoteKeyHandle))
+                }
             }
         }
 

--- a/swift/Sources/SignalClient/IdentityKey.swift
+++ b/swift/Sources/SignalClient/IdentityKey.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
@@ -49,9 +49,11 @@ public struct IdentityKeyPair {
     }
 
     public func serialize() -> [UInt8] {
-        return failOnError {
-            try invokeFnReturningArray {
-                signal_identitykeypair_serialize($0, $1, publicKey.nativeHandle, privateKey.nativeHandle)
+        return withNativeHandles(publicKey, privateKey) { publicKey, privateKey in
+            failOnError {
+                try invokeFnReturningArray {
+                    signal_identitykeypair_serialize($0, $1, publicKey, privateKey)
+                }
             }
         }
     }

--- a/swift/Sources/SignalClient/PrivateKey.swift
+++ b/swift/Sources/SignalClient/PrivateKey.swift
@@ -7,17 +7,13 @@ import SignalFfi
 import Foundation
 
 public class PrivateKey: ClonableHandleOwner {
-    public init<Bytes: ContiguousBytes>(_ bytes: Bytes) throws {
+    public convenience init<Bytes: ContiguousBytes>(_ bytes: Bytes) throws {
         let handle: OpaquePointer? = try bytes.withUnsafeBytes {
             var result: OpaquePointer?
             try checkError(signal_privatekey_deserialize(&result, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count))
             return result
         }
-        super.init(owned: handle!)
-    }
-
-    internal override init(owned handle: OpaquePointer) {
-        super.init(owned: handle)
+        self.init(owned: handle!)
     }
 
     public static func generate() -> PrivateKey {
@@ -62,7 +58,7 @@ public class PrivateKey: ClonableHandleOwner {
 
     public var publicKey: PublicKey {
         return failOnError {
-            try invokeFnReturningPublicKey {
+            try invokeFnReturningNativeHandle {
                 signal_privatekey_get_public_key($0, nativeHandle)
             }
         }

--- a/swift/Sources/SignalClient/PrivateKey.swift
+++ b/swift/Sources/SignalClient/PrivateKey.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
@@ -17,9 +17,11 @@ public class PrivateKey: ClonableHandleOwner {
     }
 
     public static func generate() -> PrivateKey {
-        var handle: OpaquePointer?
-        failOnError(signal_privatekey_generate(&handle))
-        return PrivateKey(owned: handle!)
+        return failOnError {
+            try invokeFnReturningNativeHandle {
+                signal_privatekey_generate($0)
+            }
+        }
     }
 
     internal override class func cloneNativeHandle(_ newHandle: inout OpaquePointer?, currentHandle: OpaquePointer?) -> SignalFfiErrorRef? {
@@ -31,35 +33,43 @@ public class PrivateKey: ClonableHandleOwner {
     }
 
     public func serialize() -> [UInt8] {
-        return failOnError {
-            try invokeFnReturningArray {
-                signal_privatekey_serialize($0, $1, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningArray {
+                    signal_privatekey_serialize($0, $1, nativeHandle)
+                }
             }
         }
     }
 
     public func generateSignature<Bytes: ContiguousBytes>(message: Bytes) -> [UInt8] {
-        return message.withUnsafeBytes { messageBytes in
-            failOnError {
-                try invokeFnReturningArray {
-                    signal_privatekey_sign($0, $1, nativeHandle, messageBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), messageBytes.count)
+        return withNativeHandle { nativeHandle in
+            message.withUnsafeBytes { messageBytes in
+                failOnError {
+                    try invokeFnReturningArray {
+                        signal_privatekey_sign($0, $1, nativeHandle, messageBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), messageBytes.count)
+                    }
                 }
             }
         }
     }
 
     public func keyAgreement(with other: PublicKey) -> [UInt8] {
-        return failOnError {
-            try invokeFnReturningArray {
-                signal_privatekey_agree($0, $1, nativeHandle, other.nativeHandle)
+        return withNativeHandles(self, other) { nativeHandle, otherHandle in
+            failOnError {
+                try invokeFnReturningArray {
+                    signal_privatekey_agree($0, $1, nativeHandle, otherHandle)
+                }
             }
         }
     }
 
     public var publicKey: PublicKey {
-        return failOnError {
-            try invokeFnReturningNativeHandle {
-                signal_privatekey_get_public_key($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningNativeHandle {
+                    signal_privatekey_get_public_key($0, nativeHandle)
+                }
             }
         }
     }

--- a/swift/Sources/SignalClient/Protocol.swift
+++ b/swift/Sources/SignalClient/Protocol.swift
@@ -15,7 +15,7 @@ public func signalEncrypt<Bytes: ContiguousBytes>(message: Bytes,
         try context.withOpaquePointer { context in
             try withSessionStore(sessionStore) { ffiSessionStore in
                 try withIdentityKeyStore(identityStore) { ffiIdentityStore in
-                    try invokeFnReturningCiphertextMessage {
+                    try invokeFnReturningNativeHandle {
                         signal_encrypt_message($0, messageBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), messageBytes.count, address.nativeHandle, ffiSessionStore, ffiIdentityStore, context)
                     }
                 }
@@ -85,7 +85,7 @@ public func groupEncrypt<Bytes: ContiguousBytes>(_ message: Bytes,
         try message.withUnsafeBytes { messageBytes in
             try withUnsafePointer(to: distributionId.uuid) { distributionId in
                 try withSenderKeyStore(store) { ffiStore in
-                    try invokeFnReturningCiphertextMessage {
+                    try invokeFnReturningNativeHandle {
                         signal_group_encrypt_message($0, sender.nativeHandle, distributionId, messageBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), messageBytes.count, ffiStore, context)
                     }
                 }

--- a/swift/Sources/SignalClient/Protocol.swift
+++ b/swift/Sources/SignalClient/Protocol.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
@@ -11,12 +11,14 @@ public func signalEncrypt<Bytes: ContiguousBytes>(message: Bytes,
                                                   sessionStore: SessionStore,
                                                   identityStore: IdentityKeyStore,
                                                   context: StoreContext) throws -> CiphertextMessage {
-    return try message.withUnsafeBytes { messageBytes in
-        try context.withOpaquePointer { context in
-            try withSessionStore(sessionStore) { ffiSessionStore in
-                try withIdentityKeyStore(identityStore) { ffiIdentityStore in
-                    try invokeFnReturningNativeHandle {
-                        signal_encrypt_message($0, messageBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), messageBytes.count, address.nativeHandle, ffiSessionStore, ffiIdentityStore, context)
+    return try address.withNativeHandle { addressHandle in
+        try message.withUnsafeBytes { messageBytes in
+            try context.withOpaquePointer { context in
+                try withSessionStore(sessionStore) { ffiSessionStore in
+                    try withIdentityKeyStore(identityStore) { ffiIdentityStore in
+                        try invokeFnReturningNativeHandle {
+                            signal_encrypt_message($0, messageBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), messageBytes.count, addressHandle, ffiSessionStore, ffiIdentityStore, context)
+                        }
                     }
                 }
             }
@@ -29,11 +31,13 @@ public func signalDecrypt(message: SignalMessage,
                           sessionStore: SessionStore,
                           identityStore: IdentityKeyStore,
                           context: StoreContext) throws -> [UInt8] {
-    return try context.withOpaquePointer { context in
-        try withSessionStore(sessionStore) { ffiSessionStore in
-            try withIdentityKeyStore(identityStore) { ffiIdentityStore in
-                try invokeFnReturningArray {
-                    signal_decrypt_message($0, $1, message.nativeHandle, address.nativeHandle, ffiSessionStore, ffiIdentityStore, context)
+    return try withNativeHandles(message, address) { messageHandle, addressHandle in
+        try context.withOpaquePointer { context in
+            try withSessionStore(sessionStore) { ffiSessionStore in
+                try withIdentityKeyStore(identityStore) { ffiIdentityStore in
+                    try invokeFnReturningArray {
+                        signal_decrypt_message($0, $1, messageHandle, addressHandle, ffiSessionStore, ffiIdentityStore, context)
+                    }
                 }
             }
         }
@@ -41,19 +45,21 @@ public func signalDecrypt(message: SignalMessage,
 }
 
 public func signalDecryptPreKey(message: PreKeySignalMessage,
-                                from: ProtocolAddress,
+                                from address: ProtocolAddress,
                                 sessionStore: SessionStore,
                                 identityStore: IdentityKeyStore,
                                 preKeyStore: PreKeyStore,
                                 signedPreKeyStore: SignedPreKeyStore,
                                 context: StoreContext) throws -> [UInt8] {
-    return try context.withOpaquePointer { context in
-        try withSessionStore(sessionStore) { ffiSessionStore in
-            try withIdentityKeyStore(identityStore) { ffiIdentityStore in
-                try withPreKeyStore(preKeyStore) { ffiPreKeyStore in
-                    try withSignedPreKeyStore(signedPreKeyStore) { ffiSignedPreKeyStore in
-                        try invokeFnReturningArray {
-                            signal_decrypt_pre_key_message($0, $1, message.nativeHandle, from.nativeHandle, ffiSessionStore, ffiIdentityStore, ffiPreKeyStore, ffiSignedPreKeyStore, context)
+    return try withNativeHandles(message, address) { messageHandle, addressHandle in
+        try context.withOpaquePointer { context in
+            try withSessionStore(sessionStore) { ffiSessionStore in
+                try withIdentityKeyStore(identityStore) { ffiIdentityStore in
+                    try withPreKeyStore(preKeyStore) { ffiPreKeyStore in
+                        try withSignedPreKeyStore(signedPreKeyStore) { ffiSignedPreKeyStore in
+                            try invokeFnReturningArray {
+                                signal_decrypt_pre_key_message($0, $1, messageHandle, addressHandle, ffiSessionStore, ffiIdentityStore, ffiPreKeyStore, ffiSignedPreKeyStore, context)
+                            }
                         }
                     }
                 }
@@ -67,10 +73,12 @@ public func processPreKeyBundle(_ bundle: PreKeyBundle,
                                 sessionStore: SessionStore,
                                 identityStore: IdentityKeyStore,
                                 context: StoreContext) throws {
-    return try context.withOpaquePointer { context in
-        try withSessionStore(sessionStore) { ffiSessionStore in
-            try withIdentityKeyStore(identityStore) { ffiIdentityStore in
-                try checkError(signal_process_prekey_bundle(bundle.nativeHandle, address.nativeHandle, ffiSessionStore, ffiIdentityStore, context))
+    return try withNativeHandles(bundle, address) { bundleHandle, addressHandle in
+        try context.withOpaquePointer { context in
+            try withSessionStore(sessionStore) { ffiSessionStore in
+                try withIdentityKeyStore(identityStore) { ffiIdentityStore in
+                    try checkError(signal_process_prekey_bundle(bundleHandle, addressHandle, ffiSessionStore, ffiIdentityStore, context))
+                }
             }
         }
     }
@@ -81,12 +89,14 @@ public func groupEncrypt<Bytes: ContiguousBytes>(_ message: Bytes,
                                                  distributionId: UUID,
                                                  store: SenderKeyStore,
                                                  context: StoreContext) throws -> CiphertextMessage {
-    return try context.withOpaquePointer { context in
-        try message.withUnsafeBytes { messageBytes in
-            try withUnsafePointer(to: distributionId.uuid) { distributionId in
-                try withSenderKeyStore(store) { ffiStore in
-                    try invokeFnReturningNativeHandle {
-                        signal_group_encrypt_message($0, sender.nativeHandle, distributionId, messageBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), messageBytes.count, ffiStore, context)
+    return try sender.withNativeHandle { senderHandle in
+        try context.withOpaquePointer { context in
+            try message.withUnsafeBytes { messageBytes in
+                try withUnsafePointer(to: distributionId.uuid) { distributionId in
+                    try withSenderKeyStore(store) { ffiStore in
+                        try invokeFnReturningNativeHandle {
+                            signal_group_encrypt_message($0, senderHandle, distributionId, messageBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), messageBytes.count, ffiStore, context)
+                        }
                     }
                 }
             }
@@ -98,11 +108,13 @@ public func groupDecrypt<Bytes: ContiguousBytes>(_ message: Bytes,
                                                  from sender: ProtocolAddress,
                                                  store: SenderKeyStore,
                                                  context: StoreContext) throws -> [UInt8] {
-    return try context.withOpaquePointer { context in
-        try message.withUnsafeBytes { messageBytes in
-            try withSenderKeyStore(store) { ffiStore in
-                try invokeFnReturningArray {
-                    signal_group_decrypt_message($0, $1, sender.nativeHandle, messageBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), messageBytes.count, ffiStore, context)
+    return try sender.withNativeHandle { senderHandle in
+        try context.withOpaquePointer { context in
+            try message.withUnsafeBytes { messageBytes in
+                try withSenderKeyStore(store) { ffiStore in
+                    try invokeFnReturningArray {
+                        signal_group_decrypt_message($0, $1, senderHandle, messageBytes.baseAddress?.assumingMemoryBound(to: UInt8.self), messageBytes.count, ffiStore, context)
+                    }
                 }
             }
         }
@@ -113,11 +125,13 @@ public func processSenderKeyDistributionMessage(_ message: SenderKeyDistribution
                                                 from sender: ProtocolAddress,
                                                 store: SenderKeyStore,
                                                 context: StoreContext) throws {
-    return try context.withOpaquePointer { context in
-        try withSenderKeyStore(store) {
-            try checkError(signal_process_sender_key_distribution_message(sender.nativeHandle,
-                                                                          message.nativeHandle,
-                                                                          $0, context))
+    return try withNativeHandles(sender, message) { senderHandle, messageHandle in
+        try context.withOpaquePointer { context in
+            try withSenderKeyStore(store) {
+                try checkError(signal_process_sender_key_distribution_message(senderHandle,
+                                                                              messageHandle,
+                                                                              $0, context))
+            }
         }
     }
 }

--- a/swift/Sources/SignalClient/PublicKey.swift
+++ b/swift/Sources/SignalClient/PublicKey.swift
@@ -7,21 +7,13 @@ import SignalFfi
 import Foundation
 
 public class PublicKey: ClonableHandleOwner {
-    public init<Bytes: ContiguousBytes>(_ bytes: Bytes) throws {
+    public convenience init<Bytes: ContiguousBytes>(_ bytes: Bytes) throws {
         let handle: OpaquePointer? = try bytes.withUnsafeBytes {
             var result: OpaquePointer?
             try checkError(signal_publickey_deserialize(&result, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count))
             return result
         }
-        super.init(owned: handle!)
-    }
-
-    internal override init(owned handle: OpaquePointer) {
-        super.init(owned: handle)
-    }
-
-    internal override init(borrowing handle: OpaquePointer?) {
-        super.init(borrowing: handle)
+        self.init(owned: handle!)
     }
 
     internal override class func destroyNativeHandle(_ handle: OpaquePointer) -> SignalFfiErrorRef? {

--- a/swift/Sources/SignalClient/SealedSender.swift
+++ b/swift/Sources/SignalClient/SealedSender.swift
@@ -27,7 +27,7 @@ public func sealedSenderEncrypt<Bytes: ContiguousBytes>(message: Bytes,
     return try sealedSenderEncrypt(usmc, for: address, identityStore: identityStore, context: context)
 }
 
-public class UnidentifiedSenderMessageContent: ClonableHandleOwner {
+public class UnidentifiedSenderMessageContent: NativeHandleOwner {
     public struct ContentHint: RawRepresentable, Hashable {
         public var rawValue: UInt32
         public init(rawValue: UInt32) {
@@ -49,9 +49,9 @@ public class UnidentifiedSenderMessageContent: ClonableHandleOwner {
         }
     }
 
-    public init<Bytes: ContiguousBytes>(message sealedSenderMessage: Bytes,
-                                        identityStore: IdentityKeyStore,
-                                        context: StoreContext) throws {
+    public convenience init<Bytes: ContiguousBytes>(message sealedSenderMessage: Bytes,
+                                                    identityStore: IdentityKeyStore,
+                                                    context: StoreContext) throws {
         var result: OpaquePointer?
         try sealedSenderMessage.withUnsafeBytes { messageBytes in
             try context.withOpaquePointer { context in
@@ -66,13 +66,13 @@ public class UnidentifiedSenderMessageContent: ClonableHandleOwner {
                 }
             }
         }
-        super.init(owned: result!)
+        self.init(owned: result!)
     }
 
-    public init<GroupIdBytes: ContiguousBytes>(_ message: CiphertextMessage,
-                                               from sender: SenderCertificate,
-                                               contentHint: ContentHint,
-                                               groupId: GroupIdBytes) throws {
+    public convenience init<GroupIdBytes: ContiguousBytes>(_ message: CiphertextMessage,
+                                                           from sender: SenderCertificate,
+                                                           contentHint: ContentHint,
+                                                           groupId: GroupIdBytes) throws {
         var result: OpaquePointer?
         try groupId.withUnsafeBytes { groupIdBytes in
             try checkError(
@@ -83,7 +83,7 @@ public class UnidentifiedSenderMessageContent: ClonableHandleOwner {
                                                                groupIdBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
                                                                groupIdBytes.count))
         }
-        super.init(owned: result!)
+        self.init(owned: result!)
     }
 
     internal override class func destroyNativeHandle(_ handle: OpaquePointer) -> SignalFfiErrorRef? {

--- a/swift/Sources/SignalClient/SealedSenderCertificates.swift
+++ b/swift/Sources/SignalClient/SealedSenderCertificates.swift
@@ -19,7 +19,9 @@ public class ServerCertificate: NativeHandleOwner {
     // For testing
     public convenience init(keyId: UInt32, publicKey: PublicKey, trustRoot: PrivateKey) throws {
         var result: OpaquePointer?
-        try checkError(signal_server_certificate_new(&result, keyId, publicKey.nativeHandle, trustRoot.nativeHandle))
+        try withNativeHandles(publicKey, trustRoot) { publicKeyHandle, trustRootHandle in
+            try checkError(signal_server_certificate_new(&result, keyId, publicKeyHandle, trustRootHandle))
+        }
         self.init(owned: result!)
     }
 
@@ -28,41 +30,51 @@ public class ServerCertificate: NativeHandleOwner {
     }
 
     public var keyId: UInt32 {
-        return failOnError {
-            try invokeFnReturningInteger {
-                signal_server_certificate_get_key_id($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningInteger {
+                    signal_server_certificate_get_key_id($0, nativeHandle)
+                }
             }
         }
     }
 
     public func serialize() -> [UInt8] {
-        return failOnError {
-            try invokeFnReturningArray {
-                signal_server_certificate_get_serialized($0, $1, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningArray {
+                    signal_server_certificate_get_serialized($0, $1, nativeHandle)
+                }
             }
         }
     }
 
     public var certificateBytes: [UInt8] {
-        return failOnError {
-            try invokeFnReturningArray {
-                signal_server_certificate_get_certificate($0, $1, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningArray {
+                    signal_server_certificate_get_certificate($0, $1, nativeHandle)
+                }
             }
         }
     }
 
     public var signatureBytes: [UInt8] {
-        return failOnError {
-            try invokeFnReturningArray {
-                signal_server_certificate_get_signature($0, $1, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningArray {
+                    signal_server_certificate_get_signature($0, $1, nativeHandle)
+                }
             }
         }
     }
 
     public var publicKey: PublicKey {
-        return failOnError {
-            try invokeFnReturningNativeHandle {
-                signal_server_certificate_get_key($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningNativeHandle {
+                    signal_server_certificate_get_key($0, nativeHandle)
+                }
             }
         }
     }
@@ -81,14 +93,16 @@ public class SenderCertificate: NativeHandleOwner {
     // For testing
     public convenience init(sender: SealedSenderAddress, publicKey: PublicKey, expiration: UInt64, signerCertificate: ServerCertificate, signerKey: PrivateKey) throws {
         var result: OpaquePointer?
-        try checkError(signal_sender_certificate_new(&result,
-                                                     sender.uuidString,
-                                                     sender.e164,
-                                                     sender.deviceId,
-                                                     publicKey.nativeHandle,
-                                                     expiration,
-                                                     signerCertificate.nativeHandle,
-                                                     signerKey.nativeHandle))
+        try withNativeHandles(publicKey, signerCertificate, signerKey) { publicKeyHandle, signerCertificateHandle, signerKeyHandle in
+            try checkError(signal_sender_certificate_new(&result,
+                                                         sender.uuidString,
+                                                         sender.e164,
+                                                         sender.deviceId,
+                                                         publicKeyHandle,
+                                                         expiration,
+                                                         signerCertificateHandle,
+                                                         signerKeyHandle))
+        }
         self.init(owned: result!)
     }
 
@@ -97,65 +111,81 @@ public class SenderCertificate: NativeHandleOwner {
     }
 
     public var expiration: UInt64 {
-        return failOnError {
-            try invokeFnReturningInteger {
-                signal_sender_certificate_get_expiration($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningInteger {
+                    signal_sender_certificate_get_expiration($0, nativeHandle)
+                }
             }
         }
     }
 
     public var deviceId: UInt32 {
-        return failOnError {
-            try invokeFnReturningInteger {
-                signal_sender_certificate_get_device_id($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningInteger {
+                    signal_sender_certificate_get_device_id($0, nativeHandle)
+                }
             }
         }
     }
 
     public func serialize() -> [UInt8] {
-        return failOnError {
-            try invokeFnReturningArray {
-                signal_sender_certificate_get_serialized($0, $1, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningArray {
+                    signal_sender_certificate_get_serialized($0, $1, nativeHandle)
+                }
             }
         }
     }
 
     public var certificateBytes: [UInt8] {
-        return failOnError {
-            try invokeFnReturningArray {
-                signal_sender_certificate_get_certificate($0, $1, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningArray {
+                    signal_sender_certificate_get_certificate($0, $1, nativeHandle)
+                }
             }
         }
     }
 
     public var signatureBytes: [UInt8] {
-        return failOnError {
-            try invokeFnReturningArray {
-                signal_sender_certificate_get_signature($0, $1, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningArray {
+                    signal_sender_certificate_get_signature($0, $1, nativeHandle)
+                }
             }
         }
     }
 
     public var publicKey: PublicKey {
-        return failOnError {
-            try invokeFnReturningNativeHandle {
-                signal_sender_certificate_get_key($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningNativeHandle {
+                    signal_sender_certificate_get_key($0, nativeHandle)
+                }
             }
         }
     }
 
     public var senderUuid: String {
-        return failOnError {
-            try invokeFnReturningString {
-                signal_sender_certificate_get_sender_uuid($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningString {
+                    signal_sender_certificate_get_sender_uuid($0, nativeHandle)
+                }
             }
         }
     }
 
     public var senderE164: String? {
-        return failOnError {
-            try invokeFnReturningOptionalString {
-                signal_sender_certificate_get_sender_e164($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningOptionalString {
+                    signal_sender_certificate_get_sender_e164($0, nativeHandle)
+                }
             }
         }
     }
@@ -165,14 +195,20 @@ public class SenderCertificate: NativeHandleOwner {
     }
 
     public var serverCertificate: ServerCertificate {
-        var handle: OpaquePointer?
-        failOnError(signal_sender_certificate_get_server_certificate(&handle, nativeHandle))
-        return ServerCertificate(owned: handle!)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningNativeHandle {
+                    signal_sender_certificate_get_server_certificate($0, nativeHandle)
+                }
+            }
+        }
     }
 
     public func validate(trustRoot: PublicKey, time: UInt64) throws -> Bool {
         var result: Bool = false
-        try checkError(signal_sender_certificate_validate(&result, nativeHandle, trustRoot.nativeHandle, time))
+        try withNativeHandles(self, trustRoot) { certificateHandle, trustRootHandle in
+            try checkError(signal_sender_certificate_validate(&result, certificateHandle, trustRootHandle, time))
+        }
         return result
     }
 }

--- a/swift/Sources/SignalClient/SealedSenderCertificates.swift
+++ b/swift/Sources/SignalClient/SealedSenderCertificates.swift
@@ -6,29 +6,21 @@
 import SignalFfi
 import Foundation
 
-public class ServerCertificate: ClonableHandleOwner {
-    public init<Bytes: ContiguousBytes>(_ bytes: Bytes) throws {
+public class ServerCertificate: NativeHandleOwner {
+    public convenience init<Bytes: ContiguousBytes>(_ bytes: Bytes) throws {
         let handle: OpaquePointer? = try bytes.withUnsafeBytes {
             var result: OpaquePointer?
             try checkError(signal_server_certificate_deserialize(&result, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count))
             return result
         }
-        super.init(owned: handle!)
+        self.init(owned: handle!)
     }
 
     // For testing
-    public init(keyId: UInt32, publicKey: PublicKey, trustRoot: PrivateKey) throws {
+    public convenience init(keyId: UInt32, publicKey: PublicKey, trustRoot: PrivateKey) throws {
         var result: OpaquePointer?
         try checkError(signal_server_certificate_new(&result, keyId, publicKey.nativeHandle, trustRoot.nativeHandle))
-        super.init(owned: result!)
-    }
-
-    internal override init(owned handle: OpaquePointer) {
-        super.init(owned: handle)
-    }
-
-    internal override init(borrowing handle: OpaquePointer?) {
-        super.init(borrowing: handle)
+        self.init(owned: result!)
     }
 
     internal override class func destroyNativeHandle(_ handle: OpaquePointer) -> SignalFfiErrorRef? {
@@ -69,25 +61,25 @@ public class ServerCertificate: ClonableHandleOwner {
 
     public var publicKey: PublicKey {
         return failOnError {
-            try invokeFnReturningPublicKey {
+            try invokeFnReturningNativeHandle {
                 signal_server_certificate_get_key($0, nativeHandle)
             }
         }
     }
 }
 
-public class SenderCertificate: ClonableHandleOwner {
-    public init<Bytes: ContiguousBytes>(_ bytes: Bytes) throws {
+public class SenderCertificate: NativeHandleOwner {
+    public convenience init<Bytes: ContiguousBytes>(_ bytes: Bytes) throws {
         let handle: OpaquePointer? = try bytes.withUnsafeBytes {
             var result: OpaquePointer?
             try checkError(signal_sender_certificate_deserialize(&result, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count))
             return result
         }
-        super.init(owned: handle!)
+        self.init(owned: handle!)
     }
 
     // For testing
-    public init(sender: SealedSenderAddress, publicKey: PublicKey, expiration: UInt64, signerCertificate: ServerCertificate, signerKey: PrivateKey) throws {
+    public convenience init(sender: SealedSenderAddress, publicKey: PublicKey, expiration: UInt64, signerCertificate: ServerCertificate, signerKey: PrivateKey) throws {
         var result: OpaquePointer?
         try checkError(signal_sender_certificate_new(&result,
                                                      sender.uuidString,
@@ -97,11 +89,7 @@ public class SenderCertificate: ClonableHandleOwner {
                                                      expiration,
                                                      signerCertificate.nativeHandle,
                                                      signerKey.nativeHandle))
-        super.init(owned: result!)
-    }
-
-    internal override init(owned handle: OpaquePointer) {
-        super.init(owned: handle)
+        self.init(owned: result!)
     }
 
     internal override class func destroyNativeHandle(_ handle: OpaquePointer) -> SignalFfiErrorRef? {
@@ -150,7 +138,7 @@ public class SenderCertificate: ClonableHandleOwner {
 
     public var publicKey: PublicKey {
         return failOnError {
-            try invokeFnReturningPublicKey {
+            try invokeFnReturningNativeHandle {
                 signal_sender_certificate_get_key($0, nativeHandle)
             }
         }

--- a/swift/Sources/SignalClient/Utils.swift
+++ b/swift/Sources/SignalClient/Utils.swift
@@ -49,34 +49,16 @@ internal func invokeFnReturningInteger<Result: FixedWidthInteger>(fn: (UnsafeMut
     return output
 }
 
-internal func invokeFnReturningPublicKey(fn: (UnsafeMutablePointer<OpaquePointer?>?) -> SignalFfiErrorRef?) throws -> PublicKey {
-    var pk_handle: OpaquePointer?
-    try checkError(fn(&pk_handle))
-    return PublicKey(owned: pk_handle!)
-}
-
-internal func invokeFnReturningPrivateKey(fn: (UnsafeMutablePointer<OpaquePointer?>?) -> SignalFfiErrorRef?) throws -> PrivateKey {
-    var pk_handle: OpaquePointer?
-    try checkError(fn(&pk_handle))
-    return PrivateKey(owned: pk_handle!)
-}
-
-internal func invokeFnReturningOptionalPublicKey(fn: (UnsafeMutablePointer<OpaquePointer?>?) -> SignalFfiErrorRef?) throws -> PublicKey? {
-    var pk_handle: OpaquePointer?
-    try checkError(fn(&pk_handle))
-    return pk_handle.map { PublicKey(owned: $0) }
-}
-
-internal func invokeFnReturningCiphertextMessage(fn: (UnsafeMutablePointer<OpaquePointer?>?) -> SignalFfiErrorRef?) throws -> CiphertextMessage {
+internal func invokeFnReturningNativeHandle<Owner: NativeHandleOwner>(fn: (UnsafeMutablePointer<OpaquePointer?>?) -> SignalFfiErrorRef?) throws -> Owner {
     var handle: OpaquePointer?
     try checkError(fn(&handle))
-    return CiphertextMessage(owned: handle)
+    return Owner(owned: handle!)
 }
 
-internal func invokeFnReturningProtocolAddress(fn: (UnsafeMutablePointer<OpaquePointer?>?) -> SignalFfiErrorRef?) throws -> ProtocolAddress {
+internal func invokeFnReturningOptionalNativeHandle<Owner: NativeHandleOwner>(fn: (UnsafeMutablePointer<OpaquePointer?>?) -> SignalFfiErrorRef?) throws -> Owner? {
     var handle: OpaquePointer?
     try checkError(fn(&handle))
-    return ProtocolAddress(owned: handle!)
+    return handle.map { Owner(owned: $0) }
 }
 
 extension StoreContext {

--- a/swift/Sources/SignalClient/Utils.swift
+++ b/swift/Sources/SignalClient/Utils.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 

--- a/swift/Sources/SignalClient/messages/CiphertextMessage.swift
+++ b/swift/Sources/SignalClient/messages/CiphertextMessage.swift
@@ -5,9 +5,7 @@
 
 import SignalFfi
 
-public class CiphertextMessage {
-    internal var nativeHandle: OpaquePointer?
-
+public class CiphertextMessage: NativeHandleOwner {
     public struct MessageType: RawRepresentable, Hashable {
         public var rawValue: UInt8
         public init(rawValue: UInt8) {
@@ -32,18 +30,14 @@ public class CiphertextMessage {
         }
     }
 
-    deinit {
-        failOnError(signal_ciphertext_message_destroy(nativeHandle))
+    internal override class func destroyNativeHandle(_ handle: OpaquePointer) -> SignalFfiErrorRef? {
+        return signal_ciphertext_message_destroy(handle)
     }
 
-    internal init(owned rawPtr: OpaquePointer?) {
-        nativeHandle = rawPtr
-    }
-
-    public init(_ plaintextContent: PlaintextContent) {
+    public convenience init(_ plaintextContent: PlaintextContent) {
         var result: OpaquePointer?
         failOnError(signal_ciphertext_message_from_plaintext_content(&result, plaintextContent.nativeHandle))
-        nativeHandle = result!
+        self.init(owned: result!)
     }
 
     public func serialize() -> [UInt8] {

--- a/swift/Sources/SignalClient/messages/CiphertextMessage.swift
+++ b/swift/Sources/SignalClient/messages/CiphertextMessage.swift
@@ -36,22 +36,28 @@ public class CiphertextMessage: NativeHandleOwner {
 
     public convenience init(_ plaintextContent: PlaintextContent) {
         var result: OpaquePointer?
-        failOnError(signal_ciphertext_message_from_plaintext_content(&result, plaintextContent.nativeHandle))
+        plaintextContent.withNativeHandle { plaintextContentHandle in
+            failOnError(signal_ciphertext_message_from_plaintext_content(&result, plaintextContentHandle))
+        }
         self.init(owned: result!)
     }
 
     public func serialize() -> [UInt8] {
-        return failOnError {
-            try invokeFnReturningArray {
-                signal_ciphertext_message_serialize($0, $1, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningArray {
+                    signal_ciphertext_message_serialize($0, $1, nativeHandle)
+                }
             }
         }
     }
 
     public var messageType: MessageType {
-        let rawValue = failOnError {
-            try invokeFnReturningInteger {
-                signal_ciphertext_message_type($0, nativeHandle)
+        let rawValue = withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningInteger {
+                    signal_ciphertext_message_type($0, nativeHandle)
+                }
             }
         }
         return MessageType(rawValue: rawValue)

--- a/swift/Sources/SignalClient/messages/PlaintextContent.swift
+++ b/swift/Sources/SignalClient/messages/PlaintextContent.swift
@@ -21,22 +21,28 @@ public class PlaintextContent: NativeHandleOwner {
 
     public convenience init(_ decryptionError: DecryptionErrorMessage) {
         var result: OpaquePointer?
-        failOnError(signal_plaintext_content_from_decryption_error_message(&result, decryptionError.nativeHandle))
+        decryptionError.withNativeHandle { decryptionErrorHandle in
+            failOnError(signal_plaintext_content_from_decryption_error_message(&result, decryptionErrorHandle))
+        }
         self.init(owned: result!)
     }
 
     public func serialize() -> [UInt8] {
-        return failOnError {
-            try invokeFnReturningArray {
-                signal_plaintext_content_serialize($0, $1, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningArray {
+                    signal_plaintext_content_serialize($0, $1, nativeHandle)
+                }
             }
         }
     }
 
     public var body: [UInt8] {
-        return failOnError {
-            try invokeFnReturningArray {
-                signal_plaintext_content_get_body($0, $1, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningArray {
+                    signal_plaintext_content_get_body($0, $1, nativeHandle)
+                }
             }
         }
     }
@@ -65,41 +71,49 @@ public class DecryptionErrorMessage: NativeHandleOwner {
 
     // For testing
     public static func extractFromSerializedContent<Bytes: ContiguousBytes>(_ bytes: Bytes) throws -> DecryptionErrorMessage {
-        var result: OpaquePointer?
-        try bytes.withUnsafeBytes {
-            try checkError(signal_decryption_error_message_extract_from_serialized_content(&result, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count))
+        return try bytes.withUnsafeBytes { bytes in
+            try invokeFnReturningNativeHandle {
+                signal_decryption_error_message_extract_from_serialized_content($0, bytes.baseAddress?.assumingMemoryBound(to: UInt8.self), bytes.count)
+            }
         }
-        return DecryptionErrorMessage(owned: result!)
     }
 
     public func serialize() -> [UInt8] {
-        return failOnError {
-            try invokeFnReturningArray {
-                signal_decryption_error_message_serialize($0, $1, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningArray {
+                    signal_decryption_error_message_serialize($0, $1, nativeHandle)
+                }
             }
         }
     }
 
     public var ratchetKey: PublicKey? {
-        return failOnError {
-            try invokeFnReturningOptionalNativeHandle {
-                signal_decryption_error_message_get_ratchet_key($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningOptionalNativeHandle {
+                    signal_decryption_error_message_get_ratchet_key($0, nativeHandle)
+                }
             }
         }
     }
 
     public var timestamp: UInt64 {
-        return failOnError {
-            try invokeFnReturningInteger {
-                signal_decryption_error_message_get_timestamp($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningInteger {
+                    signal_decryption_error_message_get_timestamp($0, nativeHandle)
+                }
             }
         }
     }
 
     public var deviceId: UInt32 {
-        return failOnError {
-            try invokeFnReturningInteger {
-                signal_decryption_error_message_get_device_id($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningInteger {
+                    signal_decryption_error_message_get_device_id($0, nativeHandle)
+                }
             }
         }
     }

--- a/swift/Sources/SignalClient/messages/PlaintextContent.swift
+++ b/swift/Sources/SignalClient/messages/PlaintextContent.swift
@@ -6,25 +6,23 @@
 import SignalFfi
 import Foundation
 
-public class PlaintextContent {
-    internal private(set) var nativeHandle: OpaquePointer
-
-    deinit {
-        failOnError(signal_plaintext_content_destroy(nativeHandle))
+public class PlaintextContent: NativeHandleOwner {
+    internal override class func destroyNativeHandle(_ handle: OpaquePointer) -> SignalFfiErrorRef? {
+        return signal_plaintext_content_destroy(handle)
     }
 
-    public init<Bytes: ContiguousBytes>(bytes: Bytes) throws {
-        nativeHandle = try bytes.withUnsafeBytes {
-            var result: OpaquePointer?
+    public convenience init<Bytes: ContiguousBytes>(bytes: Bytes) throws {
+        var result: OpaquePointer?
+        try bytes.withUnsafeBytes {
             try checkError(signal_plaintext_content_deserialize(&result, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count))
-            return result
-        }!
+        }
+        self.init(owned: result!)
     }
 
-    public init(_ decryptionError: DecryptionErrorMessage) {
+    public convenience init(_ decryptionError: DecryptionErrorMessage) {
         var result: OpaquePointer?
         failOnError(signal_plaintext_content_from_decryption_error_message(&result, decryptionError.nativeHandle))
-        nativeHandle = result!
+        self.init(owned: result!)
     }
 
     public func serialize() -> [UInt8] {
@@ -44,40 +42,34 @@ public class PlaintextContent {
     }
 }
 
-public class DecryptionErrorMessage {
-    fileprivate private(set) var nativeHandle: OpaquePointer
-
-    deinit {
-        failOnError(signal_decryption_error_message_destroy(nativeHandle))
+public class DecryptionErrorMessage: NativeHandleOwner {
+    internal override class func destroyNativeHandle(_ handle: OpaquePointer) -> SignalFfiErrorRef? {
+        return signal_decryption_error_message_destroy(handle)
     }
 
-    fileprivate init(owned rawPtr: OpaquePointer) {
-        nativeHandle = rawPtr
-    }
-
-    public init<Bytes: ContiguousBytes>(bytes: Bytes) throws {
-        nativeHandle = try bytes.withUnsafeBytes {
-            var result: OpaquePointer?
+    public convenience init<Bytes: ContiguousBytes>(bytes: Bytes) throws {
+        var result: OpaquePointer?
+        try bytes.withUnsafeBytes {
             try checkError(signal_decryption_error_message_deserialize(&result, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count))
-            return result
-        }!
+        }
+        self.init(owned: result!)
     }
 
-    public init<Bytes: ContiguousBytes>(originalMessageBytes bytes: Bytes, type: CiphertextMessage.MessageType, timestamp: UInt64, originalSenderDeviceId: UInt32) throws {
-        nativeHandle = try bytes.withUnsafeBytes {
-            var result: OpaquePointer?
+    public convenience init<Bytes: ContiguousBytes>(originalMessageBytes bytes: Bytes, type: CiphertextMessage.MessageType, timestamp: UInt64, originalSenderDeviceId: UInt32) throws {
+        var result: OpaquePointer?
+        try bytes.withUnsafeBytes {
             try checkError(signal_decryption_error_message_for_original_message(&result, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count, type.rawValue, timestamp, originalSenderDeviceId))
-            return result
-        }!
+        }
+        self.init(owned: result!)
     }
 
     // For testing
     public static func extractFromSerializedContent<Bytes: ContiguousBytes>(_ bytes: Bytes) throws -> DecryptionErrorMessage {
+        var result: OpaquePointer?
         try bytes.withUnsafeBytes {
-            var result: OpaquePointer?
             try checkError(signal_decryption_error_message_extract_from_serialized_content(&result, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count))
-            return DecryptionErrorMessage(owned: result!)
-        }!
+        }
+        return DecryptionErrorMessage(owned: result!)
     }
 
     public func serialize() -> [UInt8] {
@@ -90,7 +82,7 @@ public class DecryptionErrorMessage {
 
     public var ratchetKey: PublicKey? {
         return failOnError {
-            try invokeFnReturningOptionalPublicKey {
+            try invokeFnReturningOptionalNativeHandle {
                 signal_decryption_error_message_get_ratchet_key($0, nativeHandle)
             }
         }

--- a/swift/Sources/SignalClient/messages/PreKeySignalMessage.swift
+++ b/swift/Sources/SignalClient/messages/PreKeySignalMessage.swift
@@ -20,26 +20,34 @@ public class PreKeySignalMessage: NativeHandleOwner {
     }
 
     public func serialize() throws -> [UInt8] {
-        return try invokeFnReturningArray {
-            signal_pre_key_signal_message_serialize($0, $1, nativeHandle)
+        return try withNativeHandle { nativeHandle in
+            try invokeFnReturningArray {
+                signal_pre_key_signal_message_serialize($0, $1, nativeHandle)
+            }
         }
     }
 
     public func version() throws -> UInt32 {
-        return try invokeFnReturningInteger {
-            signal_pre_key_signal_message_get_version($0, nativeHandle)
+        return try withNativeHandle { nativeHandle in
+            try invokeFnReturningInteger {
+                signal_pre_key_signal_message_get_version($0, nativeHandle)
+            }
         }
     }
 
     public func registrationId() throws -> UInt32 {
-        return try invokeFnReturningInteger {
-            signal_pre_key_signal_message_get_registration_id($0, nativeHandle)
+        return try withNativeHandle { nativeHandle in
+            try invokeFnReturningInteger {
+                signal_pre_key_signal_message_get_registration_id($0, nativeHandle)
+            }
         }
     }
 
     public func preKeyId() throws -> UInt32? {
-        let id = try invokeFnReturningInteger {
-            signal_pre_key_signal_message_get_pre_key_id($0, nativeHandle)
+        let id = try withNativeHandle { nativeHandle in
+            try invokeFnReturningInteger {
+                signal_pre_key_signal_message_get_pre_key_id($0, nativeHandle)
+            }
         }
 
         if id == 0xFFFFFFFF {
@@ -50,32 +58,42 @@ public class PreKeySignalMessage: NativeHandleOwner {
     }
 
     public var signedPreKeyId: UInt32 {
-        return failOnError {
-            try invokeFnReturningInteger {
-                signal_pre_key_signal_message_get_signed_pre_key_id($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningInteger {
+                    signal_pre_key_signal_message_get_signed_pre_key_id($0, nativeHandle)
+                }
             }
         }
     }
 
     public var baseKey: PublicKey {
-        return failOnError {
-            try invokeFnReturningNativeHandle {
-                signal_pre_key_signal_message_get_base_key($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningNativeHandle {
+                    signal_pre_key_signal_message_get_base_key($0, nativeHandle)
+                }
             }
         }
     }
 
     public var identityKey: PublicKey {
-        return failOnError {
-            try invokeFnReturningNativeHandle {
-                signal_pre_key_signal_message_get_identity_key($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningNativeHandle {
+                    signal_pre_key_signal_message_get_identity_key($0, nativeHandle)
+                }
             }
         }
     }
 
     public var signalMessage: SignalMessage {
-        var m: OpaquePointer?
-        failOnError(signal_pre_key_signal_message_get_signal_message(&m, nativeHandle))
-        return SignalMessage(owned: m!)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningNativeHandle {
+                    signal_pre_key_signal_message_get_signal_message($0, nativeHandle)
+                }
+            }
+        }
     }
 }

--- a/swift/Sources/SignalClient/messages/PreKeySignalMessage.swift
+++ b/swift/Sources/SignalClient/messages/PreKeySignalMessage.swift
@@ -1,47 +1,45 @@
 //
-// Copyright 2020 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
 import SignalFfi
 import Foundation
 
-public class PreKeySignalMessage {
-    private var handle: OpaquePointer?
-
-    deinit {
-        failOnError(signal_pre_key_signal_message_destroy(handle))
+public class PreKeySignalMessage: NativeHandleOwner {
+    internal override class func destroyNativeHandle(_ handle: OpaquePointer) -> SignalFfiErrorRef? {
+        return signal_pre_key_signal_message_destroy(handle)
     }
 
-    public init<Bytes: ContiguousBytes>(bytes: Bytes) throws {
-        handle = try bytes.withUnsafeBytes {
-            var result: OpaquePointer?
+    public convenience init<Bytes: ContiguousBytes>(bytes: Bytes) throws {
+        var result: OpaquePointer?
+        try bytes.withUnsafeBytes {
             try checkError(signal_pre_key_signal_message_deserialize(&result, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count))
-            return result
         }
+        self.init(owned: result!)
     }
 
     public func serialize() throws -> [UInt8] {
         return try invokeFnReturningArray {
-            signal_pre_key_signal_message_serialize($0, $1, handle)
+            signal_pre_key_signal_message_serialize($0, $1, nativeHandle)
         }
     }
 
     public func version() throws -> UInt32 {
         return try invokeFnReturningInteger {
-            signal_pre_key_signal_message_get_version($0, handle)
+            signal_pre_key_signal_message_get_version($0, nativeHandle)
         }
     }
 
     public func registrationId() throws -> UInt32 {
         return try invokeFnReturningInteger {
-            signal_pre_key_signal_message_get_registration_id($0, handle)
+            signal_pre_key_signal_message_get_registration_id($0, nativeHandle)
         }
     }
 
     public func preKeyId() throws -> UInt32? {
         let id = try invokeFnReturningInteger {
-            signal_pre_key_signal_message_get_pre_key_id($0, handle)
+            signal_pre_key_signal_message_get_pre_key_id($0, nativeHandle)
         }
 
         if id == 0xFFFFFFFF {
@@ -54,34 +52,30 @@ public class PreKeySignalMessage {
     public var signedPreKeyId: UInt32 {
         return failOnError {
             try invokeFnReturningInteger {
-                signal_pre_key_signal_message_get_signed_pre_key_id($0, handle)
+                signal_pre_key_signal_message_get_signed_pre_key_id($0, nativeHandle)
             }
         }
     }
 
     public var baseKey: PublicKey {
         return failOnError {
-            try invokeFnReturningPublicKey {
-                signal_pre_key_signal_message_get_base_key($0, handle)
+            try invokeFnReturningNativeHandle {
+                signal_pre_key_signal_message_get_base_key($0, nativeHandle)
             }
         }
     }
 
     public var identityKey: PublicKey {
         return failOnError {
-            try invokeFnReturningPublicKey {
-                signal_pre_key_signal_message_get_identity_key($0, handle)
+            try invokeFnReturningNativeHandle {
+                signal_pre_key_signal_message_get_identity_key($0, nativeHandle)
             }
         }
     }
 
     public var signalMessage: SignalMessage {
         var m: OpaquePointer?
-        failOnError(signal_pre_key_signal_message_get_signal_message(&m, handle))
-        return SignalMessage(owned: m)
-    }
-
-    internal var nativeHandle: OpaquePointer? {
-        return handle
+        failOnError(signal_pre_key_signal_message_get_signal_message(&m, nativeHandle))
+        return SignalMessage(owned: m!)
     }
 }

--- a/swift/Sources/SignalClient/messages/SenderKeyDistributionMessage.swift
+++ b/swift/Sources/SignalClient/messages/SenderKeyDistributionMessage.swift
@@ -1,46 +1,44 @@
 //
-// Copyright 2020 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
 import SignalFfi
 import Foundation
 
-public class SenderKeyDistributionMessage {
-    private var handle: OpaquePointer?
-
-    deinit {
-        failOnError(signal_sender_key_distribution_message_destroy(handle))
+public class SenderKeyDistributionMessage: NativeHandleOwner {
+    internal override class func destroyNativeHandle(_ handle: OpaquePointer) -> SignalFfiErrorRef? {
+        return signal_sender_key_distribution_message_destroy(handle)
     }
 
-    internal var nativeHandle: OpaquePointer? {
-        return handle
-    }
-
-    public init(from sender: ProtocolAddress,
-                distributionId: UUID,
-                store: SenderKeyStore,
-                context: StoreContext) throws {
+    public convenience init(from sender: ProtocolAddress,
+                            distributionId: UUID,
+                            store: SenderKeyStore,
+                            context: StoreContext) throws {
+        var result: OpaquePointer?
         try context.withOpaquePointer { context in
             try withUnsafePointer(to: distributionId.uuid) { distributionId in
                 try withSenderKeyStore(store) {
-                    try checkError(signal_sender_key_distribution_message_create(&handle,
+                    try checkError(signal_sender_key_distribution_message_create(&result,
                                                                                  sender.nativeHandle,
                                                                                  distributionId,
                                                                                  $0, context))
                 }
             }
         }
+        self.init(owned: result!)
     }
 
-    public init(bytes: [UInt8]) throws {
-        try checkError(signal_sender_key_distribution_message_deserialize(&handle, bytes, bytes.count))
+    public convenience init(bytes: [UInt8]) throws {
+        var result: OpaquePointer?
+        try checkError(signal_sender_key_distribution_message_deserialize(&result, bytes, bytes.count))
+        self.init(owned: result!)
     }
 
     public var signatureKey: PublicKey {
         return failOnError {
-            try invokeFnReturningPublicKey {
-                signal_sender_key_distribution_message_get_signature_key($0, handle)
+            try invokeFnReturningNativeHandle {
+                signal_sender_key_distribution_message_get_signature_key($0, nativeHandle)
             }
         }
     }
@@ -48,7 +46,7 @@ public class SenderKeyDistributionMessage {
     public var distributionId: UUID {
         return failOnError {
             try invokeFnReturningUuid {
-                signal_sender_key_message_get_distribution_id($0, handle)
+                signal_sender_key_message_get_distribution_id($0, nativeHandle)
             }
         }
     }
@@ -56,7 +54,7 @@ public class SenderKeyDistributionMessage {
     public var chainId: UInt32 {
         return failOnError {
             try invokeFnReturningInteger {
-                signal_sender_key_distribution_message_get_chain_id($0, handle)
+                signal_sender_key_distribution_message_get_chain_id($0, nativeHandle)
             }
         }
     }
@@ -64,7 +62,7 @@ public class SenderKeyDistributionMessage {
     public var iteration: UInt32 {
         return failOnError {
             try invokeFnReturningInteger {
-                signal_sender_key_distribution_message_get_iteration($0, handle)
+                signal_sender_key_distribution_message_get_iteration($0, nativeHandle)
             }
         }
     }
@@ -72,7 +70,7 @@ public class SenderKeyDistributionMessage {
     public func serialize() -> [UInt8] {
         return failOnError {
             try invokeFnReturningArray {
-                signal_sender_key_distribution_message_serialize($0, $1, handle)
+                signal_sender_key_distribution_message_serialize($0, $1, nativeHandle)
             }
         }
     }
@@ -80,7 +78,7 @@ public class SenderKeyDistributionMessage {
     public var chainKey: [UInt8] {
         return failOnError {
             try invokeFnReturningArray {
-                signal_sender_key_distribution_message_get_chain_key($0, $1, handle)
+                signal_sender_key_distribution_message_get_chain_key($0, $1, nativeHandle)
             }
         }
     }

--- a/swift/Sources/SignalClient/messages/SenderKeyDistributionMessage.swift
+++ b/swift/Sources/SignalClient/messages/SenderKeyDistributionMessage.swift
@@ -16,13 +16,15 @@ public class SenderKeyDistributionMessage: NativeHandleOwner {
                             store: SenderKeyStore,
                             context: StoreContext) throws {
         var result: OpaquePointer?
-        try context.withOpaquePointer { context in
-            try withUnsafePointer(to: distributionId.uuid) { distributionId in
-                try withSenderKeyStore(store) {
-                    try checkError(signal_sender_key_distribution_message_create(&result,
-                                                                                 sender.nativeHandle,
-                                                                                 distributionId,
-                                                                                 $0, context))
+        try sender.withNativeHandle { senderHandle in
+            try context.withOpaquePointer { context in
+                try withUnsafePointer(to: distributionId.uuid) { distributionId in
+                    try withSenderKeyStore(store) {
+                        try checkError(signal_sender_key_distribution_message_create(&result,
+                                                                                     senderHandle,
+                                                                                     distributionId,
+                                                                                     $0, context))
+                    }
                 }
             }
         }
@@ -36,49 +38,61 @@ public class SenderKeyDistributionMessage: NativeHandleOwner {
     }
 
     public var signatureKey: PublicKey {
-        return failOnError {
-            try invokeFnReturningNativeHandle {
-                signal_sender_key_distribution_message_get_signature_key($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningNativeHandle {
+                    signal_sender_key_distribution_message_get_signature_key($0, nativeHandle)
+                }
             }
         }
     }
 
     public var distributionId: UUID {
-        return failOnError {
-            try invokeFnReturningUuid {
-                signal_sender_key_message_get_distribution_id($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningUuid {
+                    signal_sender_key_message_get_distribution_id($0, nativeHandle)
+                }
             }
         }
     }
 
     public var chainId: UInt32 {
-        return failOnError {
-            try invokeFnReturningInteger {
-                signal_sender_key_distribution_message_get_chain_id($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningInteger {
+                    signal_sender_key_distribution_message_get_chain_id($0, nativeHandle)
+                }
             }
         }
     }
 
     public var iteration: UInt32 {
-        return failOnError {
-            try invokeFnReturningInteger {
-                signal_sender_key_distribution_message_get_iteration($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningInteger {
+                    signal_sender_key_distribution_message_get_iteration($0, nativeHandle)
+                }
             }
         }
     }
 
     public func serialize() -> [UInt8] {
-        return failOnError {
-            try invokeFnReturningArray {
-                signal_sender_key_distribution_message_serialize($0, $1, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningArray {
+                    signal_sender_key_distribution_message_serialize($0, $1, nativeHandle)
+                }
             }
         }
     }
 
     public var chainKey: [UInt8] {
-        return failOnError {
-            try invokeFnReturningArray {
-                signal_sender_key_distribution_message_get_chain_key($0, $1, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningArray {
+                    signal_sender_key_distribution_message_get_chain_key($0, $1, nativeHandle)
+                }
             }
         }
     }

--- a/swift/Sources/SignalClient/messages/SenderKeyMessage.swift
+++ b/swift/Sources/SignalClient/messages/SenderKeyMessage.swift
@@ -1,30 +1,28 @@
 //
-// Copyright 2020 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
 import SignalFfi
 import Foundation
 
-public class SenderKeyMessage {
-    private var handle: OpaquePointer?
-
-    deinit {
-        failOnError(signal_sender_key_message_destroy(handle))
+public class SenderKeyMessage: NativeHandleOwner {
+    internal override class func destroyNativeHandle(_ handle: OpaquePointer) -> SignalFfiErrorRef? {
+        return signal_sender_key_message_destroy(handle)
     }
 
-    public init<Bytes: ContiguousBytes>(bytes: Bytes) throws {
-        handle = try bytes.withUnsafeBytes {
-            var result: OpaquePointer?
+    public convenience init<Bytes: ContiguousBytes>(bytes: Bytes) throws {
+        var result: OpaquePointer?
+        try bytes.withUnsafeBytes {
             try checkError(signal_sender_key_message_deserialize(&result, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count))
-            return result
         }
+        self.init(owned: result!)
     }
 
     public var distributionId: UUID {
         return failOnError {
             try invokeFnReturningUuid {
-                signal_sender_key_message_get_distribution_id($0, handle)
+                signal_sender_key_message_get_distribution_id($0, nativeHandle)
             }
         }
     }
@@ -32,7 +30,7 @@ public class SenderKeyMessage {
     public var chainId: UInt32 {
         return failOnError {
             try invokeFnReturningInteger {
-                signal_sender_key_message_get_chain_id($0, handle)
+                signal_sender_key_message_get_chain_id($0, nativeHandle)
             }
         }
     }
@@ -40,7 +38,7 @@ public class SenderKeyMessage {
     public var iteration: UInt32 {
         return failOnError {
             try invokeFnReturningInteger {
-                signal_sender_key_message_get_iteration($0, handle)
+                signal_sender_key_message_get_iteration($0, nativeHandle)
             }
         }
     }
@@ -48,7 +46,7 @@ public class SenderKeyMessage {
     public func serialize() -> [UInt8] {
         return failOnError {
             try invokeFnReturningArray {
-                signal_sender_key_message_serialize($0, $1, handle)
+                signal_sender_key_message_serialize($0, $1, nativeHandle)
             }
         }
     }
@@ -56,14 +54,14 @@ public class SenderKeyMessage {
     public var ciphertext: [UInt8] {
         return failOnError {
             try invokeFnReturningArray {
-                signal_sender_key_message_get_cipher_text($0, $1, handle)
+                signal_sender_key_message_get_cipher_text($0, $1, nativeHandle)
             }
         }
     }
 
     public func verifySignature(against key: PublicKey) throws -> Bool {
         var result: Bool = false
-        try checkError(signal_sender_key_message_verify_signature(&result, handle, key.nativeHandle))
+        try checkError(signal_sender_key_message_verify_signature(&result, nativeHandle, key.nativeHandle))
         return result
     }
 }

--- a/swift/Sources/SignalClient/messages/SenderKeyMessage.swift
+++ b/swift/Sources/SignalClient/messages/SenderKeyMessage.swift
@@ -20,48 +20,60 @@ public class SenderKeyMessage: NativeHandleOwner {
     }
 
     public var distributionId: UUID {
-        return failOnError {
-            try invokeFnReturningUuid {
-                signal_sender_key_message_get_distribution_id($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningUuid {
+                    signal_sender_key_message_get_distribution_id($0, nativeHandle)
+                }
             }
         }
     }
 
     public var chainId: UInt32 {
-        return failOnError {
-            try invokeFnReturningInteger {
-                signal_sender_key_message_get_chain_id($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningInteger {
+                    signal_sender_key_message_get_chain_id($0, nativeHandle)
+                }
             }
         }
     }
 
     public var iteration: UInt32 {
-        return failOnError {
-            try invokeFnReturningInteger {
-                signal_sender_key_message_get_iteration($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningInteger {
+                    signal_sender_key_message_get_iteration($0, nativeHandle)
+                }
             }
         }
     }
 
     public func serialize() -> [UInt8] {
-        return failOnError {
-            try invokeFnReturningArray {
-                signal_sender_key_message_serialize($0, $1, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningArray {
+                    signal_sender_key_message_serialize($0, $1, nativeHandle)
+                }
             }
         }
     }
 
     public var ciphertext: [UInt8] {
-        return failOnError {
-            try invokeFnReturningArray {
-                signal_sender_key_message_get_cipher_text($0, $1, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningArray {
+                    signal_sender_key_message_get_cipher_text($0, $1, nativeHandle)
+                }
             }
         }
     }
 
     public func verifySignature(against key: PublicKey) throws -> Bool {
         var result: Bool = false
-        try checkError(signal_sender_key_message_verify_signature(&result, nativeHandle, key.nativeHandle))
+        try withNativeHandles(self, key) { messageHandle, keyHandle in
+            try checkError(signal_sender_key_message_verify_signature(&result, messageHandle, keyHandle))
+        }
         return result
     }
 }

--- a/swift/Sources/SignalClient/messages/SignalMessage.swift
+++ b/swift/Sources/SignalClient/messages/SignalMessage.swift
@@ -20,41 +20,51 @@ public class SignalMessage: NativeHandleOwner {
     }
 
     public var senderRatchetKey: PublicKey {
-        return failOnError {
-            try invokeFnReturningNativeHandle {
-                signal_message_get_sender_ratchet_key($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningNativeHandle {
+                    signal_message_get_sender_ratchet_key($0, nativeHandle)
+                }
             }
         }
     }
 
     public var body: [UInt8] {
-        return failOnError {
-            try invokeFnReturningArray {
-                signal_message_get_body($0, $1, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningArray {
+                    signal_message_get_body($0, $1, nativeHandle)
+                }
             }
         }
     }
 
     public func serialize() -> [UInt8] {
-        return failOnError {
-            try invokeFnReturningArray {
-                signal_message_get_serialized($0, $1, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningArray {
+                    signal_message_get_serialized($0, $1, nativeHandle)
+                }
             }
         }
     }
 
     public var messageVersion: UInt32 {
-        return failOnError {
-            try invokeFnReturningInteger {
-                signal_message_get_message_version($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningInteger {
+                    signal_message_get_message_version($0, nativeHandle)
+                }
             }
         }
     }
 
     public var counter: UInt32 {
-        return failOnError {
-            try invokeFnReturningInteger {
-                signal_message_get_counter($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningInteger {
+                    signal_message_get_counter($0, nativeHandle)
+                }
             }
         }
     }
@@ -62,15 +72,17 @@ public class SignalMessage: NativeHandleOwner {
     public func verifyMac<Bytes: ContiguousBytes>(sender: PublicKey,
                                                   receiver: PublicKey,
                                                   macKey: Bytes) throws -> Bool {
-        return try macKey.withUnsafeBytes {
-            var result: Bool = false
-            try checkError(signal_message_verify_mac(&result,
-                                                     nativeHandle,
-                                                     sender.nativeHandle,
-                                                     receiver.nativeHandle,
-                                                     $0.baseAddress?.assumingMemoryBound(to: UInt8.self),
-                                                     $0.count))
-            return result
+        return try withNativeHandles(self, sender, receiver) { messageHandle, senderHandle, receiverHandle in
+            try macKey.withUnsafeBytes {
+                var result: Bool = false
+                try checkError(signal_message_verify_mac(&result,
+                                                         messageHandle,
+                                                         senderHandle,
+                                                         receiverHandle,
+                                                         $0.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                                                         $0.count))
+                return result
+            }
         }
     }
 }

--- a/swift/Sources/SignalClient/state/PreKeyBundle.swift
+++ b/swift/Sources/SignalClient/state/PreKeyBundle.swift
@@ -21,17 +21,20 @@ public class PreKeyBundle: NativeHandleOwner {
                                                     signedPrekeySignature: Bytes,
                                                     identity identityKey: IdentityKey) throws {
         var result: OpaquePointer?
-        try signedPrekeySignature.withUnsafeBytes {
-            try checkError(signal_pre_key_bundle_new(&result,
-                                                     registrationId,
-                                                     deviceId,
-                                                     prekeyId,
-                                                     prekey.nativeHandle,
-                                                     signedPrekeyId,
-                                                     signedPrekey.nativeHandle,
-                                                     $0.baseAddress?.assumingMemoryBound(to: UInt8.self),
-                                                     $0.count,
-                                                     identityKey.publicKey.nativeHandle))
+        try withNativeHandles(prekey, signedPrekey, identityKey.publicKey) { prekeyHandle, signedPrekeyHandle, identityKeyHandle in
+            try signedPrekeySignature.withUnsafeBytes {
+                try checkError(signal_pre_key_bundle_new(&result,
+                                                         registrationId,
+                                                         deviceId,
+                                                         prekeyId,
+                                                         prekeyHandle,
+                                                         signedPrekeyId,
+                                                         signedPrekeyHandle,
+                                                         $0.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                                                         $0.count,
+                                                         identityKeyHandle))
+            }
+
         }
         self.init(owned: result!)
     }
@@ -44,49 +47,59 @@ public class PreKeyBundle: NativeHandleOwner {
                                                     signedPrekeySignature: Bytes,
                                                     identity identityKey: IdentityKey) throws {
         var result: OpaquePointer?
-        try signedPrekeySignature.withUnsafeBytes {
-            try checkError(signal_pre_key_bundle_new(&result,
-                                                     registrationId,
-                                                     deviceId,
-                                                     ~0,
-                                                     nil,
-                                                     signedPrekeyId,
-                                                     signedPrekey.nativeHandle,
-                                                     $0.baseAddress?.assumingMemoryBound(to: UInt8.self),
-                                                     $0.count,
-                                                     identityKey.publicKey.nativeHandle))
+        try withNativeHandles(signedPrekey, identityKey.publicKey) { signedPrekeyHandle, identityKeyHandle in
+            try signedPrekeySignature.withUnsafeBytes {
+                try checkError(signal_pre_key_bundle_new(&result,
+                                                         registrationId,
+                                                         deviceId,
+                                                         ~0,
+                                                         nil,
+                                                         signedPrekeyId,
+                                                         signedPrekeyHandle,
+                                                         $0.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                                                         $0.count,
+                                                         identityKeyHandle))
+            }
         }
         self.init(owned: result!)
     }
 
     public var registrationId: UInt32 {
-        return failOnError {
-            try invokeFnReturningInteger {
-                signal_pre_key_bundle_get_registration_id($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningInteger {
+                    signal_pre_key_bundle_get_registration_id($0, nativeHandle)
+                }
             }
         }
     }
 
     public var deviceId: UInt32 {
-        return failOnError {
-            try invokeFnReturningInteger {
-                signal_pre_key_bundle_get_device_id($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningInteger {
+                    signal_pre_key_bundle_get_device_id($0, nativeHandle)
+                }
             }
         }
     }
 
     public var signedPreKeyId: UInt32 {
-        return failOnError {
-            try invokeFnReturningInteger {
-                signal_pre_key_bundle_get_signed_pre_key_id($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningInteger {
+                    signal_pre_key_bundle_get_signed_pre_key_id($0, nativeHandle)
+                }
             }
         }
     }
 
     public var preKeyId: UInt32? {
-        let prekey_id = failOnError {
-            try invokeFnReturningInteger {
-                signal_pre_key_bundle_get_signed_pre_key_id($0, nativeHandle)
+        let prekey_id = withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningInteger {
+                    signal_pre_key_bundle_get_signed_pre_key_id($0, nativeHandle)
+                }
             }
         }
 
@@ -98,34 +111,42 @@ public class PreKeyBundle: NativeHandleOwner {
     }
 
     public var preKeyPublic: PublicKey? {
-        return failOnError {
-            try invokeFnReturningOptionalNativeHandle {
-                signal_pre_key_bundle_get_pre_key_public($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningOptionalNativeHandle {
+                    signal_pre_key_bundle_get_pre_key_public($0, nativeHandle)
+                }
             }
         }
     }
 
     public var identityKey: IdentityKey {
-        let pk: PublicKey = failOnError {
-            try invokeFnReturningNativeHandle {
-                signal_pre_key_bundle_get_identity_key($0, nativeHandle)
+        let pk: PublicKey = withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningNativeHandle {
+                    signal_pre_key_bundle_get_identity_key($0, nativeHandle)
+                }
             }
         }
         return IdentityKey(publicKey: pk)
     }
 
     public var signedPreKeyPublic: PublicKey {
-        return failOnError {
-            try invokeFnReturningNativeHandle {
-                signal_pre_key_bundle_get_signed_pre_key_public($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningNativeHandle {
+                    signal_pre_key_bundle_get_signed_pre_key_public($0, nativeHandle)
+                }
             }
         }
     }
 
     public var signedPreKeySignature: [UInt8] {
-        return failOnError {
-            try invokeFnReturningArray {
-                signal_pre_key_bundle_get_signed_pre_key_signature($0, $1, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningArray {
+                    signal_pre_key_bundle_get_signed_pre_key_signature($0, $1, nativeHandle)
+                }
             }
         }
     }

--- a/swift/Sources/SignalClient/state/PreKeyBundle.swift
+++ b/swift/Sources/SignalClient/state/PreKeyBundle.swift
@@ -1,33 +1,27 @@
 //
-// Copyright 2020 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
 import SignalFfi
 import Foundation
 
-public class PreKeyBundle {
-    private var handle: OpaquePointer?
-
-    deinit {
-        failOnError(signal_pre_key_bundle_destroy(handle))
-    }
-
-    internal var nativeHandle: OpaquePointer? {
-        return handle
+public class PreKeyBundle: NativeHandleOwner {
+    internal override class func destroyNativeHandle(_ handle: OpaquePointer) -> SignalFfiErrorRef? {
+        return signal_pre_key_bundle_destroy(handle)
     }
 
     // with a prekey
-    public init<Bytes: ContiguousBytes>(registrationId: UInt32,
-                                        deviceId: UInt32,
-                                        prekeyId: UInt32,
-                                        prekey: PublicKey,
-                                        signedPrekeyId: UInt32,
-                                        signedPrekey: PublicKey,
-                                        signedPrekeySignature: Bytes,
-                                        identity identityKey: IdentityKey) throws {
-        handle = try signedPrekeySignature.withUnsafeBytes {
-            var result: OpaquePointer?
+    public convenience init<Bytes: ContiguousBytes>(registrationId: UInt32,
+                                                    deviceId: UInt32,
+                                                    prekeyId: UInt32,
+                                                    prekey: PublicKey,
+                                                    signedPrekeyId: UInt32,
+                                                    signedPrekey: PublicKey,
+                                                    signedPrekeySignature: Bytes,
+                                                    identity identityKey: IdentityKey) throws {
+        var result: OpaquePointer?
+        try signedPrekeySignature.withUnsafeBytes {
             try checkError(signal_pre_key_bundle_new(&result,
                                                      registrationId,
                                                      deviceId,
@@ -38,19 +32,19 @@ public class PreKeyBundle {
                                                      $0.baseAddress?.assumingMemoryBound(to: UInt8.self),
                                                      $0.count,
                                                      identityKey.publicKey.nativeHandle))
-            return result
         }
+        self.init(owned: result!)
     }
 
     // without a prekey
-    public init<Bytes: ContiguousBytes>(registrationId: UInt32,
-                                        deviceId: UInt32,
-                                        signedPrekeyId: UInt32,
-                                        signedPrekey: PublicKey,
-                                        signedPrekeySignature: Bytes,
-                                        identity identityKey: IdentityKey) throws {
-        handle = try signedPrekeySignature.withUnsafeBytes {
-            var result: OpaquePointer?
+    public convenience init<Bytes: ContiguousBytes>(registrationId: UInt32,
+                                                    deviceId: UInt32,
+                                                    signedPrekeyId: UInt32,
+                                                    signedPrekey: PublicKey,
+                                                    signedPrekeySignature: Bytes,
+                                                    identity identityKey: IdentityKey) throws {
+        var result: OpaquePointer?
+        try signedPrekeySignature.withUnsafeBytes {
             try checkError(signal_pre_key_bundle_new(&result,
                                                      registrationId,
                                                      deviceId,
@@ -61,14 +55,14 @@ public class PreKeyBundle {
                                                      $0.baseAddress?.assumingMemoryBound(to: UInt8.self),
                                                      $0.count,
                                                      identityKey.publicKey.nativeHandle))
-            return result
         }
+        self.init(owned: result!)
     }
 
     public var registrationId: UInt32 {
         return failOnError {
             try invokeFnReturningInteger {
-                signal_pre_key_bundle_get_registration_id($0, handle)
+                signal_pre_key_bundle_get_registration_id($0, nativeHandle)
             }
         }
     }
@@ -76,7 +70,7 @@ public class PreKeyBundle {
     public var deviceId: UInt32 {
         return failOnError {
             try invokeFnReturningInteger {
-                signal_pre_key_bundle_get_device_id($0, handle)
+                signal_pre_key_bundle_get_device_id($0, nativeHandle)
             }
         }
     }
@@ -84,7 +78,7 @@ public class PreKeyBundle {
     public var signedPreKeyId: UInt32 {
         return failOnError {
             try invokeFnReturningInteger {
-                signal_pre_key_bundle_get_signed_pre_key_id($0, handle)
+                signal_pre_key_bundle_get_signed_pre_key_id($0, nativeHandle)
             }
         }
     }
@@ -92,7 +86,7 @@ public class PreKeyBundle {
     public var preKeyId: UInt32? {
         let prekey_id = failOnError {
             try invokeFnReturningInteger {
-                signal_pre_key_bundle_get_signed_pre_key_id($0, handle)
+                signal_pre_key_bundle_get_signed_pre_key_id($0, nativeHandle)
             }
         }
 
@@ -105,16 +99,16 @@ public class PreKeyBundle {
 
     public var preKeyPublic: PublicKey? {
         return failOnError {
-            try invokeFnReturningOptionalPublicKey {
-                signal_pre_key_bundle_get_pre_key_public($0, handle)
+            try invokeFnReturningOptionalNativeHandle {
+                signal_pre_key_bundle_get_pre_key_public($0, nativeHandle)
             }
         }
     }
 
     public var identityKey: IdentityKey {
-        let pk = failOnError {
-            try invokeFnReturningPublicKey {
-                signal_pre_key_bundle_get_identity_key($0, handle)
+        let pk: PublicKey = failOnError {
+            try invokeFnReturningNativeHandle {
+                signal_pre_key_bundle_get_identity_key($0, nativeHandle)
             }
         }
         return IdentityKey(publicKey: pk)
@@ -122,8 +116,8 @@ public class PreKeyBundle {
 
     public var signedPreKeyPublic: PublicKey {
         return failOnError {
-            try invokeFnReturningPublicKey {
-                signal_pre_key_bundle_get_signed_pre_key_public($0, handle)
+            try invokeFnReturningNativeHandle {
+                signal_pre_key_bundle_get_signed_pre_key_public($0, nativeHandle)
             }
         }
     }
@@ -131,7 +125,7 @@ public class PreKeyBundle {
     public var signedPreKeySignature: [UInt8] {
         return failOnError {
             try invokeFnReturningArray {
-                signal_pre_key_bundle_get_signed_pre_key_signature($0, $1, handle)
+                signal_pre_key_bundle_get_signed_pre_key_signature($0, $1, nativeHandle)
             }
         }
     }

--- a/swift/Sources/SignalClient/state/PreKeyRecord.swift
+++ b/swift/Sources/SignalClient/state/PreKeyRecord.swift
@@ -28,7 +28,9 @@ public class PreKeyRecord: ClonableHandleOwner {
                             publicKey: PublicKey,
                             privateKey: PrivateKey) throws {
         var handle: OpaquePointer?
-        try checkError(signal_pre_key_record_new(&handle, id, publicKey.nativeHandle, privateKey.nativeHandle))
+        try withNativeHandles(publicKey, privateKey) { publicKeyHandle, privateKeyHandle in
+            try checkError(signal_pre_key_record_new(&handle, id, publicKeyHandle, privateKeyHandle))
+        }
         self.init(owned: handle!)
     }
 
@@ -37,33 +39,41 @@ public class PreKeyRecord: ClonableHandleOwner {
     }
 
     public func serialize() -> [UInt8] {
-        return failOnError {
-            try invokeFnReturningArray {
-                signal_pre_key_record_serialize($0, $1, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningArray {
+                    signal_pre_key_record_serialize($0, $1, nativeHandle)
+                }
             }
         }
     }
 
     public var id: UInt32 {
-        return failOnError {
-            try invokeFnReturningInteger {
-                signal_pre_key_record_get_id($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningInteger {
+                    signal_pre_key_record_get_id($0, nativeHandle)
+                }
             }
         }
     }
 
     public var publicKey: PublicKey {
-        return failOnError {
-            try invokeFnReturningNativeHandle {
-                signal_pre_key_record_get_public_key($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningNativeHandle {
+                    signal_pre_key_record_get_public_key($0, nativeHandle)
+                }
             }
         }
     }
 
     public var privateKey: PrivateKey {
-        return failOnError {
-            try invokeFnReturningNativeHandle {
-                signal_pre_key_record_get_private_key($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningNativeHandle {
+                    signal_pre_key_record_get_private_key($0, nativeHandle)
+                }
             }
         }
     }

--- a/swift/Sources/SignalClient/state/PreKeyRecord.swift
+++ b/swift/Sources/SignalClient/state/PreKeyRecord.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
@@ -15,25 +15,21 @@ public class PreKeyRecord: ClonableHandleOwner {
         return signal_pre_key_record_clone(&newHandle, currentHandle)
     }
 
-    public init<Bytes: ContiguousBytes>(bytes: Bytes) throws {
+    public convenience init<Bytes: ContiguousBytes>(bytes: Bytes) throws {
         let handle: OpaquePointer? = try bytes.withUnsafeBytes {
             var result: OpaquePointer?
             try checkError(signal_pre_key_record_deserialize(&result, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count))
             return result
         }
-        super.init(owned: handle!)
+        self.init(owned: handle!)
     }
 
-    internal override init(borrowing handle: OpaquePointer?) {
-        super.init(borrowing: handle)
-    }
-
-    public init(id: UInt32,
-                publicKey: PublicKey,
-                privateKey: PrivateKey) throws {
+    public convenience init(id: UInt32,
+                            publicKey: PublicKey,
+                            privateKey: PrivateKey) throws {
         var handle: OpaquePointer?
         try checkError(signal_pre_key_record_new(&handle, id, publicKey.nativeHandle, privateKey.nativeHandle))
-        super.init(owned: handle!)
+        self.init(owned: handle!)
     }
 
     public convenience init(id: UInt32, privateKey: PrivateKey) throws {
@@ -58,7 +54,7 @@ public class PreKeyRecord: ClonableHandleOwner {
 
     public var publicKey: PublicKey {
         return failOnError {
-            try invokeFnReturningPublicKey {
+            try invokeFnReturningNativeHandle {
                 signal_pre_key_record_get_public_key($0, nativeHandle)
             }
         }
@@ -66,7 +62,7 @@ public class PreKeyRecord: ClonableHandleOwner {
 
     public var privateKey: PrivateKey {
         return failOnError {
-            try invokeFnReturningPrivateKey {
+            try invokeFnReturningNativeHandle {
                 signal_pre_key_record_get_private_key($0, nativeHandle)
             }
         }

--- a/swift/Sources/SignalClient/state/SenderKeyRecord.swift
+++ b/swift/Sources/SignalClient/state/SenderKeyRecord.swift
@@ -15,27 +15,19 @@ public class SenderKeyRecord: ClonableHandleOwner {
         return signal_sender_key_record_clone(&newHandle, currentHandle)
     }
 
-    public init<Bytes: ContiguousBytes>(bytes: Bytes) throws {
+    public convenience init<Bytes: ContiguousBytes>(bytes: Bytes) throws {
         let handle: OpaquePointer? = try bytes.withUnsafeBytes {
             var result: OpaquePointer?
             try checkError(signal_sender_key_record_deserialize(&result, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count))
             return result
         }
-        super.init(owned: handle!)
+        self.init(owned: handle!)
     }
 
-    internal override init(owned handle: OpaquePointer) {
-        super.init(owned: handle)
-    }
-
-    internal override init(borrowing handle: OpaquePointer?) {
-        super.init(borrowing: handle)
-    }
-
-    public init() {
+    public convenience init() {
         var handle: OpaquePointer?
         failOnError(signal_sender_key_record_new_fresh(&handle))
-        super.init(owned: handle!)
+        self.init(owned: handle!)
     }
 
     public func serialize() -> [UInt8] {

--- a/swift/Sources/SignalClient/state/SenderKeyRecord.swift
+++ b/swift/Sources/SignalClient/state/SenderKeyRecord.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
@@ -31,9 +31,11 @@ public class SenderKeyRecord: ClonableHandleOwner {
     }
 
     public func serialize() -> [UInt8] {
-        return failOnError {
-            try invokeFnReturningArray {
-                signal_sender_key_record_serialize($0, $1, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningArray {
+                    signal_sender_key_record_serialize($0, $1, nativeHandle)
+                }
             }
         }
     }

--- a/swift/Sources/SignalClient/state/SessionRecord.swift
+++ b/swift/Sources/SignalClient/state/SessionRecord.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
@@ -25,32 +25,42 @@ public class SessionRecord: ClonableHandleOwner {
     }
 
     public func serialize() -> [UInt8] {
-        return failOnError {
-            try invokeFnReturningArray {
-                signal_session_record_serialize($0, $1, nativeHandle)
+        return self.withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningArray {
+                    signal_session_record_serialize($0, $1, nativeHandle)
+                }
             }
         }
     }
 
     public var hasCurrentState: Bool {
         var result = false
-        failOnError(signal_session_record_has_current_state(&result, nativeHandle))
+        self.withNativeHandle { nativeHandle in
+            failOnError(signal_session_record_has_current_state(&result, nativeHandle))
+        }
         return result
     }
 
     public func archiveCurrentState() {
-        failOnError(signal_session_record_archive_current_state(nativeHandle))
+        self.withNativeHandle { nativeHandle in
+            failOnError(signal_session_record_archive_current_state(nativeHandle))
+        }
     }
 
     public func remoteRegistrationId() throws -> UInt32 {
-        return try invokeFnReturningInteger {
-            signal_session_record_get_remote_registration_id($0, nativeHandle)
+        return try self.withNativeHandle { nativeHandle in
+            try invokeFnReturningInteger {
+                signal_session_record_get_remote_registration_id($0, nativeHandle)
+            }
         }
     }
 
     public func currentRatchetKeyMatches(_ key: PublicKey) throws -> Bool {
         var result: Bool = false
-        try checkError(signal_session_record_current_ratchet_key_matches(&result, nativeHandle, key.nativeHandle))
+        try withNativeHandles(self, key) { sessionHandle, keyHandle in
+            try checkError(signal_session_record_current_ratchet_key_matches(&result, sessionHandle, keyHandle))
+        }
         return result
     }
 }

--- a/swift/Sources/SignalClient/state/SessionRecord.swift
+++ b/swift/Sources/SignalClient/state/SessionRecord.swift
@@ -15,17 +15,13 @@ public class SessionRecord: ClonableHandleOwner {
         return signal_session_record_clone(&newHandle, currentHandle)
     }
 
-    public init<Bytes: ContiguousBytes>(bytes: Bytes) throws {
+    public convenience init<Bytes: ContiguousBytes>(bytes: Bytes) throws {
         let handle: OpaquePointer? = try bytes.withUnsafeBytes {
             var result: OpaquePointer?
             try checkError(signal_session_record_deserialize(&result, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count))
             return result
         }
-        super.init(owned: handle!)
-    }
-
-    internal override init(borrowing handle: OpaquePointer?) {
-        super.init(borrowing: handle)
+        self.init(owned: handle!)
     }
 
     public func serialize() -> [UInt8] {

--- a/swift/Sources/SignalClient/state/SignedPreKeyRecord.swift
+++ b/swift/Sources/SignalClient/state/SignedPreKeyRecord.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Signal Messenger, LLC
+// Copyright 2020-2021 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
@@ -29,60 +29,73 @@ public class SignedPreKeyRecord: ClonableHandleOwner {
                                                     privateKey: PrivateKey,
                                                     signature: Bytes) throws {
         let publicKey = privateKey.publicKey
-        let handle: OpaquePointer? = try signature.withUnsafeBytes {
-            var result: OpaquePointer?
-            try checkError(signal_signed_pre_key_record_new(&result, id, timestamp,
-                                                            publicKey.nativeHandle, privateKey.nativeHandle,
-                                                            $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count))
-            return result
+        var result: OpaquePointer?
+        try withNativeHandles(publicKey, privateKey) { publicKeyHandle, privateKeyHandle in
+            try signature.withUnsafeBytes {
+                try checkError(signal_signed_pre_key_record_new(&result, id, timestamp,
+                                                                publicKeyHandle, privateKeyHandle,
+                                                                $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count))
+            }
         }
-        self.init(owned: handle!)
+        self.init(owned: result!)
     }
 
     public func serialize() -> [UInt8] {
-        return failOnError {
-            try invokeFnReturningArray {
-                signal_signed_pre_key_record_serialize($0, $1, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningArray {
+                    signal_signed_pre_key_record_serialize($0, $1, nativeHandle)
+                }
             }
         }
     }
 
     public var id: UInt32 {
-        return failOnError {
-            try invokeFnReturningInteger {
-                signal_signed_pre_key_record_get_id($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningInteger {
+                    signal_signed_pre_key_record_get_id($0, nativeHandle)
+                }
             }
         }
     }
 
     public var timestamp: UInt64 {
-        return failOnError {
-            try invokeFnReturningInteger {
-                signal_signed_pre_key_record_get_timestamp($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningInteger {
+                    signal_signed_pre_key_record_get_timestamp($0, nativeHandle)
+                }
             }
         }
     }
 
     public var publicKey: PublicKey {
-        return failOnError {
-            try invokeFnReturningNativeHandle {
-                signal_signed_pre_key_record_get_public_key($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningNativeHandle {
+                    signal_signed_pre_key_record_get_public_key($0, nativeHandle)
+                }
             }
         }
     }
 
     public var privateKey: PrivateKey {
-        return failOnError {
-            try invokeFnReturningNativeHandle {
-                signal_signed_pre_key_record_get_private_key($0, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningNativeHandle {
+                    signal_signed_pre_key_record_get_private_key($0, nativeHandle)
+                }
             }
         }
     }
 
     public var signature: [UInt8] {
-        return failOnError {
-            try invokeFnReturningArray {
-                signal_signed_pre_key_record_get_signature($0, $1, nativeHandle)
+        return withNativeHandle { nativeHandle in
+            failOnError {
+                try invokeFnReturningArray {
+                    signal_signed_pre_key_record_get_signature($0, $1, nativeHandle)
+                }
             }
         }
     }

--- a/swift/Sources/SignalClient/state/SignedPreKeyRecord.swift
+++ b/swift/Sources/SignalClient/state/SignedPreKeyRecord.swift
@@ -15,19 +15,19 @@ public class SignedPreKeyRecord: ClonableHandleOwner {
         return signal_signed_pre_key_record_clone(&newHandle, currentHandle)
     }
 
-    public init<Bytes: ContiguousBytes>(bytes: Bytes) throws {
+    public convenience init<Bytes: ContiguousBytes>(bytes: Bytes) throws {
         let handle: OpaquePointer? = try bytes.withUnsafeBytes {
             var result: OpaquePointer?
             try checkError(signal_signed_pre_key_record_deserialize(&result, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count))
             return result
         }
-        super.init(owned: handle!)
+        self.init(owned: handle!)
     }
 
-    public init<Bytes: ContiguousBytes>(id: UInt32,
-                                        timestamp: UInt64,
-                                        privateKey: PrivateKey,
-                                        signature: Bytes) throws {
+    public convenience init<Bytes: ContiguousBytes>(id: UInt32,
+                                                    timestamp: UInt64,
+                                                    privateKey: PrivateKey,
+                                                    signature: Bytes) throws {
         let publicKey = privateKey.publicKey
         let handle: OpaquePointer? = try signature.withUnsafeBytes {
             var result: OpaquePointer?
@@ -36,11 +36,7 @@ public class SignedPreKeyRecord: ClonableHandleOwner {
                                                             $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count))
             return result
         }
-        super.init(owned: handle!)
-    }
-
-    internal override init(borrowing handle: OpaquePointer?) {
-        super.init(borrowing: handle)
+        self.init(owned: handle!)
     }
 
     public func serialize() -> [UInt8] {
@@ -69,7 +65,7 @@ public class SignedPreKeyRecord: ClonableHandleOwner {
 
     public var publicKey: PublicKey {
         return failOnError {
-            try invokeFnReturningPublicKey {
+            try invokeFnReturningNativeHandle {
                 signal_signed_pre_key_record_get_public_key($0, nativeHandle)
             }
         }
@@ -77,7 +73,7 @@ public class SignedPreKeyRecord: ClonableHandleOwner {
 
     public var privateKey: PrivateKey {
         return failOnError {
-            try invokeFnReturningPrivateKey {
+            try invokeFnReturningNativeHandle {
                 signal_signed_pre_key_record_get_private_key($0, nativeHandle)
             }
         }


### PR DESCRIPTION
The Swift version of #380. This one's mostly being proactive, since the Swift compiler will not optimize across modules at this time without explicitly marking code as inlinable, but it's possible that an operation that creates and destroys an object entirely within the SignalClient module could have the deinitialization of the Swift wrapper happen before the Rust object pointer's final use. The standard `withExtendedLifetime` protects against this, and the new `withNativeHandle` wraps that up to access the native object pointer at the same time.

In order to implement this uniformly, I also brought all wrapper objects under a common superclass.

