### PR TITLE
java: Improve zkgroup's ByteArray helper class

### DIFF
--- a/java/java/src/main/java/org/signal/zkgroup/NotarySignature.java
+++ b/java/java/src/main/java/org/signal/zkgroup/NotarySignature.java
@@ -15,8 +15,4 @@ public final class NotarySignature extends ByteArray {
     super(contents, SIZE);
   }
 
-  public byte[] serialize() {
-    return contents.clone();
-  }
-
 }

--- a/java/java/src/main/java/org/signal/zkgroup/ServerPublicParams.java
+++ b/java/java/src/main/java/org/signal/zkgroup/ServerPublicParams.java
@@ -9,20 +9,13 @@ import org.signal.zkgroup.internal.ByteArray;
 import org.signal.client.internal.Native;
 
 public final class ServerPublicParams extends ByteArray {
-
-  public static final int SIZE = 225;
-
   public ServerPublicParams(byte[] contents)  {
-    super(contents, SIZE, true);
+    super(contents);
     Native.ServerPublicParams_CheckValidContents(contents);
   }
 
   public void verifySignature(byte[] message, NotarySignature notarySignature) throws VerificationFailedException {
     Native.ServerPublicParams_VerifySignature(contents, message, notarySignature.getInternalContentsForJNI());
-  }
-
-  public byte[] serialize() {
-    return contents.clone();
   }
 
 }

--- a/java/java/src/main/java/org/signal/zkgroup/ServerSecretParams.java
+++ b/java/java/src/main/java/org/signal/zkgroup/ServerSecretParams.java
@@ -13,8 +13,6 @@ import static org.signal.zkgroup.internal.Constants.RANDOM_LENGTH;
 
 public final class ServerSecretParams extends ByteArray {
 
-  public static final int SIZE = 1121;
-
   public static ServerSecretParams generate() {
     return generate(new SecureRandom());
   }
@@ -33,7 +31,7 @@ public final class ServerSecretParams extends ByteArray {
   }
 
   public ServerSecretParams(byte[] contents)  {
-    super(contents, SIZE, true);
+    super(contents);
     Native.ServerSecretParams_CheckValidContents(contents);
   }
 
@@ -57,11 +55,6 @@ public final class ServerSecretParams extends ByteArray {
     } catch (InvalidInputException e) {
       throw new AssertionError(e);
     }
-
-  }
-
-  public byte[] serialize() {
-    return contents.clone();
   }
 
 }

--- a/java/java/src/main/java/org/signal/zkgroup/auth/AuthCredential.java
+++ b/java/java/src/main/java/org/signal/zkgroup/auth/AuthCredential.java
@@ -10,16 +10,12 @@ import org.signal.zkgroup.internal.ByteArray;
 import org.signal.client.internal.Native;
 
 public final class AuthCredential extends ByteArray {
-
-  public static final int SIZE = 181;
-
   public AuthCredential(byte[] contents) throws InvalidInputException {
-    super(contents, SIZE);
-    Native.AuthCredential_CheckValidContents(contents);
+    super(contents);
+    try {
+      Native.AuthCredential_CheckValidContents(contents);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidInputException(e.getMessage());
+    }
   }
-
-  public byte[] serialize() {
-    return contents.clone();
-  }
-
 }

--- a/java/java/src/main/java/org/signal/zkgroup/auth/AuthCredentialPresentation.java
+++ b/java/java/src/main/java/org/signal/zkgroup/auth/AuthCredentialPresentation.java
@@ -13,11 +13,13 @@ import org.signal.client.internal.Native;
 
 public final class AuthCredentialPresentation extends ByteArray {
 
-  public static final int SIZE = 493;
-
   public AuthCredentialPresentation(byte[] contents) throws InvalidInputException {
-    super(contents, SIZE);
-    Native.AuthCredentialPresentation_CheckValidContents(contents);
+    super(contents);
+    try {
+      Native.AuthCredentialPresentation_CheckValidContents(contents);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidInputException(e.getMessage());
+    }
   }
 
   public UuidCiphertext getUuidCiphertext() {
@@ -32,10 +34,6 @@ public final class AuthCredentialPresentation extends ByteArray {
 
   public int getRedemptionTime() {
     return Native.AuthCredentialPresentation_GetRedemptionTime(contents);
-  }
-
-  public byte[] serialize() {
-    return contents.clone();
   }
 
 }

--- a/java/java/src/main/java/org/signal/zkgroup/auth/AuthCredentialResponse.java
+++ b/java/java/src/main/java/org/signal/zkgroup/auth/AuthCredentialResponse.java
@@ -10,16 +10,12 @@ import org.signal.zkgroup.internal.ByteArray;
 import org.signal.client.internal.Native;
 
 public final class AuthCredentialResponse extends ByteArray {
-
-  public static final int SIZE = 361;
-
   public AuthCredentialResponse(byte[] contents) throws InvalidInputException {
-    super(contents, SIZE);
-    Native.AuthCredentialResponse_CheckValidContents(contents);
+    super(contents);
+    try {
+      Native.AuthCredentialResponse_CheckValidContents(contents);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidInputException(e.getMessage());
+    }
   }
-
-  public byte[] serialize() {
-    return contents.clone();
-  }
-
 }

--- a/java/java/src/main/java/org/signal/zkgroup/auth/ClientZkAuthOperations.java
+++ b/java/java/src/main/java/org/signal/zkgroup/auth/ClientZkAuthOperations.java
@@ -48,7 +48,6 @@ public class ClientZkAuthOperations {
     } catch (InvalidInputException e) {
       throw new AssertionError(e);
     }
-
   }
 
 }

--- a/java/java/src/main/java/org/signal/zkgroup/auth/ServerZkAuthOperations.java
+++ b/java/java/src/main/java/org/signal/zkgroup/auth/ServerZkAuthOperations.java
@@ -41,7 +41,6 @@ public class ServerZkAuthOperations {
     } catch (InvalidInputException e) {
       throw new AssertionError(e);
     }
-
   }
 
   public void verifyAuthCredentialPresentation(GroupPublicParams groupPublicParams, AuthCredentialPresentation authCredentialPresentation) throws VerificationFailedException, InvalidRedemptionTimeException {

--- a/java/java/src/main/java/org/signal/zkgroup/groups/ClientZkGroupCipher.java
+++ b/java/java/src/main/java/org/signal/zkgroup/groups/ClientZkGroupCipher.java
@@ -31,7 +31,6 @@ public class ClientZkGroupCipher {
     } catch (InvalidInputException e) {
       throw new AssertionError(e);
     }
-
   }
 
   public UUID decryptUuid(UuidCiphertext uuidCiphertext) throws VerificationFailedException {
@@ -46,7 +45,6 @@ public class ClientZkGroupCipher {
     } catch (InvalidInputException e) {
       throw new AssertionError(e);
     }
-
   }
 
   public ProfileKey decryptProfileKey(ProfileKeyCiphertext profileKeyCiphertext, UUID uuid) throws VerificationFailedException {
@@ -57,7 +55,6 @@ public class ClientZkGroupCipher {
     } catch (InvalidInputException e) {
       throw new AssertionError(e);
     }
-
   }
 
   public byte[] encryptBlob(byte[] plaintext) throws VerificationFailedException {

--- a/java/java/src/main/java/org/signal/zkgroup/groups/GroupIdentifier.java
+++ b/java/java/src/main/java/org/signal/zkgroup/groups/GroupIdentifier.java
@@ -16,8 +16,4 @@ public final class GroupIdentifier extends ByteArray {
     super(contents, SIZE);
   }
 
-  public byte[] serialize() {
-    return contents.clone();
-  }
-
 }

--- a/java/java/src/main/java/org/signal/zkgroup/groups/GroupMasterKey.java
+++ b/java/java/src/main/java/org/signal/zkgroup/groups/GroupMasterKey.java
@@ -16,8 +16,4 @@ public final class GroupMasterKey extends ByteArray {
     super(contents, SIZE);
   }
 
-  public byte[] serialize() {
-    return contents.clone();
-  }
-
 }

--- a/java/java/src/main/java/org/signal/zkgroup/groups/GroupPublicParams.java
+++ b/java/java/src/main/java/org/signal/zkgroup/groups/GroupPublicParams.java
@@ -11,12 +11,13 @@ import org.signal.client.internal.Native;
 
 public final class GroupPublicParams extends ByteArray {
 
-  public static final int SIZE = 97;
-
   public GroupPublicParams(byte[] contents) throws InvalidInputException {
-    super(contents, SIZE);
-    
-    Native.GroupPublicParams_CheckValidContents(contents);
+    super(contents);
+    try {
+      Native.GroupPublicParams_CheckValidContents(contents);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidInputException(e.getMessage());
+    }
   }
 
   public GroupIdentifier getGroupIdentifier() {
@@ -27,11 +28,6 @@ public final class GroupPublicParams extends ByteArray {
     } catch (InvalidInputException e) {
       throw new AssertionError(e);
     }
-
-  }
-
-  public byte[] serialize() {
-    return contents.clone();
   }
 
 }

--- a/java/java/src/main/java/org/signal/zkgroup/groups/GroupSecretParams.java
+++ b/java/java/src/main/java/org/signal/zkgroup/groups/GroupSecretParams.java
@@ -14,8 +14,6 @@ import static org.signal.zkgroup.internal.Constants.RANDOM_LENGTH;
 
 public final class GroupSecretParams extends ByteArray {
 
-  public static final int SIZE = 289;
-
   public static GroupSecretParams generate() {
     return generate(new SecureRandom());
   }
@@ -44,7 +42,7 @@ public final class GroupSecretParams extends ByteArray {
   }
 
   public GroupSecretParams(byte[] contents)  {
-    super(contents, SIZE, true);
+    super(contents);
     Native.GroupSecretParams_CheckValidContents(contents);
   }
 
@@ -56,7 +54,6 @@ public final class GroupSecretParams extends ByteArray {
     } catch (InvalidInputException e) {
       throw new AssertionError(e);
     }
-
   }
 
   public GroupPublicParams getPublicParams() {
@@ -67,7 +64,6 @@ public final class GroupSecretParams extends ByteArray {
     } catch (InvalidInputException e) {
       throw new AssertionError(e);
     }
-
   }
 
   public byte[] serialize() {

--- a/java/java/src/main/java/org/signal/zkgroup/groups/ProfileKeyCiphertext.java
+++ b/java/java/src/main/java/org/signal/zkgroup/groups/ProfileKeyCiphertext.java
@@ -10,16 +10,12 @@ import org.signal.zkgroup.internal.ByteArray;
 import org.signal.client.internal.Native;
 
 public final class ProfileKeyCiphertext extends ByteArray {
-
-  public static final int SIZE = 65;
-
   public ProfileKeyCiphertext(byte[] contents) throws InvalidInputException {
-    super(contents, SIZE);
-    Native.ProfileKeyCiphertext_CheckValidContents(contents);
+    super(contents);
+    try {
+      Native.ProfileKeyCiphertext_CheckValidContents(contents);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidInputException(e.getMessage());
+    }
   }
-
-  public byte[] serialize() {
-    return contents.clone();
-  }
-
 }

--- a/java/java/src/main/java/org/signal/zkgroup/groups/UuidCiphertext.java
+++ b/java/java/src/main/java/org/signal/zkgroup/groups/UuidCiphertext.java
@@ -10,16 +10,12 @@ import org.signal.zkgroup.internal.ByteArray;
 import org.signal.client.internal.Native;
 
 public final class UuidCiphertext extends ByteArray {
-
-  public static final int SIZE = 65;
-
   public UuidCiphertext(byte[] contents) throws InvalidInputException {
-    super(contents, SIZE);
-    Native.UuidCiphertext_CheckValidContents(contents);
+    super(contents);
+    try {
+      Native.UuidCiphertext_CheckValidContents(contents);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidInputException(e.getMessage());
+    }
   }
-
-  public byte[] serialize() {
-    return contents.clone();
-  }
-
 }

--- a/java/java/src/main/java/org/signal/zkgroup/internal/ByteArray.java
+++ b/java/java/src/main/java/org/signal/zkgroup/internal/ByteArray.java
@@ -14,16 +14,12 @@ public abstract class ByteArray {
 
   protected final byte[] contents;
 
-  protected ByteArray(byte[] contents, int expectedLength) throws InvalidInputException {
-    this.contents = cloneArrayOfLength(contents, expectedLength);
+  protected ByteArray(byte[] contents) {
+    this.contents = contents.clone();
   }
 
-  protected ByteArray(byte[] contents, int expectedLength, boolean unrecoverable) {
-    try {
-      this.contents = cloneArrayOfLength(contents, expectedLength);
-    } catch (InvalidInputException e) {
-      throw new IllegalArgumentException(e);
-    }
+  protected ByteArray(byte[] contents, int expectedLength) throws InvalidInputException {
+    this.contents = cloneArrayOfLength(contents, expectedLength);
   }
 
   private static byte[] cloneArrayOfLength(byte[] bytes, int expectedLength) throws InvalidInputException {
@@ -38,6 +34,10 @@ public abstract class ByteArray {
     return contents;
   }
 
+  public byte[] serialize() {
+    return contents.clone();
+  }
+
   @Override
   public int hashCode() {
     return getClass().hashCode() * 31 + Arrays.hashCode(contents);
@@ -48,13 +48,13 @@ public abstract class ByteArray {
     if (o == null || getClass() != o.getClass()) return false;
 
     ByteArray other = (ByteArray) o;
-    if (contents == other.contents) return true;
+    if (contents == other.getInternalContentsForJNI()) return true;
 
-    if (contents.length != other.contents.length) return false;
+    if (contents.length != other.getInternalContentsForJNI().length) return false;
 
     int result = 0;
     for (int i = 0; i < contents.length; i++) {
-      result |= contents[i] ^ other.contents[i];
+      result |= contents[i] ^ other.getInternalContentsForJNI()[i];
     }
     return result == 0;
   }

--- a/java/java/src/main/java/org/signal/zkgroup/profiles/ClientZkProfileOperations.java
+++ b/java/java/src/main/java/org/signal/zkgroup/profiles/ClientZkProfileOperations.java
@@ -38,7 +38,6 @@ public class ClientZkProfileOperations {
     } catch (InvalidInputException e) {
       throw new AssertionError(e);
     }
-
   }
 
   public ProfileKeyCredential receiveProfileKeyCredential(ProfileKeyCredentialRequestContext profileKeyCredentialRequestContext, ProfileKeyCredentialResponse profileKeyCredentialResponse) throws VerificationFailedException {
@@ -53,7 +52,6 @@ public class ClientZkProfileOperations {
     } catch (InvalidInputException e) {
       throw new AssertionError(e);
     }
-
   }
 
   public ProfileKeyCredentialPresentation createProfileKeyCredentialPresentation(GroupSecretParams groupSecretParams, ProfileKeyCredential profileKeyCredential) {
@@ -71,7 +69,6 @@ public class ClientZkProfileOperations {
     } catch (InvalidInputException e) {
       throw new AssertionError(e);
     }
-
   }
 
 }

--- a/java/java/src/main/java/org/signal/zkgroup/profiles/ProfileKey.java
+++ b/java/java/src/main/java/org/signal/zkgroup/profiles/ProfileKey.java
@@ -13,10 +13,13 @@ import org.signal.client.internal.Native;
 
 public final class ProfileKey extends ByteArray {
 
-  public static final int SIZE = 32;
-
   public ProfileKey(byte[] contents) throws InvalidInputException {
-    super(contents, SIZE);
+    super(contents);
+    try {
+      Native.ProfileKey_CheckValidContents(contents);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidInputException(e.getMessage());
+    }
   }
 
   public ProfileKeyCommitment getCommitment(UUID uuid) {
@@ -27,7 +30,6 @@ public final class ProfileKey extends ByteArray {
     } catch (InvalidInputException e) {
       throw new AssertionError(e);
     }
-
   }
 
   public ProfileKeyVersion getProfileKeyVersion(UUID uuid) {
@@ -38,11 +40,6 @@ public final class ProfileKey extends ByteArray {
     } catch (InvalidInputException e) {
       throw new AssertionError(e);
     }
-
-  }
-
-  public byte[] serialize() {
-    return contents.clone();
   }
 
 }

--- a/java/java/src/main/java/org/signal/zkgroup/profiles/ProfileKeyCommitment.java
+++ b/java/java/src/main/java/org/signal/zkgroup/profiles/ProfileKeyCommitment.java
@@ -10,16 +10,12 @@ import org.signal.zkgroup.internal.ByteArray;
 import org.signal.client.internal.Native;
 
 public final class ProfileKeyCommitment extends ByteArray {
-
-  public static final int SIZE = 97;
-
   public ProfileKeyCommitment(byte[] contents) throws InvalidInputException {
-    super(contents, SIZE);
-    Native.ProfileKeyCommitment_CheckValidContents(contents);
+    super(contents);
+    try {
+      Native.ProfileKeyCommitment_CheckValidContents(contents);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidInputException(e.getMessage());
+    }
   }
-
-  public byte[] serialize() {
-    return contents.clone();
-  }
-
 }

--- a/java/java/src/main/java/org/signal/zkgroup/profiles/ProfileKeyCredential.java
+++ b/java/java/src/main/java/org/signal/zkgroup/profiles/ProfileKeyCredential.java
@@ -10,16 +10,12 @@ import org.signal.zkgroup.internal.ByteArray;
 import org.signal.client.internal.Native;
 
 public final class ProfileKeyCredential extends ByteArray {
-
-  public static final int SIZE = 145;
-
   public ProfileKeyCredential(byte[] contents) throws InvalidInputException {
-    super(contents, SIZE);
-    Native.ProfileKeyCredential_CheckValidContents(contents);
+    super(contents);
+    try {
+      Native.ProfileKeyCredential_CheckValidContents(contents);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidInputException(e.getMessage());
+    }
   }
-
-  public byte[] serialize() {
-    return contents.clone();
-  }
-
 }

--- a/java/java/src/main/java/org/signal/zkgroup/profiles/ProfileKeyCredentialPresentation.java
+++ b/java/java/src/main/java/org/signal/zkgroup/profiles/ProfileKeyCredentialPresentation.java
@@ -12,12 +12,13 @@ import org.signal.zkgroup.internal.ByteArray;
 import org.signal.client.internal.Native;
 
 public final class ProfileKeyCredentialPresentation extends ByteArray {
-
-  public static final int SIZE = 713;
-
   public ProfileKeyCredentialPresentation(byte[] contents) throws InvalidInputException {
-    super(contents, SIZE);
-    Native.ProfileKeyCredentialPresentation_CheckValidContents(contents);
+    super(contents);
+    try {
+      Native.ProfileKeyCredentialPresentation_CheckValidContents(contents);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidInputException(e.getMessage());
+    }
   }
 
   public UuidCiphertext getUuidCiphertext() {
@@ -28,7 +29,6 @@ public final class ProfileKeyCredentialPresentation extends ByteArray {
     } catch (InvalidInputException e) {
       throw new AssertionError(e);
     }
-
   }
 
   public ProfileKeyCiphertext getProfileKeyCiphertext() {
@@ -39,11 +39,6 @@ public final class ProfileKeyCredentialPresentation extends ByteArray {
     } catch (InvalidInputException e) {
       throw new AssertionError(e);
     }
-
-  }
-
-  public byte[] serialize() {
-    return contents.clone();
   }
 
 }

--- a/java/java/src/main/java/org/signal/zkgroup/profiles/ProfileKeyCredentialRequest.java
+++ b/java/java/src/main/java/org/signal/zkgroup/profiles/ProfileKeyCredentialRequest.java
@@ -10,16 +10,12 @@ import org.signal.zkgroup.internal.ByteArray;
 import org.signal.client.internal.Native;
 
 public final class ProfileKeyCredentialRequest extends ByteArray {
-
-  public static final int SIZE = 329;
-
   public ProfileKeyCredentialRequest(byte[] contents) throws InvalidInputException {
-    super(contents, SIZE);
-    Native.ProfileKeyCredentialRequest_CheckValidContents(contents);
+    super(contents);
+    try {
+      Native.ProfileKeyCredentialRequest_CheckValidContents(contents);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidInputException(e.getMessage());
+    }
   }
-
-  public byte[] serialize() {
-    return contents.clone();
-  }
-
 }

--- a/java/java/src/main/java/org/signal/zkgroup/profiles/ProfileKeyCredentialRequestContext.java
+++ b/java/java/src/main/java/org/signal/zkgroup/profiles/ProfileKeyCredentialRequestContext.java
@@ -10,12 +10,13 @@ import org.signal.zkgroup.internal.ByteArray;
 import org.signal.client.internal.Native;
 
 public final class ProfileKeyCredentialRequestContext extends ByteArray {
-
-  public static final int SIZE = 473;
-
   public ProfileKeyCredentialRequestContext(byte[] contents) throws InvalidInputException {
-    super(contents, SIZE);
-    Native.ProfileKeyCredentialRequestContext_CheckValidContents(contents);
+    super(contents);
+    try {
+      Native.ProfileKeyCredentialRequestContext_CheckValidContents(contents);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidInputException(e.getMessage());
+    }
   }
 
   public ProfileKeyCredentialRequest getRequest() {
@@ -26,11 +27,5 @@ public final class ProfileKeyCredentialRequestContext extends ByteArray {
     } catch (InvalidInputException e) {
       throw new AssertionError(e);
     }
-
   }
-
-  public byte[] serialize() {
-    return contents.clone();
-  }
-
 }

--- a/java/java/src/main/java/org/signal/zkgroup/profiles/ProfileKeyCredentialResponse.java
+++ b/java/java/src/main/java/org/signal/zkgroup/profiles/ProfileKeyCredentialResponse.java
@@ -10,16 +10,12 @@ import org.signal.zkgroup.internal.ByteArray;
 import org.signal.client.internal.Native;
 
 public final class ProfileKeyCredentialResponse extends ByteArray {
-
-  public static final int SIZE = 457;
-
   public ProfileKeyCredentialResponse(byte[] contents) throws InvalidInputException {
-    super(contents, SIZE);
-    Native.ProfileKeyCredentialResponse_CheckValidContents(contents);
+    super(contents);
+    try {
+      Native.ProfileKeyCredentialResponse_CheckValidContents(contents);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidInputException(e.getMessage());
+    }
   }
-
-  public byte[] serialize() {
-    return contents.clone();
-  }
-
 }

--- a/java/java/src/main/java/org/signal/zkgroup/profiles/ProfileKeyVersion.java
+++ b/java/java/src/main/java/org/signal/zkgroup/profiles/ProfileKeyVersion.java
@@ -9,16 +9,19 @@ import org.signal.zkgroup.InvalidInputException;
 import org.signal.zkgroup.internal.ByteArray;
 import java.io.UnsupportedEncodingException;
 
-public final class ProfileKeyVersion extends ByteArray {
+public final class ProfileKeyVersion {
 
-  public static final int SIZE = 64;
+  private byte[] contents;
 
   public ProfileKeyVersion(byte[] contents) throws InvalidInputException {
-    super(contents, SIZE);
+    if (contents.length != 64) {
+      throw new InvalidInputException("bad length");
+    }
+    this.contents = contents.clone();
   }
 
   public ProfileKeyVersion(String contents) throws InvalidInputException, UnsupportedEncodingException {
-    super(contents.getBytes("UTF-8"), SIZE);
+    this(contents.getBytes("UTF-8"));
   }
 
   public String serialize() {

--- a/java/java/src/main/java/org/signal/zkgroup/profiles/ServerZkProfileOperations.java
+++ b/java/java/src/main/java/org/signal/zkgroup/profiles/ServerZkProfileOperations.java
@@ -38,7 +38,6 @@ public class ServerZkProfileOperations {
     } catch (InvalidInputException e) {
       throw new AssertionError(e);
     }
-
   }
 
   public void verifyProfileKeyCredentialPresentation(GroupPublicParams groupPublicParams, ProfileKeyCredentialPresentation profileKeyCredentialPresentation) throws VerificationFailedException {

--- a/java/java/src/main/java/org/signal/zkgroup/receipts/ClientZkReceiptOperations.java
+++ b/java/java/src/main/java/org/signal/zkgroup/receipts/ClientZkReceiptOperations.java
@@ -36,7 +36,6 @@ public class ClientZkReceiptOperations {
     } catch (InvalidInputException e) {
       throw new AssertionError(e);
     }
-
   }
 
   public ReceiptCredential receiveReceiptCredential(ReceiptCredentialRequestContext receiptCredentialRequestContext, ReceiptCredentialResponse receiptCredentialResponse) throws VerificationFailedException {
@@ -47,7 +46,6 @@ public class ClientZkReceiptOperations {
     } catch (InvalidInputException e) {
       throw new AssertionError(e);
     }
-
   }
 
   public ReceiptCredentialPresentation createReceiptCredentialPresentation(ReceiptCredential receiptCredential) throws VerificationFailedException {
@@ -65,7 +63,6 @@ public class ClientZkReceiptOperations {
     } catch (InvalidInputException e) {
       throw new AssertionError(e);
     }
-
   }
 
 }

--- a/java/java/src/main/java/org/signal/zkgroup/receipts/ReceiptCredential.java
+++ b/java/java/src/main/java/org/signal/zkgroup/receipts/ReceiptCredential.java
@@ -12,10 +12,8 @@ import org.signal.client.internal.Native;
 
 public final class ReceiptCredential extends ByteArray {
 
-  public static final int SIZE = 129;
-
   public ReceiptCredential(byte[] contents) throws InvalidInputException {
-    super(contents, SIZE);
+    super(contents);
     Native.ReceiptCredential_CheckValidContents(contents);
   }
 
@@ -25,10 +23,6 @@ public final class ReceiptCredential extends ByteArray {
 
   public long getReceiptLevel() {
     return Native.ReceiptCredential_GetReceiptLevel(contents);
-  }
-
-  public byte[] serialize() {
-    return contents.clone();
   }
 
 }

--- a/java/java/src/main/java/org/signal/zkgroup/receipts/ReceiptCredentialPresentation.java
+++ b/java/java/src/main/java/org/signal/zkgroup/receipts/ReceiptCredentialPresentation.java
@@ -11,11 +11,8 @@ import org.signal.zkgroup.internal.ByteArray;
 import org.signal.client.internal.Native;
 
 public final class ReceiptCredentialPresentation extends ByteArray {
-
-  public static final int SIZE = 329;
-
   public ReceiptCredentialPresentation(byte[] contents) throws InvalidInputException {
-    super(contents, SIZE);
+    super(contents);
     Native.ReceiptCredentialPresentation_CheckValidContents(contents);
   }
 
@@ -35,11 +32,6 @@ public final class ReceiptCredentialPresentation extends ByteArray {
     } catch (InvalidInputException e) {
       throw new AssertionError(e);
     }
-
-  }
-
-  public byte[] serialize() {
-    return contents.clone();
   }
 
 }

--- a/java/java/src/main/java/org/signal/zkgroup/receipts/ReceiptCredentialRequest.java
+++ b/java/java/src/main/java/org/signal/zkgroup/receipts/ReceiptCredentialRequest.java
@@ -10,16 +10,8 @@ import org.signal.zkgroup.internal.ByteArray;
 import org.signal.client.internal.Native;
 
 public final class ReceiptCredentialRequest extends ByteArray {
-
-  public static final int SIZE = 97;
-
   public ReceiptCredentialRequest(byte[] contents) throws InvalidInputException {
-    super(contents, SIZE);
+    super(contents);
     Native.ReceiptCredentialRequest_CheckValidContents(contents);
   }
-
-  public byte[] serialize() {
-    return contents.clone();
-  }
-
 }

--- a/java/java/src/main/java/org/signal/zkgroup/receipts/ReceiptCredentialRequestContext.java
+++ b/java/java/src/main/java/org/signal/zkgroup/receipts/ReceiptCredentialRequestContext.java
@@ -26,7 +26,6 @@ public final class ReceiptCredentialRequestContext extends ByteArray {
     } catch (InvalidInputException e) {
       throw new AssertionError(e);
     }
-
   }
 
   public byte[] serialize() {

--- a/java/java/src/main/java/org/signal/zkgroup/receipts/ReceiptCredentialResponse.java
+++ b/java/java/src/main/java/org/signal/zkgroup/receipts/ReceiptCredentialResponse.java
@@ -10,16 +10,8 @@ import org.signal.zkgroup.internal.ByteArray;
 import org.signal.client.internal.Native;
 
 public final class ReceiptCredentialResponse extends ByteArray {
-
-  public static final int SIZE = 409;
-
   public ReceiptCredentialResponse(byte[] contents) throws InvalidInputException {
-    super(contents, SIZE);
+    super(contents);
     Native.ReceiptCredentialResponse_CheckValidContents(contents);
   }
-
-  public byte[] serialize() {
-    return contents.clone();
-  }
-
 }

--- a/java/java/src/main/java/org/signal/zkgroup/receipts/ReceiptSerial.java
+++ b/java/java/src/main/java/org/signal/zkgroup/receipts/ReceiptSerial.java
@@ -16,8 +16,4 @@ public final class ReceiptSerial extends ByteArray {
     super(contents, SIZE);
   }
 
-  public byte[] serialize() {
-    return contents.clone();
-  }
-
 }

--- a/java/java/src/main/java/org/signal/zkgroup/receipts/ServerZkReceiptOperations.java
+++ b/java/java/src/main/java/org/signal/zkgroup/receipts/ServerZkReceiptOperations.java
@@ -36,7 +36,6 @@ public class ServerZkReceiptOperations {
     } catch (InvalidInputException e) {
       throw new AssertionError(e);
     }
-
   }
 
   public void verifyReceiptCredentialPresentation(ReceiptCredentialPresentation receiptCredentialPresentation) throws VerificationFailedException {

--- a/java/tests/src/test/java/org/signal/zkgroup/integrationtests/ZkGroupTest.java
+++ b/java/tests/src/test/java/org/signal/zkgroup/integrationtests/ZkGroupTest.java
@@ -302,10 +302,37 @@ private static final byte[] profileKeyPresentationResult = Hex.fromStringCondens
     //assertByteArray("31f2c60f86f4c5996e9e2568355591d9", groupPublicParams.getGroupIdentifier().serialize());
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testErrors() throws RuntimeException {
+  @Test(expected = InvalidInputException.class)
+  public void testInvalidSerialized() throws InvalidInputException {
 
-    byte[] ckp = new byte[GroupSecretParams.SIZE];
+    byte[] ckp = new byte[97]; // right size, wrong contents
+    Arrays.fill(ckp, (byte) -127);
+
+    GroupPublicParams groupSecretParams = new GroupPublicParams(ckp);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidSerializedInfallible() {
+
+    byte[] ckp = new byte[289]; // right size, wrong contents
+    Arrays.fill(ckp, (byte) -127);
+
+    GroupSecretParams groupSecretParams = new GroupSecretParams(ckp);
+  }
+
+  @Test(expected = InvalidInputException.class)
+  public void testWrongSizeSerialized() throws InvalidInputException {
+
+    byte[] ckp = new byte[5]; // right size, wrong contents
+    Arrays.fill(ckp, (byte) -127);
+
+    GroupPublicParams groupSecretParams = new GroupPublicParams(ckp);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testWrongSizeSerializedInfallible() {
+
+    byte[] ckp = new byte[5]; // right size, wrong contents
     Arrays.fill(ckp, (byte) -127);
 
     GroupSecretParams groupSecretParams = new GroupSecretParams(ckp);


### PR DESCRIPTION
- Don't validate sizes ahead of time if the subclass calls CheckValidContents anyway. (Now that these classes aren't code-gen'd, keeping sizes in sync is a pain.)
- Move `serialize()` up to ByteArray. Consequently, make ProfileKeyVersion *not* a ByteArray, since it serializes as a string.