### PR TITLE
java: Build a "testable" signal-client-java as well

### DIFF
--- a/.github/workflows/jni_artifacts.yml
+++ b/.github/workflows/jni_artifacts.yml
@@ -1,0 +1,49 @@
+name: Publish JNI Artifacts to GitHub Release
+
+on:
+  push:
+    tags:
+      - v*
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            library: libsignal_jni.so
+          - os: windows-latest
+            library: signal_jni.dll
+          - os: macos-latest
+            library: libsignal_jni.dylib
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install nightly rust
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+
+    - run: cargo build --release -p libsignal-jni
+      env:
+        # Keep this settings in sync with java/build_jni.sh, which supports Android as well.
+        CARGO_PROFILE_RELEASE_DEBUG: 1
+        CARGO_PROFILE_RELEASE_LTO: thin
+        CARGO_PROFILE_RELEASE_OPT_LEVEL: s
+
+    - name: Upload
+      uses: svenstaro/upload-release-action@2.2.0
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: target/release/${{ matrix.library }}
+        tag: ${{ github.ref }}
+        overwrite: true

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,6 @@ java/gradle.properties
 java/local.properties
 java/android/src/main/jniLibs
 java/java/src/main/resources
+java/java/src/otherPlatformLibraries/resources
 
 .DS_Store

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -50,7 +50,11 @@ Note that both the tag *and* the branch need to be pushed.
 
 ### Android: Sonatype
 
-Set the environment variables `SONATYPE_USERNAME`, `SONATYPE_PASSWORD`, `KEYRING_FILE`, `SIGNING_KEY`, and `SIGNING_KEY_PASSSWORD`, then run `make -C java publish_java` to build through Docker. (Sonatype is pretty slow; even after the build completes it might take a while for it to show up.)
+1. Wait for the "Publish JNI Artifacts to GitHub Release" action to complete. These artifacts, though not built reproducibly, will be included in the "testable" jar that supports running on macOS and Windows as well.
+2. Set the environment variables `SONATYPE_USERNAME`, `SONATYPE_PASSWORD`, `KEYRING_FILE`, `SIGNING_KEY`, and `SIGNING_KEY_PASSSWORD`.
+3. Run `make -C java publish_java` to build through Docker.
+
+Note that Sonatype is pretty slow; even after the build completes it might take a while for it to show up.
 
 ### Node: NPM
 

--- a/java/build_jni.sh
+++ b/java/build_jni.sh
@@ -15,6 +15,8 @@ cd "${SCRIPT_DIR}"/..
 ANDROID_LIB_DIR=java/android/src/main/jniLibs
 DESKTOP_LIB_DIR=java/java/src/main/resources
 
+# Keep these settings in sync with .github/workflows/jni_artifacts.yml,
+# which builds for Windows as well.
 export CARGO_PROFILE_RELEASE_DEBUG=1 # enable line tables
 # On Linux, cdylibs don't include public symbols from their dependencies,
 # even if those symbols have been re-exported in the Rust source.

--- a/java/java/build.gradle
+++ b/java/java/build.gradle
@@ -5,6 +5,10 @@ buildscript {
     }
 }
 
+plugins {
+    id "de.undercouch.download" version "4.1.1"
+}
+
 apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'signing'
@@ -25,6 +29,7 @@ sourceSets {
             srcDirs = ['src/test/java/', project(':tests').file('src/test/java')]
         }
     }
+    otherPlatformLibraries {}
 }
 
 dependencies {
@@ -63,7 +68,7 @@ def getRepositoryPassword() {
 }
 
 signing {
-    required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
+    required { isReleaseBuild() && gradle.taskGraph.hasTask(":java:uploadArchives") }
     sign configurations.archives
 }
 
@@ -125,12 +130,34 @@ task packageSources(type: Jar) {
     classifier = 'sources'
 }
 
+task testableJar(type: Jar) {
+    from sourceSets.main.output
+    from sourceSets.otherPlatformLibraries.resources
+    classifier = 'testable'
+
+    onlyIf { gradle.taskGraph.hasTask(':java:uploadArchives') }
+
+    def extraResources = ['signal_jni.dll', 'libsignal_jni.dylib']
+    def extraResourcesDir = 'src/otherPlatformLibraries/resources'
+
+    doFirst {
+        mkdir extraResourcesDir
+        extraResources.each { name ->
+            download {
+                src 'https://github.com/signalapp/libsignal-client/releases/download/v' + project.version + '/' + name
+                dest extraResourcesDir + '/' + name
+            }
+        }
+    }
+}
+
 artifacts {
     archives(packageJavadoc) {
         type = 'javadoc'
     }
 
     archives packageSources
+    archives testableJar
 }
 
 tasks.withType(JavaCompile) {


### PR DESCRIPTION
This is like signal-client-java, but also contains dylibs for Mac and Windows for testing purposes. This is something [zkgroup](/signalapp/zkgroup) already has; in particular it allows developers working on the [server](/signalapp/Signal-Server) to use the zkgroup APIs even if they run macOS or Windows on their individual machines. The first commit builds the libraries as a GitHub Action whenever a new release is tagged; the second adds a new Gradle target that automatically downloads those libraries and includes them in the new jar output.