### PR TITLE
Two small fixes for Java

### DIFF
--- a/java/java/src/main/java/org/whispersystems/libsignal/SignalProtocolAddress.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/SignalProtocolAddress.java
@@ -38,7 +38,7 @@ public class SignalProtocolAddress implements NativeHandleGuard.Owner {
 
   @Override
   public String toString() {
-    return getName() + ":" + getDeviceId();
+    return getName() + "." + getDeviceId();
   }
 
   @Override

--- a/java/java/src/main/java/org/whispersystems/libsignal/StaleKeyExchangeException.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/StaleKeyExchangeException.java
@@ -1,9 +1,0 @@
-/**
- * Copyright (C) 2014-2016 Open Whisper Systems
- *
- * Licensed according to the LICENSE file in this repository.
- */
-package org.whispersystems.libsignal;
-
-public class StaleKeyExchangeException extends Throwable {
-}


### PR DESCRIPTION
- Remove unused StaleKeyExchangeException
- Change SignalProtocolAddress.toString to "UUID.device", instead of "UUID:device". Neither is inherently better than the
other but Desktop and the Rust library both use "UUID.device" already.