### PR TITLE
bridge: Be more explicit about bridging u64 timestamps

### DIFF
--- a/node/Native.d.ts
+++ b/node/Native.d.ts
@@ -6,6 +6,7 @@
 // WARNING: this file was automatically generated
 
 type Uuid = Buffer;
+type Timestamp = number;
 
 export abstract class IdentityKeyStore {
   _getIdentityKey(): Promise<PrivateKey>;
@@ -51,10 +52,10 @@ export function CiphertextMessage_Serialize(obj: Wrapper<CiphertextMessage>): Bu
 export function CiphertextMessage_Type(msg: Wrapper<CiphertextMessage>): number;
 export function DecryptionErrorMessage_Deserialize(data: Buffer): DecryptionErrorMessage;
 export function DecryptionErrorMessage_ExtractFromSerializedContent(bytes: Buffer): DecryptionErrorMessage;
-export function DecryptionErrorMessage_ForOriginalMessage(originalBytes: Buffer, originalType: number, originalTimestamp: number, originalSenderDeviceId: number): DecryptionErrorMessage;
+export function DecryptionErrorMessage_ForOriginalMessage(originalBytes: Buffer, originalType: number, originalTimestamp: Timestamp, originalSenderDeviceId: number): DecryptionErrorMessage;
 export function DecryptionErrorMessage_GetDeviceId(obj: Wrapper<DecryptionErrorMessage>): number;
 export function DecryptionErrorMessage_GetRatchetKey(m: Wrapper<DecryptionErrorMessage>): PublicKey | null;
-export function DecryptionErrorMessage_GetTimestamp(obj: Wrapper<DecryptionErrorMessage>): number;
+export function DecryptionErrorMessage_GetTimestamp(obj: Wrapper<DecryptionErrorMessage>): Timestamp;
 export function DecryptionErrorMessage_Serialize(obj: Wrapper<DecryptionErrorMessage>): Buffer;
 export function Fingerprint_DisplayString(obj: Wrapper<Fingerprint>): string;
 export function Fingerprint_New(iterations: number, version: number, localIdentifier: Buffer, localKey: Wrapper<PublicKey>, remoteIdentifier: Buffer, remoteKey: Wrapper<PublicKey>): Fingerprint;
@@ -113,7 +114,7 @@ export function SealedSenderDecryptionResult_GetDeviceId(obj: Wrapper<SealedSend
 export function SealedSenderDecryptionResult_GetSenderE164(obj: Wrapper<SealedSenderDecryptionResult>): string | null;
 export function SealedSenderDecryptionResult_GetSenderUuid(obj: Wrapper<SealedSenderDecryptionResult>): string;
 export function SealedSenderDecryptionResult_Message(obj: Wrapper<SealedSenderDecryptionResult>): Buffer;
-export function SealedSender_DecryptMessage(message: Buffer, trustRoot: Wrapper<PublicKey>, timestamp: number, localE164: string | null, localUuid: string, localDeviceId: number, sessionStore: SessionStore, identityStore: IdentityKeyStore, prekeyStore: PreKeyStore, signedPrekeyStore: SignedPreKeyStore): Promise<SealedSenderDecryptionResult>;
+export function SealedSender_DecryptMessage(message: Buffer, trustRoot: Wrapper<PublicKey>, timestamp: Timestamp, localE164: string | null, localUuid: string, localDeviceId: number, sessionStore: SessionStore, identityStore: IdentityKeyStore, prekeyStore: PreKeyStore, signedPrekeyStore: SignedPreKeyStore): Promise<SealedSenderDecryptionResult>;
 export function SealedSender_DecryptToUsmc(ctext: Buffer, identityStore: IdentityKeyStore, ctx: null): Promise<UnidentifiedSenderMessageContent>;
 export function SealedSender_Encrypt(destination: Wrapper<ProtocolAddress>, content: Wrapper<UnidentifiedSenderMessageContent>, identityKeyStore: IdentityKeyStore, ctx: null): Promise<Buffer>;
 export function SealedSender_MultiRecipientEncrypt(recipients: Wrapper<ProtocolAddress>[], recipientSessions: Wrapper<SessionRecord>[], content: Wrapper<UnidentifiedSenderMessageContent>, identityKeyStore: IdentityKeyStore, ctx: null): Promise<Buffer>;
@@ -121,15 +122,15 @@ export function SealedSender_MultiRecipientMessageForSingleRecipient(encodedMult
 export function SenderCertificate_Deserialize(data: Buffer): SenderCertificate;
 export function SenderCertificate_GetCertificate(obj: Wrapper<SenderCertificate>): Buffer;
 export function SenderCertificate_GetDeviceId(obj: Wrapper<SenderCertificate>): number;
-export function SenderCertificate_GetExpiration(obj: Wrapper<SenderCertificate>): number;
+export function SenderCertificate_GetExpiration(obj: Wrapper<SenderCertificate>): Timestamp;
 export function SenderCertificate_GetKey(obj: Wrapper<SenderCertificate>): PublicKey;
 export function SenderCertificate_GetSenderE164(obj: Wrapper<SenderCertificate>): string | null;
 export function SenderCertificate_GetSenderUuid(obj: Wrapper<SenderCertificate>): string;
 export function SenderCertificate_GetSerialized(obj: Wrapper<SenderCertificate>): Buffer;
 export function SenderCertificate_GetServerCertificate(cert: Wrapper<SenderCertificate>): ServerCertificate;
 export function SenderCertificate_GetSignature(obj: Wrapper<SenderCertificate>): Buffer;
-export function SenderCertificate_New(senderUuid: string, senderE164: string | null, senderDeviceId: number, senderKey: Wrapper<PublicKey>, expiration: number, signerCert: Wrapper<ServerCertificate>, signerKey: Wrapper<PrivateKey>): SenderCertificate;
-export function SenderCertificate_Validate(cert: Wrapper<SenderCertificate>, key: Wrapper<PublicKey>, time: number): boolean;
+export function SenderCertificate_New(senderUuid: string, senderE164: string | null, senderDeviceId: number, senderKey: Wrapper<PublicKey>, expiration: Timestamp, signerCert: Wrapper<ServerCertificate>, signerKey: Wrapper<PrivateKey>): SenderCertificate;
+export function SenderCertificate_Validate(cert: Wrapper<SenderCertificate>, key: Wrapper<PublicKey>, time: Timestamp): boolean;
 export function SenderKeyDistributionMessage_Create(sender: Wrapper<ProtocolAddress>, distributionId: Uuid, store: SenderKeyStore, ctx: null): Promise<SenderKeyDistributionMessage>;
 export function SenderKeyDistributionMessage_Deserialize(data: Buffer): SenderKeyDistributionMessage;
 export function SenderKeyDistributionMessage_GetChainId(obj: Wrapper<SenderKeyDistributionMessage>): number;
@@ -180,8 +181,8 @@ export function SignedPreKeyRecord_GetId(obj: Wrapper<SignedPreKeyRecord>): numb
 export function SignedPreKeyRecord_GetPrivateKey(obj: Wrapper<SignedPreKeyRecord>): PrivateKey;
 export function SignedPreKeyRecord_GetPublicKey(obj: Wrapper<SignedPreKeyRecord>): PublicKey;
 export function SignedPreKeyRecord_GetSignature(obj: Wrapper<SignedPreKeyRecord>): Buffer;
-export function SignedPreKeyRecord_GetTimestamp(obj: Wrapper<SignedPreKeyRecord>): number;
-export function SignedPreKeyRecord_New(id: number, timestamp: number, pubKey: Wrapper<PublicKey>, privKey: Wrapper<PrivateKey>, signature: Buffer): SignedPreKeyRecord;
+export function SignedPreKeyRecord_GetTimestamp(obj: Wrapper<SignedPreKeyRecord>): Timestamp;
+export function SignedPreKeyRecord_New(id: number, timestamp: Timestamp, pubKey: Wrapper<PublicKey>, privKey: Wrapper<PrivateKey>, signature: Buffer): SignedPreKeyRecord;
 export function SignedPreKeyRecord_Serialize(obj: Wrapper<SignedPreKeyRecord>): Buffer;
 export function UnidentifiedSenderMessageContent_Deserialize(data: Buffer): UnidentifiedSenderMessageContent;
 export function UnidentifiedSenderMessageContent_GetContentHint(m: Wrapper<UnidentifiedSenderMessageContent>): number;

--- a/rust/bridge/node/bin/Native.d.ts.in
+++ b/rust/bridge/node/bin/Native.d.ts.in
@@ -6,6 +6,7 @@
 // WARNING: this file was automatically generated
 
 type Uuid = Buffer;
+type Timestamp = number;
 
 export abstract class IdentityKeyStore {
   _getIdentityKey(): Promise<PrivateKey>;

--- a/rust/bridge/shared/src/ffi/convert.rs
+++ b/rust/bridge/shared/src/ffi/convert.rs
@@ -350,6 +350,20 @@ impl ResultTypeInfo for Option<u32> {
     }
 }
 
+impl SimpleArgTypeInfo for crate::protocol::Timestamp {
+    type ArgType = u64;
+    fn convert_from(foreign: Self::ArgType) -> SignalFfiResult<Self> {
+        Ok(Self::from_millis(foreign))
+    }
+}
+
+impl ResultTypeInfo for crate::protocol::Timestamp {
+    type ResultType = u64;
+    fn convert_into(self) -> SignalFfiResult<Self::ResultType> {
+        Ok(self.as_millis())
+    }
+}
+
 /// A marker for Rust objects exposed as opaque pointers.
 ///
 /// When we do this, we hand the lifetime over to the app. Since we don't know how long the object
@@ -503,6 +517,7 @@ macro_rules! ffi_arg_type {
     (Option<String>) => (*const libc::c_char);
     (Option<&str>) => (*const libc::c_char);
     (Context) => (*mut libc::c_void);
+    (Timestamp) => (u64);
     (Uuid) => (*const [u8; 16]);
     (&[& $typ:ty]) => (*const *const $typ);
     (&mut dyn $typ:ty) => (*const paste!(ffi::[<Ffi $typ Struct>]));
@@ -537,6 +552,7 @@ macro_rules! ffi_result_type {
     (Option<String>) => (*const libc::c_char);
     (Option<&str>) => (*const libc::c_char);
     (Option<$typ:ty>) => (*mut $typ);
+    (Timestamp) => (u64);
     (Uuid) => ([u8; 16]);
     ( $typ:ty ) => (*mut $typ);
 }

--- a/rust/bridge/shared/src/node/convert.rs
+++ b/rust/bridge/shared/src/node/convert.rs
@@ -250,14 +250,14 @@ const MAX_SAFE_JS_INTEGER: f64 = 9007199254740991.0;
 /// Converts non-negative numbers up to [`Number.MAX_SAFE_INTEGER`][].
 ///
 /// [`Number.MAX_SAFE_INTEGER`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
-impl SimpleArgTypeInfo for u64 {
+impl SimpleArgTypeInfo for crate::protocol::Timestamp {
     type ArgType = JsNumber;
     fn convert_from(cx: &mut FunctionContext, foreign: Handle<Self::ArgType>) -> NeonResult<Self> {
         let value = foreign.value(cx);
         if !can_convert_js_number_to_int(value, 0.0..=MAX_SAFE_JS_INTEGER) {
-            return cx.throw_range_error(format!("cannot convert {} to u64", value));
+            return cx.throw_range_error(format!("cannot convert {} to Timestamp (u64)", value));
         }
-        Ok(value as u64)
+        Ok(Self::from_millis(value as u64))
     }
 }
 
@@ -527,17 +527,17 @@ impl<'a> ResultTypeInfo<'a> for bool {
 /// Converts non-negative values up to [`Number.MAX_SAFE_INTEGER`][].
 ///
 /// [`Number.MAX_SAFE_INTEGER`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
-impl<'a> ResultTypeInfo<'a> for u64 {
+impl<'a> ResultTypeInfo<'a> for crate::protocol::Timestamp {
     type ResultType = JsNumber;
     fn convert_into(self, cx: &mut impl Context<'a>) -> NeonResult<Handle<'a, Self::ResultType>> {
-        let result = self as f64;
+        let result = self.as_millis() as f64;
         if result > MAX_SAFE_JS_INTEGER {
             cx.throw_range_error(format!(
                 "precision loss during conversion of {} to f64",
-                self
+                self.as_millis()
             ))?;
         }
-        Ok(cx.number(self as f64))
+        Ok(cx.number(result))
     }
 }
 


### PR DESCRIPTION
u64 can't be represented as a primitive in Java or TypeScript (and for the latter, [Neon doesn't support bigint yet](https://github.com/neon-bindings/neon/issues/376)). However, for timestamps represented as milliseconds, the integer-safe range of float64 still covers more than 285,000 years, so it's reasonably safe to use TypeScript's 'number' or Java's 'long' to represent these ostensibly-64-bit values. Indicate this with a new Timestamp wrapper type in the bridge layer.

In theory we could push this new Timestamp type down to the libsignal-protocol crate. However, the protocol itself doesn't impose any restrictions on the timestamp fields, so I figured it was best to put it at the bridge layer, to indicate that it's about how Signal specifically uses these fields.

This commit paves the way for being stricter about *other* u64 values that might want to use the full 64-bit space.