### PR TITLE
bridge: Add zkgroup APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,6 +809,7 @@ dependencies = [
  "signal-neon-futures",
  "static_assertions",
  "uuid",
+ "zkgroup",
 ]
 
 [[package]]
@@ -839,6 +840,7 @@ dependencies = [
  "log-panics",
  "rand 0.7.3",
  "signal-crypto",
+ "zkgroup",
 ]
 
 [[package]]

--- a/java/java/src/main/java/org/signal/client/internal/Native.java
+++ b/java/java/src/main/java/org/signal/client/internal/Native.java
@@ -104,6 +104,14 @@ public final class Native {
   public static native byte[] Aes256GcmSiv_Encrypt(long aesGcmSivObj, byte[] ptext, byte[] nonce, byte[] associatedData);
   public static native long Aes256GcmSiv_New(byte[] key);
 
+  public static native void AuthCredentialPresentation_CheckValidContents(byte[] obj);
+  public static native int AuthCredentialPresentation_GetRedemptionTime(byte[] presentation);
+  public static native byte[] AuthCredentialPresentation_GetUuidCiphertext(byte[] presentation);
+
+  public static native void AuthCredentialResponse_CheckValidContents(byte[] obj);
+
+  public static native void AuthCredential_CheckValidContents(byte[] obj);
+
   public static native void CryptographicHash_Destroy(long handle);
   public static native byte[] CryptographicHash_Finalize(long hash);
   public static native long CryptographicHash_New(String algo);
@@ -145,6 +153,23 @@ public final class Native {
 
   public static native byte[] GroupCipher_DecryptMessage(long sender, byte[] message, SenderKeyStore store, Object ctx);
   public static native CiphertextMessage GroupCipher_EncryptMessage(long sender, UUID distributionId, byte[] message, SenderKeyStore store, Object ctx);
+
+  public static native void GroupMasterKey_CheckValidContents(byte[] obj);
+
+  public static native void GroupPublicParams_CheckValidContents(byte[] obj);
+  public static native byte[] GroupPublicParams_GetGroupIdentifier(byte[] groupPublicParams);
+
+  public static native void GroupSecretParams_CheckValidContents(byte[] obj);
+  public static native byte[] GroupSecretParams_DecryptBlob(byte[] params, byte[] ciphertext);
+  public static native byte[] GroupSecretParams_DecryptProfileKey(byte[] params, byte[] profileKey, UUID uuid);
+  public static native UUID GroupSecretParams_DecryptUuid(byte[] params, byte[] uuid);
+  public static native byte[] GroupSecretParams_DeriveFromMasterKey(byte[] masterKey);
+  public static native byte[] GroupSecretParams_EncryptBlobDeterministic(byte[] params, byte[] randomness, byte[] plaintext);
+  public static native byte[] GroupSecretParams_EncryptProfileKey(byte[] params, byte[] profileKey, UUID uuid);
+  public static native byte[] GroupSecretParams_EncryptUuid(byte[] params, UUID uuid);
+  public static native byte[] GroupSecretParams_GenerateDeterministic(byte[] randomness);
+  public static native byte[] GroupSecretParams_GetMasterKey(byte[] params);
+  public static native byte[] GroupSecretParams_GetPublicParams(byte[] params);
 
   public static native long GroupSessionBuilder_CreateSenderKeyDistributionMessage(long sender, UUID distributionId, SenderKeyStore store, Object ctx);
   public static native void GroupSessionBuilder_ProcessSenderKeyDistributionMessage(long sender, long senderKeyDistributionMessage, SenderKeyStore store, Object ctx);
@@ -207,10 +232,47 @@ public final class Native {
   public static native int PreKeySignalMessage_GetVersion(long obj);
   public static native long PreKeySignalMessage_New(int messageVersion, int registrationId, int preKeyId, int signedPreKeyId, long baseKey, long identityKey, long signalMessage);
 
+  public static native void ProfileKeyCiphertext_CheckValidContents(byte[] obj);
+
+  public static native void ProfileKeyCommitment_CheckValidContents(byte[] obj);
+
+  public static native void ProfileKeyCredentialPresentation_CheckValidContents(byte[] obj);
+  public static native byte[] ProfileKeyCredentialPresentation_GetProfileKeyCiphertext(byte[] presentation);
+  public static native byte[] ProfileKeyCredentialPresentation_GetUuidCiphertext(byte[] presentation);
+
+  public static native void ProfileKeyCredentialRequestContext_CheckValidContents(byte[] obj);
+  public static native byte[] ProfileKeyCredentialRequestContext_GetRequest(byte[] context);
+
+  public static native void ProfileKeyCredentialRequest_CheckValidContents(byte[] obj);
+
+  public static native void ProfileKeyCredentialResponse_CheckValidContents(byte[] obj);
+
+  public static native void ProfileKeyCredential_CheckValidContents(byte[] obj);
+
+  public static native void ProfileKey_CheckValidContents(byte[] obj);
+  public static native byte[] ProfileKey_GetCommitment(byte[] profileKey, UUID uuid);
+  public static native byte[] ProfileKey_GetProfileKeyVersion(byte[] profileKey, UUID uuid);
+
   public static native void ProtocolAddress_Destroy(long handle);
   public static native int ProtocolAddress_DeviceId(long obj);
   public static native String ProtocolAddress_Name(long obj);
   public static native long ProtocolAddress_New(String name, int deviceId);
+
+  public static native void ReceiptCredentialPresentation_CheckValidContents(byte[] obj);
+  public static native long ReceiptCredentialPresentation_GetReceiptExpirationTime(byte[] presentation);
+  public static native long ReceiptCredentialPresentation_GetReceiptLevel(byte[] presentation);
+  public static native byte[] ReceiptCredentialPresentation_GetReceiptSerial(byte[] presentation);
+
+  public static native void ReceiptCredentialRequestContext_CheckValidContents(byte[] obj);
+  public static native byte[] ReceiptCredentialRequestContext_GetRequest(byte[] requestContext);
+
+  public static native void ReceiptCredentialRequest_CheckValidContents(byte[] obj);
+
+  public static native void ReceiptCredentialResponse_CheckValidContents(byte[] obj);
+
+  public static native void ReceiptCredential_CheckValidContents(byte[] obj);
+  public static native long ReceiptCredential_GetReceiptExpirationTime(byte[] receiptCredential);
+  public static native long ReceiptCredential_GetReceiptLevel(byte[] receiptCredential);
 
   public static native boolean ScannableFingerprint_Compare(byte[] fprint1, byte[] fprint2);
 
@@ -267,6 +329,28 @@ public final class Native {
   public static native byte[] ServerCertificate_GetSignature(long obj);
   public static native long ServerCertificate_New(int keyId, long serverKey, long trustRoot);
 
+  public static native void ServerPublicParams_CheckValidContents(byte[] obj);
+  public static native byte[] ServerPublicParams_CreateAuthCredentialPresentationDeterministic(byte[] serverPublicParams, byte[] randomness, byte[] groupSecretParams, byte[] authCredential);
+  public static native byte[] ServerPublicParams_CreateProfileKeyCredentialPresentationDeterministic(byte[] serverPublicParams, byte[] randomness, byte[] groupSecretParams, byte[] profileKeyCredential);
+  public static native byte[] ServerPublicParams_CreateProfileKeyCredentialRequestContextDeterministic(byte[] serverPublicParams, byte[] randomness, UUID uuid, byte[] profileKey);
+  public static native byte[] ServerPublicParams_CreateReceiptCredentialPresentationDeterministic(byte[] serverPublicParams, byte[] randomness, byte[] receiptCredential);
+  public static native byte[] ServerPublicParams_CreateReceiptCredentialRequestContextDeterministic(byte[] serverPublicParams, byte[] randomness, byte[] receiptSerial);
+  public static native byte[] ServerPublicParams_ReceiveAuthCredential(byte[] params, UUID uuid, int redemptionTime, byte[] response);
+  public static native byte[] ServerPublicParams_ReceiveProfileKeyCredential(byte[] serverPublicParams, byte[] requestContext, byte[] response);
+  public static native byte[] ServerPublicParams_ReceiveReceiptCredential(byte[] serverPublicParams, byte[] requestContext, byte[] response);
+  public static native void ServerPublicParams_VerifySignature(byte[] serverPublicParams, byte[] message, byte[] notarySignature);
+
+  public static native void ServerSecretParams_CheckValidContents(byte[] obj);
+  public static native byte[] ServerSecretParams_GenerateDeterministic(byte[] randomness);
+  public static native byte[] ServerSecretParams_GetPublicParams(byte[] params);
+  public static native byte[] ServerSecretParams_IssueAuthCredentialDeterministic(byte[] serverSecretParams, byte[] randomness, UUID uuid, int redemptionTime);
+  public static native byte[] ServerSecretParams_IssueProfileKeyCredentialDeterministic(byte[] serverSecretParams, byte[] randomness, byte[] request, UUID uuid, byte[] commitment);
+  public static native byte[] ServerSecretParams_IssueReceiptCredentialDeterministic(byte[] serverSecretParams, byte[] randomness, byte[] request, long receiptExpirationTime, long receiptLevel);
+  public static native byte[] ServerSecretParams_SignDeterministic(byte[] params, byte[] randomness, byte[] message);
+  public static native void ServerSecretParams_VerifyAuthCredentialPresentation(byte[] serverSecretParams, byte[] groupPublicParams, byte[] presentation);
+  public static native void ServerSecretParams_VerifyProfileKeyCredentialPresentation(byte[] serverSecretParams, byte[] groupPublicParams, byte[] presentation);
+  public static native void ServerSecretParams_VerifyReceiptCredentialPresentation(byte[] serverSecretParams, byte[] presentation);
+
   public static native void SessionBuilder_ProcessPreKeyBundle(long bundle, long protocolAddress, SessionStore sessionStore, IdentityKeyStore identityKeyStore, Object ctx);
 
   public static native byte[] SessionCipher_DecryptPreKeySignalMessage(long message, long protocolAddress, SessionStore sessionStore, IdentityKeyStore identityKeyStore, PreKeyStore prekeyStore, SignedPreKeyStore signedPrekeyStore, Object ctx);
@@ -321,4 +405,6 @@ public final class Native {
   public static native long UnidentifiedSenderMessageContent_GetSenderCert(long m);
   public static native byte[] UnidentifiedSenderMessageContent_GetSerialized(long obj);
   public static native long UnidentifiedSenderMessageContent_New(CiphertextMessage message, long sender, int contentHint, byte[] groupId);
+
+  public static native void UuidCiphertext_CheckValidContents(byte[] obj);
 }

--- a/node/Native.d.ts
+++ b/node/Native.d.ts
@@ -50,6 +50,11 @@ export const enum LogLevel { Error = 1, Warn, Info, Debug, Trace }
 export function Aes256GcmSiv_Decrypt(aesGcmSiv: Wrapper<Aes256GcmSiv>, ctext: Buffer, nonce: Buffer, associatedData: Buffer): Buffer;
 export function Aes256GcmSiv_Encrypt(aesGcmSivObj: Wrapper<Aes256GcmSiv>, ptext: Buffer, nonce: Buffer, associatedData: Buffer): Buffer;
 export function Aes256GcmSiv_New(key: Buffer): Aes256GcmSiv;
+export function AuthCredentialPresentation_CheckValidContents(Obj: Serialized<AuthCredentialPresentation>): void;
+export function AuthCredentialPresentation_GetRedemptionTime(presentation: Serialized<AuthCredentialPresentation>): number;
+export function AuthCredentialPresentation_GetUuidCiphertext(presentation: Serialized<AuthCredentialPresentation>): Serialized<UuidCiphertext>;
+export function AuthCredentialResponse_CheckValidContents(Obj: Serialized<AuthCredentialResponse>): void;
+export function AuthCredential_CheckValidContents(Obj: Serialized<AuthCredential>): void;
 export function CiphertextMessage_FromPlaintextContent(m: Wrapper<PlaintextContent>): CiphertextMessage;
 export function CiphertextMessage_Serialize(obj: Wrapper<CiphertextMessage>): Buffer;
 export function CiphertextMessage_Type(msg: Wrapper<CiphertextMessage>): number;
@@ -65,6 +70,20 @@ export function Fingerprint_New(iterations: number, version: number, localIdenti
 export function Fingerprint_ScannableEncoding(obj: Wrapper<Fingerprint>): Buffer;
 export function GroupCipher_DecryptMessage(sender: Wrapper<ProtocolAddress>, message: Buffer, store: SenderKeyStore, ctx: null): Promise<Buffer>;
 export function GroupCipher_EncryptMessage(sender: Wrapper<ProtocolAddress>, distributionId: Uuid, message: Buffer, store: SenderKeyStore, ctx: null): Promise<CiphertextMessage>;
+export function GroupMasterKey_CheckValidContents(Obj: Serialized<GroupMasterKey>): void;
+export function GroupPublicParams_CheckValidContents(Obj: Serialized<GroupPublicParams>): void;
+export function GroupPublicParams_GetGroupIdentifier(groupPublicParams: Serialized<GroupPublicParams>): Buffer;
+export function GroupSecretParams_CheckValidContents(Obj: Serialized<GroupSecretParams>): void;
+export function GroupSecretParams_DecryptBlob(params: Serialized<GroupSecretParams>, ciphertext: Buffer): Buffer;
+export function GroupSecretParams_DecryptProfileKey(params: Serialized<GroupSecretParams>, profileKey: Serialized<ProfileKeyCiphertext>, uuid: Uuid): Serialized<ProfileKey>;
+export function GroupSecretParams_DecryptUuid(params: Serialized<GroupSecretParams>, uuid: Serialized<UuidCiphertext>): Uuid;
+export function GroupSecretParams_DeriveFromMasterKey(masterKey: Serialized<GroupMasterKey>): Serialized<GroupSecretParams>;
+export function GroupSecretParams_EncryptBlobDeterministic(params: Serialized<GroupSecretParams>, randomness: Buffer, plaintext: Buffer): Buffer;
+export function GroupSecretParams_EncryptProfileKey(params: Serialized<GroupSecretParams>, profileKey: Serialized<ProfileKey>, uuid: Uuid): Serialized<ProfileKeyCiphertext>;
+export function GroupSecretParams_EncryptUuid(params: Serialized<GroupSecretParams>, uuid: Uuid): Serialized<UuidCiphertext>;
+export function GroupSecretParams_GenerateDeterministic(randomness: Buffer): Serialized<GroupSecretParams>;
+export function GroupSecretParams_GetMasterKey(params: Serialized<GroupSecretParams>): Serialized<GroupMasterKey>;
+export function GroupSecretParams_GetPublicParams(params: Serialized<GroupSecretParams>): Serialized<GroupPublicParams>;
 export function HKDF_DeriveSecrets(outputLength: number, ikm: Buffer, label: Buffer | null, salt: Buffer | null): Buffer;
 export function HsmEnclaveClient_CompleteHandshake(cli: Wrapper<HsmEnclaveClient>, handshakeReceived: Buffer): void;
 export function HsmEnclaveClient_EstablishedRecv(cli: Wrapper<HsmEnclaveClient>, receivedCiphertext: Buffer): Buffer;
@@ -104,6 +123,19 @@ export function PrivateKey_Generate(): PrivateKey;
 export function PrivateKey_GetPublicKey(k: Wrapper<PrivateKey>): PublicKey;
 export function PrivateKey_Serialize(obj: Wrapper<PrivateKey>): Buffer;
 export function PrivateKey_Sign(key: Wrapper<PrivateKey>, message: Buffer): Buffer;
+export function ProfileKeyCiphertext_CheckValidContents(Obj: Serialized<ProfileKeyCiphertext>): void;
+export function ProfileKeyCommitment_CheckValidContents(Obj: Serialized<ProfileKeyCommitment>): void;
+export function ProfileKeyCredentialPresentation_CheckValidContents(Obj: Serialized<ProfileKeyCredentialPresentation>): void;
+export function ProfileKeyCredentialPresentation_GetProfileKeyCiphertext(presentation: Serialized<ProfileKeyCredentialPresentation>): Serialized<ProfileKeyCiphertext>;
+export function ProfileKeyCredentialPresentation_GetUuidCiphertext(presentation: Serialized<ProfileKeyCredentialPresentation>): Serialized<UuidCiphertext>;
+export function ProfileKeyCredentialRequestContext_CheckValidContents(Obj: Serialized<ProfileKeyCredentialRequestContext>): void;
+export function ProfileKeyCredentialRequestContext_GetRequest(context: Serialized<ProfileKeyCredentialRequestContext>): Serialized<ProfileKeyCredentialRequest>;
+export function ProfileKeyCredentialRequest_CheckValidContents(Obj: Serialized<ProfileKeyCredentialRequest>): void;
+export function ProfileKeyCredentialResponse_CheckValidContents(Obj: Serialized<ProfileKeyCredentialResponse>): void;
+export function ProfileKeyCredential_CheckValidContents(Obj: Serialized<ProfileKeyCredential>): void;
+export function ProfileKey_CheckValidContents(Obj: Serialized<ProfileKey>): void;
+export function ProfileKey_GetCommitment(profileKey: Serialized<ProfileKey>, uuid: Uuid): Serialized<ProfileKeyCommitment>;
+export function ProfileKey_GetProfileKeyVersion(profileKey: Serialized<ProfileKey>, uuid: Uuid): Buffer;
 export function ProtocolAddress_DeviceId(obj: Wrapper<ProtocolAddress>): number;
 export function ProtocolAddress_Name(obj: Wrapper<ProtocolAddress>): string;
 export function ProtocolAddress_New(name: string, deviceId: number): ProtocolAddress;
@@ -112,6 +144,17 @@ export function PublicKey_Deserialize(data: Buffer): PublicKey;
 export function PublicKey_GetPublicKeyBytes(obj: Wrapper<PublicKey>): Buffer;
 export function PublicKey_Serialize(obj: Wrapper<PublicKey>): Buffer;
 export function PublicKey_Verify(key: Wrapper<PublicKey>, message: Buffer, signature: Buffer): boolean;
+export function ReceiptCredentialPresentation_CheckValidContents(Obj: Serialized<ReceiptCredentialPresentation>): void;
+export function ReceiptCredentialPresentation_GetReceiptExpirationTime(presentation: Serialized<ReceiptCredentialPresentation>): Buffer;
+export function ReceiptCredentialPresentation_GetReceiptLevel(presentation: Serialized<ReceiptCredentialPresentation>): Buffer;
+export function ReceiptCredentialPresentation_GetReceiptSerial(presentation: Serialized<ReceiptCredentialPresentation>): Buffer;
+export function ReceiptCredentialRequestContext_CheckValidContents(Obj: Serialized<ReceiptCredentialRequestContext>): void;
+export function ReceiptCredentialRequestContext_GetRequest(requestContext: Serialized<ReceiptCredentialRequestContext>): Serialized<ReceiptCredentialRequest>;
+export function ReceiptCredentialRequest_CheckValidContents(Obj: Serialized<ReceiptCredentialRequest>): void;
+export function ReceiptCredentialResponse_CheckValidContents(Obj: Serialized<ReceiptCredentialResponse>): void;
+export function ReceiptCredential_CheckValidContents(Obj: Serialized<ReceiptCredential>): void;
+export function ReceiptCredential_GetReceiptExpirationTime(receiptCredential: Serialized<ReceiptCredential>): Buffer;
+export function ReceiptCredential_GetReceiptLevel(receiptCredential: Serialized<ReceiptCredential>): Buffer;
 export function ScannableFingerprint_Compare(fprint1: Buffer, fprint2: Buffer): boolean;
 export function SealedSenderDecryptionResult_GetDeviceId(obj: Wrapper<SealedSenderDecryptionResult>): number;
 export function SealedSenderDecryptionResult_GetSenderE164(obj: Wrapper<SealedSenderDecryptionResult>): string | null;
@@ -161,6 +204,26 @@ export function ServerCertificate_GetKeyId(obj: Wrapper<ServerCertificate>): num
 export function ServerCertificate_GetSerialized(obj: Wrapper<ServerCertificate>): Buffer;
 export function ServerCertificate_GetSignature(obj: Wrapper<ServerCertificate>): Buffer;
 export function ServerCertificate_New(keyId: number, serverKey: Wrapper<PublicKey>, trustRoot: Wrapper<PrivateKey>): ServerCertificate;
+export function ServerPublicParams_CheckValidContents(Obj: Serialized<ServerPublicParams>): void;
+export function ServerPublicParams_CreateAuthCredentialPresentationDeterministic(serverPublicParams: Serialized<ServerPublicParams>, randomness: Buffer, groupSecretParams: Serialized<GroupSecretParams>, authCredential: Serialized<AuthCredential>): Serialized<AuthCredentialPresentation>;
+export function ServerPublicParams_CreateProfileKeyCredentialPresentationDeterministic(serverPublicParams: Serialized<ServerPublicParams>, randomness: Buffer, groupSecretParams: Serialized<GroupSecretParams>, profileKeyCredential: Serialized<ProfileKeyCredential>): Serialized<ProfileKeyCredentialPresentation>;
+export function ServerPublicParams_CreateProfileKeyCredentialRequestContextDeterministic(serverPublicParams: Serialized<ServerPublicParams>, randomness: Buffer, uuid: Uuid, profileKey: Serialized<ProfileKey>): Serialized<ProfileKeyCredentialRequestContext>;
+export function ServerPublicParams_CreateReceiptCredentialPresentationDeterministic(serverPublicParams: Serialized<ServerPublicParams>, randomness: Buffer, receiptCredential: Serialized<ReceiptCredential>): Serialized<ReceiptCredentialPresentation>;
+export function ServerPublicParams_CreateReceiptCredentialRequestContextDeterministic(serverPublicParams: Serialized<ServerPublicParams>, randomness: Buffer, receiptSerial: Buffer): Serialized<ReceiptCredentialRequestContext>;
+export function ServerPublicParams_ReceiveAuthCredential(params: Serialized<ServerPublicParams>, uuid: Uuid, redemptionTime: number, response: Serialized<AuthCredentialResponse>): Serialized<AuthCredential>;
+export function ServerPublicParams_ReceiveProfileKeyCredential(serverPublicParams: Serialized<ServerPublicParams>, requestContext: Serialized<ProfileKeyCredentialRequestContext>, response: Serialized<ProfileKeyCredentialResponse>): Serialized<ProfileKeyCredential>;
+export function ServerPublicParams_ReceiveReceiptCredential(serverPublicParams: Serialized<ServerPublicParams>, requestContext: Serialized<ReceiptCredentialRequestContext>, response: Serialized<ReceiptCredentialResponse>): Serialized<ReceiptCredential>;
+export function ServerPublicParams_VerifySignature(serverPublicParams: Serialized<ServerPublicParams>, message: Buffer, notarySignature: Buffer): void;
+export function ServerSecretParams_CheckValidContents(Obj: Serialized<ServerSecretParams>): void;
+export function ServerSecretParams_GenerateDeterministic(randomness: Buffer): Serialized<ServerSecretParams>;
+export function ServerSecretParams_GetPublicParams(params: Serialized<ServerSecretParams>): Serialized<ServerPublicParams>;
+export function ServerSecretParams_IssueAuthCredentialDeterministic(serverSecretParams: Serialized<ServerSecretParams>, randomness: Buffer, uuid: Uuid, redemptionTime: number): Serialized<AuthCredentialResponse>;
+export function ServerSecretParams_IssueProfileKeyCredentialDeterministic(serverSecretParams: Serialized<ServerSecretParams>, randomness: Buffer, request: Serialized<ProfileKeyCredentialRequest>, uuid: Uuid, commitment: Serialized<ProfileKeyCommitment>): Serialized<ProfileKeyCredentialResponse>;
+export function ServerSecretParams_IssueReceiptCredentialDeterministic(serverSecretParams: Serialized<ServerSecretParams>, randomness: Buffer, request: Serialized<ReceiptCredentialRequest>, receiptExpirationTime: Buffer, receiptLevel: Buffer): Serialized<ReceiptCredentialResponse>;
+export function ServerSecretParams_SignDeterministic(params: Serialized<ServerSecretParams>, randomness: Buffer, message: Buffer): Buffer;
+export function ServerSecretParams_VerifyAuthCredentialPresentation(serverSecretParams: Serialized<ServerSecretParams>, groupPublicParams: Serialized<GroupPublicParams>, presentation: Serialized<AuthCredentialPresentation>): void;
+export function ServerSecretParams_VerifyProfileKeyCredentialPresentation(serverSecretParams: Serialized<ServerSecretParams>, groupPublicParams: Serialized<GroupPublicParams>, presentation: Serialized<ProfileKeyCredentialPresentation>): void;
+export function ServerSecretParams_VerifyReceiptCredentialPresentation(serverSecretParams: Serialized<ServerSecretParams>, presentation: Serialized<ReceiptCredentialPresentation>): void;
 export function SessionBuilder_ProcessPreKeyBundle(bundle: Wrapper<PreKeyBundle>, protocolAddress: Wrapper<ProtocolAddress>, sessionStore: SessionStore, identityKeyStore: IdentityKeyStore, ctx: null): Promise<void>;
 export function SessionCipher_DecryptPreKeySignalMessage(message: Wrapper<PreKeySignalMessage>, protocolAddress: Wrapper<ProtocolAddress>, sessionStore: SessionStore, identityKeyStore: IdentityKeyStore, prekeyStore: PreKeyStore, signedPrekeyStore: SignedPreKeyStore, ctx: null): Promise<Buffer>;
 export function SessionCipher_DecryptSignalMessage(message: Wrapper<SignalMessage>, protocolAddress: Wrapper<ProtocolAddress>, sessionStore: SessionStore, identityKeyStore: IdentityKeyStore, ctx: null): Promise<Buffer>;
@@ -195,26 +258,49 @@ export function UnidentifiedSenderMessageContent_GetMsgType(m: Wrapper<Unidentif
 export function UnidentifiedSenderMessageContent_GetSenderCert(m: Wrapper<UnidentifiedSenderMessageContent>): SenderCertificate;
 export function UnidentifiedSenderMessageContent_New(message: Wrapper<CiphertextMessage>, sender: Wrapper<SenderCertificate>, contentHint: number, groupId: Buffer | null): UnidentifiedSenderMessageContent;
 export function UnidentifiedSenderMessageContent_Serialize(obj: Wrapper<UnidentifiedSenderMessageContent>): Buffer;
+export function UuidCiphertext_CheckValidContents(Obj: Serialized<UuidCiphertext>): void;
 export function initLogger(maxLevel: LogLevel, callback: (level: LogLevel, target: string, file: string | null, line: number | null, message: string) => void): void
 interface Aes256GcmSiv { readonly __type: unique symbol; }
+interface AuthCredential { readonly __type: unique symbol; }
+interface AuthCredentialPresentation { readonly __type: unique symbol; }
+interface AuthCredentialResponse { readonly __type: unique symbol; }
 interface CiphertextMessage { readonly __type: unique symbol; }
 interface DecryptionErrorMessage { readonly __type: unique symbol; }
 interface Fingerprint { readonly __type: unique symbol; }
+interface GroupMasterKey { readonly __type: unique symbol; }
+interface GroupPublicParams { readonly __type: unique symbol; }
+interface GroupSecretParams { readonly __type: unique symbol; }
 interface HsmEnclaveClient { readonly __type: unique symbol; }
 interface PlaintextContent { readonly __type: unique symbol; }
 interface PreKeyBundle { readonly __type: unique symbol; }
 interface PreKeyRecord { readonly __type: unique symbol; }
 interface PreKeySignalMessage { readonly __type: unique symbol; }
 interface PrivateKey { readonly __type: unique symbol; }
+interface ProfileKey { readonly __type: unique symbol; }
+interface ProfileKeyCiphertext { readonly __type: unique symbol; }
+interface ProfileKeyCommitment { readonly __type: unique symbol; }
+interface ProfileKeyCredential { readonly __type: unique symbol; }
+interface ProfileKeyCredentialPresentation { readonly __type: unique symbol; }
+interface ProfileKeyCredentialRequest { readonly __type: unique symbol; }
+interface ProfileKeyCredentialRequestContext { readonly __type: unique symbol; }
+interface ProfileKeyCredentialResponse { readonly __type: unique symbol; }
 interface ProtocolAddress { readonly __type: unique symbol; }
 interface PublicKey { readonly __type: unique symbol; }
+interface ReceiptCredential { readonly __type: unique symbol; }
+interface ReceiptCredentialPresentation { readonly __type: unique symbol; }
+interface ReceiptCredentialRequest { readonly __type: unique symbol; }
+interface ReceiptCredentialRequestContext { readonly __type: unique symbol; }
+interface ReceiptCredentialResponse { readonly __type: unique symbol; }
 interface SealedSenderDecryptionResult { readonly __type: unique symbol; }
 interface SenderCertificate { readonly __type: unique symbol; }
 interface SenderKeyDistributionMessage { readonly __type: unique symbol; }
 interface SenderKeyMessage { readonly __type: unique symbol; }
 interface SenderKeyRecord { readonly __type: unique symbol; }
 interface ServerCertificate { readonly __type: unique symbol; }
+interface ServerPublicParams { readonly __type: unique symbol; }
+interface ServerSecretParams { readonly __type: unique symbol; }
 interface SessionRecord { readonly __type: unique symbol; }
 interface SignalMessage { readonly __type: unique symbol; }
 interface SignedPreKeyRecord { readonly __type: unique symbol; }
 interface UnidentifiedSenderMessageContent { readonly __type: unique symbol; }
+interface UuidCiphertext { readonly __type: unique symbol; }

--- a/rust/bridge/ffi/Cargo.toml
+++ b/rust/bridge/ffi/Cargo.toml
@@ -23,6 +23,7 @@ libsignal-protocol = { path = "../../protocol" }
 device-transfer = { path = "../../device-transfer" }
 hsm-enclave = { path = "../../hsm-enclave" }
 signal-crypto = { path = "../../crypto" }
+zkgroup = { path = "../../zkgroup" }
 libsignal-bridge = { path = "../shared", features = ["ffi"] }
 async-trait = "0.1.41"
 cpufeatures = "0.2.1" # Make sure iOS gets optimized crypto.

--- a/rust/bridge/ffi/cbindgen.toml
+++ b/rust/bridge/ffi/cbindgen.toml
@@ -17,8 +17,10 @@ style = "type"
 prefix_with_name = true
 
 [export]
-include = ["SignalErrorCode", "FfiDirection", "FfiCiphertextMessageType", "FfiContentHint"]
-item_types = ["enums", "functions", "opaque", "structs", "typedefs"]
+include = ["SignalErrorCode", "FfiDirection", "FfiCiphertextMessageType", "FfiContentHint", "RandomnessBytes"]
+exclude = ["TAG_SIZE", "NONCE_SIZE"]
+item_types = ["enums", "functions", "opaque", "structs", "typedefs", "constants"]
+# FIXME: this doesn't work well with constants in SCREAMING_SNAKE_CASE
 prefix = "Signal"
 renaming_overrides_prefixing = true
 
@@ -42,8 +44,8 @@ sort_by = "None"
 
 [parse]
 parse_deps = true
-include = ["libsignal-protocol", "signal-crypto"]
-extra_bindings = ["libsignal-bridge"]
+include = ["libsignal-protocol", "signal-crypto", "zkgroup"]
+extra_bindings = ["libsignal-bridge", "zkgroup"]
 
 [parse.expand]
 crates = ["libsignal-ffi", "libsignal-bridge"]

--- a/rust/bridge/shared/Cargo.toml
+++ b/rust/bridge/shared/Cargo.toml
@@ -15,6 +15,7 @@ libsignal-protocol = { path = "../../protocol" }
 signal-crypto = { path = "../../crypto" }
 device-transfer = { path = "../../device-transfer" }
 hsm-enclave = { path = "../../hsm-enclave" }
+zkgroup = { path = "../../zkgroup" }
 libsignal-bridge-macros = { path = "macros" }
 aes-gcm-siv = "0.10.1"
 async-trait = "0.1.41"

--- a/rust/bridge/shared/src/ffi/convert.rs
+++ b/rust/bridge/shared/src/ffi/convert.rs
@@ -325,6 +325,13 @@ impl<T: ResultTypeInfo> ResultTypeInfo for Result<T, signal_crypto::Error> {
     }
 }
 
+impl<T: ResultTypeInfo> ResultTypeInfo for Result<T, zkgroup::ZkGroupError> {
+    type ResultType = T::ResultType;
+    fn convert_into(self) -> SignalFfiResult<Self::ResultType> {
+        T::convert_into(self?)
+    }
+}
+
 /// Allocates and returns a new Rust-owned C string.
 impl ResultTypeInfo for String {
     type ResultType = *const libc::c_char;

--- a/rust/bridge/shared/src/ffi/error.rs
+++ b/rust/bridge/shared/src/ffi/error.rs
@@ -10,6 +10,7 @@ use device_transfer::Error as DeviceTransferError;
 use hsm_enclave::Error as HsmEnclaveError;
 use libsignal_protocol::*;
 use signal_crypto::Error as SignalCryptoError;
+use zkgroup::ZkGroupError;
 
 use crate::support::describe_panic;
 
@@ -20,6 +21,7 @@ pub enum SignalFfiError {
     DeviceTransfer(DeviceTransferError),
     HsmEnclave(HsmEnclaveError),
     SignalCrypto(SignalCryptoError),
+    ZkGroup(ZkGroupError),
     InsufficientOutputSize(usize, usize),
     NullPointer,
     InvalidUtf8String,
@@ -40,6 +42,7 @@ impl fmt::Display for SignalFfiError {
             SignalFfiError::SignalCrypto(c) => {
                 write!(f, "Cryptographic operation failed: {}", c)
             }
+            SignalFfiError::ZkGroup(e) => write!(f, "{}", e),
             SignalFfiError::NullPointer => write!(f, "null pointer"),
             SignalFfiError::InvalidType => write!(f, "invalid type"),
             SignalFfiError::InvalidUtf8String => write!(f, "invalid UTF8 string"),
@@ -74,6 +77,12 @@ impl From<HsmEnclaveError> for SignalFfiError {
 impl From<SignalCryptoError> for SignalFfiError {
     fn from(e: SignalCryptoError) -> SignalFfiError {
         SignalFfiError::SignalCrypto(e)
+    }
+}
+
+impl From<ZkGroupError> for SignalFfiError {
+    fn from(e: ZkGroupError) -> SignalFfiError {
+        SignalFfiError::ZkGroup(e)
     }
 }
 

--- a/rust/bridge/shared/src/jni/convert.rs
+++ b/rust/bridge/shared/src/jni/convert.rs
@@ -703,6 +703,16 @@ impl<T: ResultTypeInfo> ResultTypeInfo for Result<T, signal_crypto::Error> {
     }
 }
 
+impl<T: ResultTypeInfo> ResultTypeInfo for Result<T, zkgroup::ZkGroupError> {
+    type ResultType = T::ResultType;
+    fn convert_into(self, env: &JNIEnv) -> SignalJniResult<Self::ResultType> {
+        T::convert_into(self?, env)
+    }
+    fn convert_into_jobject(signal_jni_result: &SignalJniResult<Self::ResultType>) -> JObject {
+        <T as ResultTypeInfo>::convert_into_jobject(signal_jni_result)
+    }
+}
+
 impl<T: ResultTypeInfo> ResultTypeInfo for SignalJniResult<T> {
     type ResultType = T::ResultType;
     fn convert_into(self, env: &JNIEnv) -> SignalJniResult<Self::ResultType> {

--- a/rust/bridge/shared/src/jni/error.rs
+++ b/rust/bridge/shared/src/jni/error.rs
@@ -11,6 +11,7 @@ use device_transfer::Error as DeviceTransferError;
 use hsm_enclave::Error as HsmEnclaveError;
 use libsignal_protocol::*;
 use signal_crypto::Error as SignalCryptoError;
+use zkgroup::ZkGroupError;
 
 use crate::support::describe_panic;
 
@@ -22,13 +23,14 @@ pub enum SignalJniError {
     Signal(SignalProtocolError),
     DeviceTransfer(DeviceTransferError),
     SignalCrypto(SignalCryptoError),
+    HsmEnclave(HsmEnclaveError),
+    ZkGroup(ZkGroupError),
     Jni(jni::errors::Error),
     BadJniParameter(&'static str),
     DeserializationFailed(&'static str),
     UnexpectedJniResultType(&'static str, &'static str),
     NullHandle,
     IntegerOverflow(String),
-    HsmEnclave(HsmEnclaveError),
     UnexpectedPanic(std::boxed::Box<dyn std::any::Any + std::marker::Send>),
 }
 
@@ -37,7 +39,9 @@ impl fmt::Display for SignalJniError {
         match self {
             SignalJniError::Signal(s) => write!(f, "{}", s),
             SignalJniError::DeviceTransfer(s) => write!(f, "{}", s),
+            SignalJniError::HsmEnclave(e) => write!(f, "{}", e),
             SignalJniError::SignalCrypto(s) => write!(f, "{}", s),
+            SignalJniError::ZkGroup(e) => write!(f, "{}", e),
             SignalJniError::Jni(s) => write!(f, "JNI error {}", s),
             SignalJniError::NullHandle => write!(f, "null handle"),
             SignalJniError::BadJniParameter(m) => write!(f, "bad parameter type {}", m),
@@ -49,9 +53,6 @@ impl fmt::Display for SignalJniError {
             }
             SignalJniError::DeserializationFailed(ty) => {
                 write!(f, "failed to deserialize {}", ty)
-            }
-            SignalJniError::HsmEnclave(e) => {
-                write!(f, "{}", e)
             }
             SignalJniError::UnexpectedPanic(e) => {
                 write!(f, "unexpected panic: {}", describe_panic(e))
@@ -81,6 +82,12 @@ impl From<HsmEnclaveError> for SignalJniError {
 impl From<SignalCryptoError> for SignalJniError {
     fn from(e: SignalCryptoError) -> SignalJniError {
         SignalJniError::SignalCrypto(e)
+    }
+}
+
+impl From<ZkGroupError> for SignalJniError {
+    fn from(e: ZkGroupError) -> SignalJniError {
+        SignalJniError::ZkGroup(e)
     }
 }
 

--- a/rust/bridge/shared/src/jni/mod.rs
+++ b/rust/bridge/shared/src/jni/mod.rs
@@ -14,6 +14,7 @@ use libsignal_protocol::*;
 use signal_crypto::Error as SignalCryptoError;
 use std::convert::{TryFrom, TryInto};
 use std::error::Error;
+use zkgroup::ZkGroupError;
 
 pub(crate) use jni::objects::{AutoArray, JClass, JObject, JString, ReleaseMode};
 pub(crate) use jni::sys::{jboolean, jbyteArray, jint, jlong, jlongArray, jstring};
@@ -307,6 +308,16 @@ fn throw_error(env: &JNIEnv, error: SignalJniError) {
         SignalJniError::HsmEnclave(HsmEnclaveError::InvalidBridgeStateError) => {
             "java/lang/IllegalStateException"
         }
+
+        SignalJniError::ZkGroup(ZkGroupError::BadArgs) => {
+            "org/signal/zkgroup/InvalidInputException"
+        }
+        SignalJniError::ZkGroup(
+            ZkGroupError::DecryptionFailure
+            | ZkGroupError::MacVerificationFailure
+            | ZkGroupError::ProofVerificationFailure
+            | ZkGroupError::SignatureVerificationFailure,
+        ) => "org/signal/zkgroup/VerificationFailedException",
     };
 
     if let Err(e) = env.throw_new(exception_type, error.to_string()) {

--- a/rust/bridge/shared/src/lib.rs
+++ b/rust/bridge/shared/src/lib.rs
@@ -33,3 +33,5 @@ pub mod protocol;
 pub mod device_transfer;
 
 pub mod hsm_enclave;
+
+pub mod zkgroup;

--- a/rust/bridge/shared/src/node/error.rs
+++ b/rust/bridge/shared/src/node/error.rs
@@ -167,6 +167,8 @@ impl SignalNodeError for hsm_enclave::Error {}
 
 impl SignalNodeError for signal_crypto::Error {}
 
+impl SignalNodeError for zkgroup::ZkGroupError {}
+
 /// Represents an error returned by a callback.
 #[derive(Debug)]
 struct CallbackError {

--- a/rust/bridge/shared/src/support/serialized.rs
+++ b/rust/bridge/shared/src/support/serialized.rs
@@ -24,7 +24,6 @@ pub(crate) trait FixedLengthBincodeSerializable: 'static {
 pub(crate) struct Serialized<T>(T);
 
 impl<T> Serialized<T> {
-    #[allow(dead_code)]
     pub fn into_inner(self) -> T {
         self.0
     }

--- a/rust/bridge/shared/src/zkgroup.rs
+++ b/rust/bridge/shared/src/zkgroup.rs
@@ -1,0 +1,476 @@
+//
+// Copyright 2021 Signal Messenger, LLC.
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+use ::zkgroup;
+use zkgroup::auth::*;
+use zkgroup::groups::*;
+use zkgroup::profiles::*;
+use zkgroup::receipts::*;
+use zkgroup::*;
+
+use libsignal_bridge_macros::*;
+use std::convert::TryInto;
+use uuid::Uuid;
+
+use crate::support::*;
+use crate::*;
+
+type Result<T> = std::result::Result<T, ZkGroupError>;
+
+/// Exposes a ZKGroup serializable type to the bridges via [`FixedLengthSerializable`].
+///
+/// `fixed_length_serializable!(FooBar)` generates
+/// - `impl FixedLengthSerializable for FooBar`, using `[u8; FOO_BAR_LEN]` as the associated array
+///   type.
+/// - `#[bridge_fn] fn FooBar_CheckValidContents`, which checks that the type can be deserialized.
+macro_rules! fixed_length_serializable {
+    ($typ:ident) => {
+        paste! {
+            // Declare a marker type for TypeScript, the same as bridge_handle.
+            // (This is harmless for the other bridges.)
+            #[doc = "ts: interface " $typ " { readonly __type: unique symbol; }"]
+            impl FixedLengthBincodeSerializable for $typ {
+                type Array = [u8; [<$typ:snake:upper _LEN>]];
+            }
+            #[bridge_fn]
+            fn [<$typ _CheckValidContents>](_obj: Serialized<$typ>) {
+                // Do nothing; if we successfully deserialized the value, it's valid.
+            }
+        }
+    };
+}
+
+fixed_length_serializable!(AuthCredential);
+fixed_length_serializable!(AuthCredentialPresentation);
+fixed_length_serializable!(AuthCredentialResponse);
+fixed_length_serializable!(GroupMasterKey);
+fixed_length_serializable!(GroupPublicParams);
+fixed_length_serializable!(GroupSecretParams);
+fixed_length_serializable!(ProfileKey);
+fixed_length_serializable!(ProfileKeyCiphertext);
+fixed_length_serializable!(ProfileKeyCommitment);
+fixed_length_serializable!(ProfileKeyCredential);
+fixed_length_serializable!(ProfileKeyCredentialPresentation);
+fixed_length_serializable!(ProfileKeyCredentialRequest);
+fixed_length_serializable!(ProfileKeyCredentialRequestContext);
+fixed_length_serializable!(ProfileKeyCredentialResponse);
+fixed_length_serializable!(ReceiptCredential);
+fixed_length_serializable!(ReceiptCredentialPresentation);
+fixed_length_serializable!(ReceiptCredentialRequest);
+fixed_length_serializable!(ReceiptCredentialRequestContext);
+fixed_length_serializable!(ReceiptCredentialResponse);
+fixed_length_serializable!(ServerPublicParams);
+fixed_length_serializable!(ServerSecretParams);
+fixed_length_serializable!(UuidCiphertext);
+
+#[bridge_fn]
+fn ProfileKey_GetCommitment(
+    profile_key: Serialized<ProfileKey>,
+    uuid: Uuid,
+) -> Serialized<ProfileKeyCommitment> {
+    profile_key.get_commitment(*uuid.as_bytes()).into()
+}
+
+#[bridge_fn]
+fn ProfileKey_GetProfileKeyVersion(
+    profile_key: Serialized<ProfileKey>,
+    uuid: Uuid,
+) -> [u8; PROFILE_KEY_VERSION_ENCODED_LEN] {
+    let serialized = bincode::serialize(&profile_key.get_profile_key_version(*uuid.as_bytes()))
+        .expect("can serialize");
+    serialized.try_into().expect("right length")
+}
+
+#[bridge_fn]
+fn GroupSecretParams_GenerateDeterministic(
+    randomness: &[u8; RANDOMNESS_LEN],
+) -> Result<Serialized<GroupSecretParams>> {
+    Ok(GroupSecretParams::generate(*randomness).into())
+}
+
+#[bridge_fn]
+fn GroupSecretParams_DeriveFromMasterKey(
+    master_key: Serialized<GroupMasterKey>,
+) -> Serialized<GroupSecretParams> {
+    GroupSecretParams::derive_from_master_key(master_key.into_inner()).into()
+}
+
+// FIXME: Could be bridge_get! if we provide ArgTypeInfo for &GroupSecretParams.
+#[bridge_fn]
+fn GroupSecretParams_GetMasterKey(
+    params: Serialized<GroupSecretParams>,
+) -> Serialized<GroupMasterKey> {
+    params.get_master_key().into()
+}
+
+// FIXME: Could be bridge_get! if we provide ArgTypeInfo for &GroupSecretParams.
+#[bridge_fn]
+fn GroupSecretParams_GetPublicParams(
+    params: Serialized<GroupSecretParams>,
+) -> Serialized<GroupPublicParams> {
+    params.get_public_params().into()
+}
+
+#[bridge_fn]
+fn GroupSecretParams_EncryptUuid(
+    params: Serialized<GroupSecretParams>,
+    uuid: Uuid,
+) -> Serialized<UuidCiphertext> {
+    params.encrypt_uuid(*uuid.as_bytes()).into()
+}
+
+#[bridge_fn]
+fn GroupSecretParams_DecryptUuid(
+    params: Serialized<GroupSecretParams>,
+    uuid: Serialized<UuidCiphertext>,
+) -> Result<Uuid> {
+    Ok(Uuid::from_bytes(params.decrypt_uuid(uuid.into_inner())?))
+}
+
+#[bridge_fn]
+fn GroupSecretParams_EncryptProfileKey(
+    params: Serialized<GroupSecretParams>,
+    profile_key: Serialized<ProfileKey>,
+    uuid: Uuid,
+) -> Serialized<ProfileKeyCiphertext> {
+    params
+        .encrypt_profile_key(profile_key.into_inner(), *uuid.as_bytes())
+        .into()
+}
+
+#[bridge_fn]
+fn GroupSecretParams_DecryptProfileKey(
+    params: Serialized<GroupSecretParams>,
+    profile_key: Serialized<ProfileKeyCiphertext>,
+    uuid: Uuid,
+) -> Result<Serialized<ProfileKey>> {
+    Ok(params
+        .decrypt_profile_key(profile_key.into_inner(), *uuid.as_bytes())?
+        .into())
+}
+
+#[bridge_fn_buffer]
+fn GroupSecretParams_EncryptBlobDeterministic(
+    params: Serialized<GroupSecretParams>,
+    randomness: &[u8; RANDOMNESS_LEN],
+    plaintext: &[u8],
+) -> Result<Vec<u8>> {
+    params.encrypt_blob(*randomness, plaintext)
+}
+
+#[bridge_fn_buffer]
+fn GroupSecretParams_DecryptBlob(
+    params: Serialized<GroupSecretParams>,
+    ciphertext: &[u8],
+) -> Result<Vec<u8>> {
+    params.decrypt_blob(ciphertext)
+}
+
+#[bridge_fn]
+fn ServerSecretParams_GenerateDeterministic(
+    randomness: &[u8; RANDOMNESS_LEN],
+) -> Result<Serialized<ServerSecretParams>> {
+    Ok(ServerSecretParams::generate(*randomness).into())
+}
+
+// FIXME: Could be bridge_get!
+#[bridge_fn]
+fn ServerSecretParams_GetPublicParams(
+    params: Serialized<ServerSecretParams>,
+) -> Serialized<ServerPublicParams> {
+    params.get_public_params().into()
+}
+
+#[bridge_fn]
+fn ServerSecretParams_SignDeterministic(
+    params: Serialized<ServerSecretParams>,
+    randomness: &[u8; RANDOMNESS_LEN],
+    message: &[u8],
+) -> Result<[u8; SIGNATURE_LEN]> {
+    params.sign(*randomness, message)
+}
+
+#[bridge_fn]
+fn ServerPublicParams_ReceiveAuthCredential(
+    params: Serialized<ServerPublicParams>,
+    uuid: Uuid,
+    redemption_time: u32,
+    response: Serialized<AuthCredentialResponse>,
+) -> Result<Serialized<AuthCredential>> {
+    Ok(params
+        .receive_auth_credential(*uuid.as_bytes(), redemption_time, &response)?
+        .into())
+}
+
+#[bridge_fn]
+fn ServerPublicParams_CreateAuthCredentialPresentationDeterministic(
+    server_public_params: Serialized<ServerPublicParams>,
+    randomness: &[u8; RANDOMNESS_LEN],
+    group_secret_params: Serialized<GroupSecretParams>,
+    auth_credential: Serialized<AuthCredential>,
+) -> Result<Serialized<AuthCredentialPresentation>> {
+    Ok(server_public_params
+        .create_auth_credential_presentation(
+            *randomness,
+            group_secret_params.into_inner(),
+            auth_credential.into_inner(),
+        )
+        .into())
+}
+
+#[bridge_fn]
+fn ServerPublicParams_CreateProfileKeyCredentialRequestContextDeterministic(
+    server_public_params: Serialized<ServerPublicParams>,
+    randomness: &[u8; RANDOMNESS_LEN],
+    uuid: Uuid,
+    profile_key: Serialized<ProfileKey>,
+) -> Result<Serialized<ProfileKeyCredentialRequestContext>> {
+    Ok(server_public_params
+        .create_profile_key_credential_request_context(
+            *randomness,
+            *uuid.as_bytes(),
+            profile_key.into_inner(),
+        )
+        .into())
+}
+
+#[bridge_fn]
+fn ServerPublicParams_ReceiveProfileKeyCredential(
+    server_public_params: Serialized<ServerPublicParams>,
+    request_context: Serialized<ProfileKeyCredentialRequestContext>,
+    response: Serialized<ProfileKeyCredentialResponse>,
+) -> Result<Serialized<ProfileKeyCredential>> {
+    Ok(server_public_params
+        .receive_profile_key_credential(&request_context, &response)?
+        .into())
+}
+
+#[bridge_fn]
+fn ServerPublicParams_CreateProfileKeyCredentialPresentationDeterministic(
+    server_public_params: Serialized<ServerPublicParams>,
+    randomness: &[u8; RANDOMNESS_LEN],
+    group_secret_params: Serialized<GroupSecretParams>,
+    profile_key_credential: Serialized<ProfileKeyCredential>,
+) -> Result<Serialized<ProfileKeyCredentialPresentation>> {
+    Ok(server_public_params
+        .create_profile_key_credential_presentation(
+            *randomness,
+            group_secret_params.into_inner(),
+            profile_key_credential.into_inner(),
+        )
+        .into())
+}
+
+#[bridge_fn]
+fn ServerPublicParams_CreateReceiptCredentialRequestContextDeterministic(
+    server_public_params: Serialized<ServerPublicParams>,
+    randomness: &[u8; RANDOMNESS_LEN],
+    receipt_serial: &[u8; RECEIPT_SERIAL_LEN],
+) -> Result<Serialized<ReceiptCredentialRequestContext>> {
+    Ok(server_public_params
+        .create_receipt_credential_request_context(*randomness, *receipt_serial)
+        .into())
+}
+
+#[bridge_fn]
+fn ServerPublicParams_ReceiveReceiptCredential(
+    server_public_params: Serialized<ServerPublicParams>,
+    request_context: Serialized<ReceiptCredentialRequestContext>,
+    response: Serialized<ReceiptCredentialResponse>,
+) -> Result<Serialized<ReceiptCredential>> {
+    Ok(server_public_params
+        .receive_receipt_credential(&request_context, &response)?
+        .into())
+}
+
+#[bridge_fn]
+fn ServerPublicParams_CreateReceiptCredentialPresentationDeterministic(
+    server_public_params: Serialized<ServerPublicParams>,
+    randomness: &[u8; RANDOMNESS_LEN],
+    receipt_credential: Serialized<ReceiptCredential>,
+) -> Result<Serialized<ReceiptCredentialPresentation>> {
+    Ok(server_public_params
+        .create_receipt_credential_presentation(*randomness, &receipt_credential)
+        .into())
+}
+
+#[bridge_fn]
+fn ServerSecretParams_IssueAuthCredentialDeterministic(
+    server_secret_params: Serialized<ServerSecretParams>,
+    randomness: &[u8; RANDOMNESS_LEN],
+    uuid: Uuid,
+    redemption_time: u32,
+) -> Result<Serialized<AuthCredentialResponse>> {
+    Ok(server_secret_params
+        .issue_auth_credential(*randomness, *uuid.as_bytes(), redemption_time)
+        .into())
+}
+
+#[bridge_fn_void]
+fn ServerSecretParams_VerifyAuthCredentialPresentation(
+    server_secret_params: Serialized<ServerSecretParams>,
+    group_public_params: Serialized<GroupPublicParams>,
+    presentation: Serialized<AuthCredentialPresentation>,
+) -> Result<()> {
+    server_secret_params
+        .verify_auth_credential_presentation(group_public_params.into_inner(), &presentation)
+}
+
+#[bridge_fn]
+fn ServerSecretParams_IssueProfileKeyCredentialDeterministic(
+    server_secret_params: Serialized<ServerSecretParams>,
+    randomness: &[u8; RANDOMNESS_LEN],
+    request: Serialized<ProfileKeyCredentialRequest>,
+    uuid: Uuid,
+    commitment: Serialized<ProfileKeyCommitment>,
+) -> Result<Serialized<ProfileKeyCredentialResponse>> {
+    Ok(server_secret_params
+        .issue_profile_key_credential(
+            *randomness,
+            &request,
+            *uuid.as_bytes(),
+            commitment.into_inner(),
+        )?
+        .into())
+}
+
+#[bridge_fn_void]
+fn ServerSecretParams_VerifyProfileKeyCredentialPresentation(
+    server_secret_params: Serialized<ServerSecretParams>,
+    group_public_params: Serialized<GroupPublicParams>,
+    presentation: Serialized<ProfileKeyCredentialPresentation>,
+) -> Result<()> {
+    server_secret_params
+        .verify_profile_key_credential_presentation(group_public_params.into_inner(), &presentation)
+}
+
+#[bridge_fn]
+fn ServerSecretParams_IssueReceiptCredentialDeterministic(
+    server_secret_params: Serialized<ServerSecretParams>,
+    randomness: &[u8; RANDOMNESS_LEN],
+    request: Serialized<ReceiptCredentialRequest>,
+    receipt_expiration_time: u64,
+    receipt_level: u64,
+) -> Result<Serialized<ReceiptCredentialResponse>> {
+    Ok(server_secret_params
+        .issue_receipt_credential(
+            *randomness,
+            &request,
+            receipt_expiration_time,
+            receipt_level,
+        )
+        .into())
+}
+
+#[bridge_fn_void]
+fn ServerSecretParams_VerifyReceiptCredentialPresentation(
+    server_secret_params: Serialized<ServerSecretParams>,
+    presentation: Serialized<ReceiptCredentialPresentation>,
+) -> Result<()> {
+    server_secret_params.verify_receipt_credential_presentation(&presentation)
+}
+
+// FIXME: Should be bridge_get!
+#[bridge_fn]
+fn GroupPublicParams_GetGroupIdentifier(
+    group_public_params: Serialized<GroupPublicParams>,
+) -> [u8; GROUP_IDENTIFIER_LEN] {
+    group_public_params.get_group_identifier()
+}
+
+#[bridge_fn_void]
+fn ServerPublicParams_VerifySignature(
+    server_public_params: Serialized<ServerPublicParams>,
+    message: &[u8],
+    notary_signature: &[u8; SIGNATURE_LEN],
+) -> Result<()> {
+    server_public_params.verify_signature(message, *notary_signature)
+}
+
+// FIXME: bridge_get
+#[bridge_fn]
+fn AuthCredentialPresentation_GetUuidCiphertext(
+    presentation: Serialized<AuthCredentialPresentation>,
+) -> Serialized<UuidCiphertext> {
+    presentation.get_uuid_ciphertext().into()
+}
+
+// FIXME: bridge_get
+#[bridge_fn]
+fn AuthCredentialPresentation_GetRedemptionTime(
+    presentation: Serialized<AuthCredentialPresentation>,
+) -> u32 {
+    presentation.get_redemption_time()
+}
+
+// FIXME: bridge_get
+#[bridge_fn]
+fn ProfileKeyCredentialRequestContext_GetRequest(
+    context: Serialized<ProfileKeyCredentialRequestContext>,
+) -> Serialized<ProfileKeyCredentialRequest> {
+    context.get_request().into()
+}
+
+// FIXME: bridge_get
+#[bridge_fn]
+fn ProfileKeyCredentialPresentation_GetUuidCiphertext(
+    presentation: Serialized<ProfileKeyCredentialPresentation>,
+) -> Serialized<UuidCiphertext> {
+    presentation.get_uuid_ciphertext().into()
+}
+
+// FIXME: bridge_get
+#[bridge_fn]
+fn ProfileKeyCredentialPresentation_GetProfileKeyCiphertext(
+    presentation: Serialized<ProfileKeyCredentialPresentation>,
+) -> Serialized<ProfileKeyCiphertext> {
+    presentation.get_profile_key_ciphertext().into()
+}
+
+// FIXME: bridge_get
+#[bridge_fn]
+fn ReceiptCredentialRequestContext_GetRequest(
+    request_context: Serialized<ReceiptCredentialRequestContext>,
+) -> Serialized<ReceiptCredentialRequest> {
+    request_context.get_request().into()
+}
+
+// FIXME: bridge_get
+#[bridge_fn]
+fn ReceiptCredential_GetReceiptExpirationTime(
+    receipt_credential: Serialized<ReceiptCredential>,
+) -> u64 {
+    receipt_credential.get_receipt_expiration_time()
+}
+
+// FIXME: bridge_get
+#[bridge_fn]
+fn ReceiptCredential_GetReceiptLevel(receipt_credential: Serialized<ReceiptCredential>) -> u64 {
+    receipt_credential.get_receipt_level()
+}
+
+// FIXME: bridge_get
+#[bridge_fn]
+fn ReceiptCredentialPresentation_GetReceiptExpirationTime(
+    presentation: Serialized<ReceiptCredentialPresentation>,
+) -> u64 {
+    presentation.get_receipt_expiration_time()
+}
+
+// FIXME: bridge_get
+#[bridge_fn]
+fn ReceiptCredentialPresentation_GetReceiptLevel(
+    presentation: Serialized<ReceiptCredentialPresentation>,
+) -> u64 {
+    presentation.get_receipt_level()
+}
+
+// FIXME: bridge_get
+#[bridge_fn]
+fn ReceiptCredentialPresentation_GetReceiptSerial(
+    presentation: Serialized<ReceiptCredentialPresentation>,
+) -> [u8; RECEIPT_SERIAL_LEN] {
+    presentation.get_receipt_serial_bytes()
+}

--- a/swift/Sources/SignalFfi/signal_ffi.h
+++ b/swift/Sources/SignalFfi/signal_ffi.h
@@ -14,6 +14,78 @@ SPDX-License-Identifier: AGPL-3.0-only
 #include <stdint.h>
 #include <stdlib.h>
 
+#define SignalNUM_AUTH_CRED_ATTRIBUTES 3
+
+#define SignalNUM_PROFILE_KEY_CRED_ATTRIBUTES 4
+
+#define SignalNUM_RECEIPT_CRED_ATTRIBUTES 2
+
+#define SignalAES_KEY_LEN 32
+
+#define SignalAESGCM_NONCE_LEN 12
+
+#define SignalAESGCM_TAG_LEN 16
+
+#define SignalGROUP_MASTER_KEY_LEN 32
+
+#define SignalGROUP_SECRET_PARAMS_LEN 289
+
+#define SignalGROUP_PUBLIC_PARAMS_LEN 97
+
+#define SignalGROUP_IDENTIFIER_LEN 32
+
+#define SignalAUTH_CREDENTIAL_LEN 181
+
+#define SignalAUTH_CREDENTIAL_PRESENTATION_LEN 493
+
+#define SignalAUTH_CREDENTIAL_RESPONSE_LEN 361
+
+#define SignalPROFILE_KEY_LEN 32
+
+#define SignalPROFILE_KEY_CIPHERTEXT_LEN 65
+
+#define SignalPROFILE_KEY_COMMITMENT_LEN 97
+
+#define SignalPROFILE_KEY_CREDENTIAL_LEN 145
+
+#define SignalPROFILE_KEY_CREDENTIAL_PRESENTATION_LEN 713
+
+#define SignalPROFILE_KEY_CREDENTIAL_REQUEST_LEN 329
+
+#define SignalPROFILE_KEY_CREDENTIAL_REQUEST_CONTEXT_LEN 473
+
+#define SignalPROFILE_KEY_CREDENTIAL_RESPONSE_LEN 457
+
+#define SignalPROFILE_KEY_VERSION_LEN 32
+
+#define SignalPROFILE_KEY_VERSION_ENCODED_LEN 64
+
+#define SignalRECEIPT_CREDENTIAL_LEN 129
+
+#define SignalRECEIPT_CREDENTIAL_PRESENTATION_LEN 329
+
+#define SignalRECEIPT_CREDENTIAL_REQUEST_LEN 97
+
+#define SignalRECEIPT_CREDENTIAL_REQUEST_CONTEXT_LEN 177
+
+#define SignalRECEIPT_CREDENTIAL_RESPONSE_LEN 409
+
+#define SignalRECEIPT_SERIAL_LEN 16
+
+#define SignalRESERVED_LEN 1
+
+#define SignalSERVER_SECRET_PARAMS_LEN 1121
+
+#define SignalSERVER_PUBLIC_PARAMS_LEN 225
+
+#define SignalUUID_CIPHERTEXT_LEN 65
+
+#define SignalRANDOMNESS_LEN 32
+
+#define SignalSIGNATURE_LEN 64
+
+#define SignalUUID_LEN 16
+
 typedef enum {
   SignalCiphertextMessageType_Whisper = 2,
   SignalCiphertextMessageType_PreKey = 3,
@@ -67,6 +139,7 @@ typedef enum {
   SignalErrorCode_InvalidRegistrationId = 81,
   SignalErrorCode_DuplicatedMessage = 90,
   SignalErrorCode_CallbackError = 100,
+  SignalErrorCode_VerificationFailure = 110,
 } SignalErrorCode;
 
 /**
@@ -201,6 +274,8 @@ typedef struct {
   SignalLoadSenderKey load_sender_key;
   SignalStoreSenderKey store_sender_key;
 } SignalSenderKeyStore;
+
+typedef uint8_t SignalRandomnessBytes[SignalRANDOMNESS_LEN];
 
 void signal_print_ptr(const void *p);
 
@@ -1043,5 +1118,228 @@ SignalFfiError *signal_hsm_enclave_client_established_recv(const unsigned char *
                                                            SignalHsmEnclaveClient *cli,
                                                            const unsigned char *received_ciphertext,
                                                            size_t received_ciphertext_len);
+
+SignalFfiError *signal_auth_credential_check_valid_contents(const unsigned char (*_obj)[SignalAUTH_CREDENTIAL_LEN]);
+
+SignalFfiError *signal_auth_credential_presentation_check_valid_contents(const unsigned char (*_obj)[SignalAUTH_CREDENTIAL_PRESENTATION_LEN]);
+
+SignalFfiError *signal_auth_credential_response_check_valid_contents(const unsigned char (*_obj)[SignalAUTH_CREDENTIAL_RESPONSE_LEN]);
+
+SignalFfiError *signal_group_master_key_check_valid_contents(const unsigned char (*_obj)[SignalGROUP_MASTER_KEY_LEN]);
+
+SignalFfiError *signal_group_public_params_check_valid_contents(const unsigned char (*_obj)[SignalGROUP_PUBLIC_PARAMS_LEN]);
+
+SignalFfiError *signal_group_secret_params_check_valid_contents(const unsigned char (*_obj)[SignalGROUP_SECRET_PARAMS_LEN]);
+
+SignalFfiError *signal_profile_key_check_valid_contents(const unsigned char (*_obj)[SignalPROFILE_KEY_LEN]);
+
+SignalFfiError *signal_profile_key_ciphertext_check_valid_contents(const unsigned char (*_obj)[SignalPROFILE_KEY_CIPHERTEXT_LEN]);
+
+SignalFfiError *signal_profile_key_commitment_check_valid_contents(const unsigned char (*_obj)[SignalPROFILE_KEY_COMMITMENT_LEN]);
+
+SignalFfiError *signal_profile_key_credential_check_valid_contents(const unsigned char (*_obj)[SignalPROFILE_KEY_CREDENTIAL_LEN]);
+
+SignalFfiError *signal_profile_key_credential_presentation_check_valid_contents(const unsigned char (*_obj)[SignalPROFILE_KEY_CREDENTIAL_PRESENTATION_LEN]);
+
+SignalFfiError *signal_profile_key_credential_request_check_valid_contents(const unsigned char (*_obj)[SignalPROFILE_KEY_CREDENTIAL_REQUEST_LEN]);
+
+SignalFfiError *signal_profile_key_credential_request_context_check_valid_contents(const unsigned char (*_obj)[SignalPROFILE_KEY_CREDENTIAL_REQUEST_CONTEXT_LEN]);
+
+SignalFfiError *signal_profile_key_credential_response_check_valid_contents(const unsigned char (*_obj)[SignalPROFILE_KEY_CREDENTIAL_RESPONSE_LEN]);
+
+SignalFfiError *signal_receipt_credential_check_valid_contents(const unsigned char (*_obj)[SignalRECEIPT_CREDENTIAL_LEN]);
+
+SignalFfiError *signal_receipt_credential_presentation_check_valid_contents(const unsigned char (*_obj)[SignalRECEIPT_CREDENTIAL_PRESENTATION_LEN]);
+
+SignalFfiError *signal_receipt_credential_request_check_valid_contents(const unsigned char (*_obj)[SignalRECEIPT_CREDENTIAL_REQUEST_LEN]);
+
+SignalFfiError *signal_receipt_credential_request_context_check_valid_contents(const unsigned char (*_obj)[SignalRECEIPT_CREDENTIAL_REQUEST_CONTEXT_LEN]);
+
+SignalFfiError *signal_receipt_credential_response_check_valid_contents(const unsigned char (*_obj)[SignalRECEIPT_CREDENTIAL_RESPONSE_LEN]);
+
+SignalFfiError *signal_server_public_params_check_valid_contents(const unsigned char (*_obj)[SignalSERVER_PUBLIC_PARAMS_LEN]);
+
+SignalFfiError *signal_server_secret_params_check_valid_contents(const unsigned char (*_obj)[SignalSERVER_SECRET_PARAMS_LEN]);
+
+SignalFfiError *signal_uuid_ciphertext_check_valid_contents(const unsigned char (*_obj)[SignalUUID_CIPHERTEXT_LEN]);
+
+SignalFfiError *signal_profile_key_get_commitment(unsigned char (*out)[SignalPROFILE_KEY_COMMITMENT_LEN],
+                                                  const unsigned char (*profile_key)[SignalPROFILE_KEY_LEN],
+                                                  const uint8_t (*uuid)[16]);
+
+SignalFfiError *signal_profile_key_get_profile_key_version(uint8_t (*out)[SignalPROFILE_KEY_VERSION_ENCODED_LEN],
+                                                           const unsigned char (*profile_key)[SignalPROFILE_KEY_LEN],
+                                                           const uint8_t (*uuid)[16]);
+
+SignalFfiError *signal_group_secret_params_generate_deterministic(unsigned char (*out)[SignalGROUP_SECRET_PARAMS_LEN],
+                                                                  const uint8_t (*randomness)[SignalRANDOMNESS_LEN]);
+
+SignalFfiError *signal_group_secret_params_derive_from_master_key(unsigned char (*out)[SignalGROUP_SECRET_PARAMS_LEN],
+                                                                  const unsigned char (*master_key)[SignalGROUP_MASTER_KEY_LEN]);
+
+SignalFfiError *signal_group_secret_params_get_master_key(unsigned char (*out)[SignalGROUP_MASTER_KEY_LEN],
+                                                          const unsigned char (*params)[SignalGROUP_SECRET_PARAMS_LEN]);
+
+SignalFfiError *signal_group_secret_params_get_public_params(unsigned char (*out)[SignalGROUP_PUBLIC_PARAMS_LEN],
+                                                             const unsigned char (*params)[SignalGROUP_SECRET_PARAMS_LEN]);
+
+SignalFfiError *signal_group_secret_params_encrypt_uuid(unsigned char (*out)[SignalUUID_CIPHERTEXT_LEN],
+                                                        const unsigned char (*params)[SignalGROUP_SECRET_PARAMS_LEN],
+                                                        const uint8_t (*uuid)[16]);
+
+SignalFfiError *signal_group_secret_params_decrypt_uuid(uint8_t (*out)[16],
+                                                        const unsigned char (*params)[SignalGROUP_SECRET_PARAMS_LEN],
+                                                        const unsigned char (*uuid)[SignalUUID_CIPHERTEXT_LEN]);
+
+SignalFfiError *signal_group_secret_params_encrypt_profile_key(unsigned char (*out)[SignalPROFILE_KEY_CIPHERTEXT_LEN],
+                                                               const unsigned char (*params)[SignalGROUP_SECRET_PARAMS_LEN],
+                                                               const unsigned char (*profile_key)[SignalPROFILE_KEY_LEN],
+                                                               const uint8_t (*uuid)[16]);
+
+SignalFfiError *signal_group_secret_params_decrypt_profile_key(unsigned char (*out)[SignalPROFILE_KEY_LEN],
+                                                               const unsigned char (*params)[SignalGROUP_SECRET_PARAMS_LEN],
+                                                               const unsigned char (*profile_key)[SignalPROFILE_KEY_CIPHERTEXT_LEN],
+                                                               const uint8_t (*uuid)[16]);
+
+SignalFfiError *signal_group_secret_params_encrypt_blob_deterministic(const unsigned char **out,
+                                                                      size_t *out_len,
+                                                                      const unsigned char (*params)[SignalGROUP_SECRET_PARAMS_LEN],
+                                                                      const uint8_t (*randomness)[SignalRANDOMNESS_LEN],
+                                                                      const unsigned char *plaintext,
+                                                                      size_t plaintext_len);
+
+SignalFfiError *signal_group_secret_params_decrypt_blob(const unsigned char **out,
+                                                        size_t *out_len,
+                                                        const unsigned char (*params)[SignalGROUP_SECRET_PARAMS_LEN],
+                                                        const unsigned char *ciphertext,
+                                                        size_t ciphertext_len);
+
+SignalFfiError *signal_server_secret_params_generate_deterministic(unsigned char (*out)[SignalSERVER_SECRET_PARAMS_LEN],
+                                                                   const uint8_t (*randomness)[SignalRANDOMNESS_LEN]);
+
+SignalFfiError *signal_server_secret_params_get_public_params(unsigned char (*out)[SignalSERVER_PUBLIC_PARAMS_LEN],
+                                                              const unsigned char (*params)[SignalSERVER_SECRET_PARAMS_LEN]);
+
+SignalFfiError *signal_server_secret_params_sign_deterministic(uint8_t (*out)[SignalSIGNATURE_LEN],
+                                                               const unsigned char (*params)[SignalSERVER_SECRET_PARAMS_LEN],
+                                                               const uint8_t (*randomness)[SignalRANDOMNESS_LEN],
+                                                               const unsigned char *message,
+                                                               size_t message_len);
+
+SignalFfiError *signal_server_public_params_receive_auth_credential(unsigned char (*out)[SignalAUTH_CREDENTIAL_LEN],
+                                                                    const unsigned char (*params)[SignalSERVER_PUBLIC_PARAMS_LEN],
+                                                                    const uint8_t (*uuid)[16],
+                                                                    uint32_t redemption_time,
+                                                                    const unsigned char (*response)[SignalAUTH_CREDENTIAL_RESPONSE_LEN]);
+
+SignalFfiError *signal_server_public_params_create_auth_credential_presentation_deterministic(unsigned char (*out)[SignalAUTH_CREDENTIAL_PRESENTATION_LEN],
+                                                                                              const unsigned char (*server_public_params)[SignalSERVER_PUBLIC_PARAMS_LEN],
+                                                                                              const uint8_t (*randomness)[SignalRANDOMNESS_LEN],
+                                                                                              const unsigned char (*group_secret_params)[SignalGROUP_SECRET_PARAMS_LEN],
+                                                                                              const unsigned char (*auth_credential)[SignalAUTH_CREDENTIAL_LEN]);
+
+SignalFfiError *signal_server_public_params_create_profile_key_credential_request_context_deterministic(unsigned char (*out)[SignalPROFILE_KEY_CREDENTIAL_REQUEST_CONTEXT_LEN],
+                                                                                                        const unsigned char (*server_public_params)[SignalSERVER_PUBLIC_PARAMS_LEN],
+                                                                                                        const uint8_t (*randomness)[SignalRANDOMNESS_LEN],
+                                                                                                        const uint8_t (*uuid)[16],
+                                                                                                        const unsigned char (*profile_key)[SignalPROFILE_KEY_LEN]);
+
+SignalFfiError *signal_server_public_params_receive_profile_key_credential(unsigned char (*out)[SignalPROFILE_KEY_CREDENTIAL_LEN],
+                                                                           const unsigned char (*server_public_params)[SignalSERVER_PUBLIC_PARAMS_LEN],
+                                                                           const unsigned char (*request_context)[SignalPROFILE_KEY_CREDENTIAL_REQUEST_CONTEXT_LEN],
+                                                                           const unsigned char (*response)[SignalPROFILE_KEY_CREDENTIAL_RESPONSE_LEN]);
+
+SignalFfiError *signal_server_public_params_create_profile_key_credential_presentation_deterministic(unsigned char (*out)[SignalPROFILE_KEY_CREDENTIAL_PRESENTATION_LEN],
+                                                                                                     const unsigned char (*server_public_params)[SignalSERVER_PUBLIC_PARAMS_LEN],
+                                                                                                     const uint8_t (*randomness)[SignalRANDOMNESS_LEN],
+                                                                                                     const unsigned char (*group_secret_params)[SignalGROUP_SECRET_PARAMS_LEN],
+                                                                                                     const unsigned char (*profile_key_credential)[SignalPROFILE_KEY_CREDENTIAL_LEN]);
+
+SignalFfiError *signal_server_public_params_create_receipt_credential_request_context_deterministic(unsigned char (*out)[SignalRECEIPT_CREDENTIAL_REQUEST_CONTEXT_LEN],
+                                                                                                    const unsigned char (*server_public_params)[SignalSERVER_PUBLIC_PARAMS_LEN],
+                                                                                                    const uint8_t (*randomness)[SignalRANDOMNESS_LEN],
+                                                                                                    const uint8_t (*receipt_serial)[SignalRECEIPT_SERIAL_LEN]);
+
+SignalFfiError *signal_server_public_params_receive_receipt_credential(unsigned char (*out)[SignalRECEIPT_CREDENTIAL_LEN],
+                                                                       const unsigned char (*server_public_params)[SignalSERVER_PUBLIC_PARAMS_LEN],
+                                                                       const unsigned char (*request_context)[SignalRECEIPT_CREDENTIAL_REQUEST_CONTEXT_LEN],
+                                                                       const unsigned char (*response)[SignalRECEIPT_CREDENTIAL_RESPONSE_LEN]);
+
+SignalFfiError *signal_server_public_params_create_receipt_credential_presentation_deterministic(unsigned char (*out)[SignalRECEIPT_CREDENTIAL_PRESENTATION_LEN],
+                                                                                                 const unsigned char (*server_public_params)[SignalSERVER_PUBLIC_PARAMS_LEN],
+                                                                                                 const uint8_t (*randomness)[SignalRANDOMNESS_LEN],
+                                                                                                 const unsigned char (*receipt_credential)[SignalRECEIPT_CREDENTIAL_LEN]);
+
+SignalFfiError *signal_server_secret_params_issue_auth_credential_deterministic(unsigned char (*out)[SignalAUTH_CREDENTIAL_RESPONSE_LEN],
+                                                                                const unsigned char (*server_secret_params)[SignalSERVER_SECRET_PARAMS_LEN],
+                                                                                const uint8_t (*randomness)[SignalRANDOMNESS_LEN],
+                                                                                const uint8_t (*uuid)[16],
+                                                                                uint32_t redemption_time);
+
+SignalFfiError *signal_server_secret_params_verify_auth_credential_presentation(const unsigned char (*server_secret_params)[SignalSERVER_SECRET_PARAMS_LEN],
+                                                                                const unsigned char (*group_public_params)[SignalGROUP_PUBLIC_PARAMS_LEN],
+                                                                                const unsigned char (*presentation)[SignalAUTH_CREDENTIAL_PRESENTATION_LEN]);
+
+SignalFfiError *signal_server_secret_params_issue_profile_key_credential_deterministic(unsigned char (*out)[SignalPROFILE_KEY_CREDENTIAL_RESPONSE_LEN],
+                                                                                       const unsigned char (*server_secret_params)[SignalSERVER_SECRET_PARAMS_LEN],
+                                                                                       const uint8_t (*randomness)[SignalRANDOMNESS_LEN],
+                                                                                       const unsigned char (*request)[SignalPROFILE_KEY_CREDENTIAL_REQUEST_LEN],
+                                                                                       const uint8_t (*uuid)[16],
+                                                                                       const unsigned char (*commitment)[SignalPROFILE_KEY_COMMITMENT_LEN]);
+
+SignalFfiError *signal_server_secret_params_verify_profile_key_credential_presentation(const unsigned char (*server_secret_params)[SignalSERVER_SECRET_PARAMS_LEN],
+                                                                                       const unsigned char (*group_public_params)[SignalGROUP_PUBLIC_PARAMS_LEN],
+                                                                                       const unsigned char (*presentation)[SignalPROFILE_KEY_CREDENTIAL_PRESENTATION_LEN]);
+
+SignalFfiError *signal_server_secret_params_issue_receipt_credential_deterministic(unsigned char (*out)[SignalRECEIPT_CREDENTIAL_RESPONSE_LEN],
+                                                                                   const unsigned char (*server_secret_params)[SignalSERVER_SECRET_PARAMS_LEN],
+                                                                                   const uint8_t (*randomness)[SignalRANDOMNESS_LEN],
+                                                                                   const unsigned char (*request)[SignalRECEIPT_CREDENTIAL_REQUEST_LEN],
+                                                                                   uint64_t receipt_expiration_time,
+                                                                                   uint64_t receipt_level);
+
+SignalFfiError *signal_server_secret_params_verify_receipt_credential_presentation(const unsigned char (*server_secret_params)[SignalSERVER_SECRET_PARAMS_LEN],
+                                                                                   const unsigned char (*presentation)[SignalRECEIPT_CREDENTIAL_PRESENTATION_LEN]);
+
+SignalFfiError *signal_group_public_params_get_group_identifier(uint8_t (*out)[SignalGROUP_IDENTIFIER_LEN],
+                                                                const unsigned char (*group_public_params)[SignalGROUP_PUBLIC_PARAMS_LEN]);
+
+SignalFfiError *signal_server_public_params_verify_signature(const unsigned char (*server_public_params)[SignalSERVER_PUBLIC_PARAMS_LEN],
+                                                             const unsigned char *message,
+                                                             size_t message_len,
+                                                             const uint8_t (*notary_signature)[SignalSIGNATURE_LEN]);
+
+SignalFfiError *signal_auth_credential_presentation_get_uuid_ciphertext(unsigned char (*out)[SignalUUID_CIPHERTEXT_LEN],
+                                                                        const unsigned char (*presentation)[SignalAUTH_CREDENTIAL_PRESENTATION_LEN]);
+
+SignalFfiError *signal_auth_credential_presentation_get_redemption_time(uint32_t *out,
+                                                                        const unsigned char (*presentation)[SignalAUTH_CREDENTIAL_PRESENTATION_LEN]);
+
+SignalFfiError *signal_profile_key_credential_request_context_get_request(unsigned char (*out)[SignalPROFILE_KEY_CREDENTIAL_REQUEST_LEN],
+                                                                          const unsigned char (*context)[SignalPROFILE_KEY_CREDENTIAL_REQUEST_CONTEXT_LEN]);
+
+SignalFfiError *signal_profile_key_credential_presentation_get_uuid_ciphertext(unsigned char (*out)[SignalUUID_CIPHERTEXT_LEN],
+                                                                               const unsigned char (*presentation)[SignalPROFILE_KEY_CREDENTIAL_PRESENTATION_LEN]);
+
+SignalFfiError *signal_profile_key_credential_presentation_get_profile_key_ciphertext(unsigned char (*out)[SignalPROFILE_KEY_CIPHERTEXT_LEN],
+                                                                                      const unsigned char (*presentation)[SignalPROFILE_KEY_CREDENTIAL_PRESENTATION_LEN]);
+
+SignalFfiError *signal_receipt_credential_request_context_get_request(unsigned char (*out)[SignalRECEIPT_CREDENTIAL_REQUEST_LEN],
+                                                                      const unsigned char (*request_context)[SignalRECEIPT_CREDENTIAL_REQUEST_CONTEXT_LEN]);
+
+SignalFfiError *signal_receipt_credential_get_receipt_expiration_time(uint64_t *out,
+                                                                      const unsigned char (*receipt_credential)[SignalRECEIPT_CREDENTIAL_LEN]);
+
+SignalFfiError *signal_receipt_credential_get_receipt_level(uint64_t *out,
+                                                            const unsigned char (*receipt_credential)[SignalRECEIPT_CREDENTIAL_LEN]);
+
+SignalFfiError *signal_receipt_credential_presentation_get_receipt_expiration_time(uint64_t *out,
+                                                                                   const unsigned char (*presentation)[SignalRECEIPT_CREDENTIAL_PRESENTATION_LEN]);
+
+SignalFfiError *signal_receipt_credential_presentation_get_receipt_level(uint64_t *out,
+                                                                         const unsigned char (*presentation)[SignalRECEIPT_CREDENTIAL_PRESENTATION_LEN]);
+
+SignalFfiError *signal_receipt_credential_presentation_get_receipt_serial(uint8_t (*out)[SignalRECEIPT_SERIAL_LEN],
+                                                                          const unsigned char (*presentation)[SignalRECEIPT_CREDENTIAL_PRESENTATION_LEN]);
 
 #endif /* SIGNAL_FFI_H_ */


### PR DESCRIPTION
These APIs are designed to match the generated "simpleapi" entry points in [the original zkgroup repository](/signalapp/zkgroup), to make it easier to adapt the existing Java, Swift, and TypeScript code to libsignal-client.

The cbindgen-generated signal_ffi.h now includes constants, so that the fixed-size arrays used to serialize zkgroup types can use named constants in Rust. This meant filtering out some constants that were getting picked up but that should not be included.

Note that this commit makes references to Java exception types that will be added in a later commit.