### PR TITLE
Android: upload unstripped libraries to Maven as well

### DIFF
--- a/java/android/build.gradle
+++ b/java/android/build.gradle
@@ -131,6 +131,15 @@ task installArchives(type: Upload) {
     }
 }
 
+task libsWithDebugSymbols(type: Zip) {
+    from 'src/main/jniLibs'
+    classifier 'debug-symbols'
+}
+
+artifacts {
+    archives libsWithDebugSymbols
+}
+
 tasks.withType(JavaCompile) {
     compileTask -> compileTask.dependsOn ':makeJniLibrariesAndroid'
 }


### PR DESCRIPTION
This allows us to symbolicate native crash traces if necessary.