### PR TITLE
swift: Improve zkgroup's ByteArray helper class

### DIFF
--- a/swift/Sources/SignalClient/zkgroup/AuthCredential.swift
+++ b/swift/Sources/SignalClient/zkgroup/AuthCredential.swift
@@ -7,15 +7,7 @@ import Foundation
 import SignalFfi
 
 public class AuthCredential: ByteArray {
-
-  public static let SIZE: Int = 181
-
   public required init(contents: [UInt8]) throws {
-    try super.init(newContents: contents, expectedLength: AuthCredential.SIZE)
-
-    try withUnsafePointerToSerialized { contents in
-      try checkError(signal_auth_credential_check_valid_contents(contents))
-    }
+    try super.init(contents, checkValid: signal_auth_credential_check_valid_contents)
   }
-
 }

--- a/swift/Sources/SignalClient/zkgroup/AuthCredentialPresentation.swift
+++ b/swift/Sources/SignalClient/zkgroup/AuthCredentialPresentation.swift
@@ -8,14 +8,8 @@ import SignalFfi
 
 public class AuthCredentialPresentation: ByteArray {
 
-  public static let SIZE: Int = 493
-
   public required init(contents: [UInt8]) throws {
-    try super.init(newContents: contents, expectedLength: AuthCredentialPresentation.SIZE)
-
-    try withUnsafePointerToSerialized { contents in
-      try checkError(signal_auth_credential_presentation_check_valid_contents(contents))
-    }
+    try super.init(contents, checkValid: signal_auth_credential_presentation_check_valid_contents)
   }
 
   public func getUuidCiphertext() throws -> UuidCiphertext {

--- a/swift/Sources/SignalClient/zkgroup/AuthCredentialResponse.swift
+++ b/swift/Sources/SignalClient/zkgroup/AuthCredentialResponse.swift
@@ -7,15 +7,7 @@ import Foundation
 import SignalFfi
 
 public class AuthCredentialResponse: ByteArray {
-
-  public static let SIZE: Int = 361
-
   public required init(contents: [UInt8]) throws {
-    try super.init(newContents: contents, expectedLength: AuthCredentialResponse.SIZE)
-
-    try withUnsafePointerToSerialized { contents in
-      try checkError(signal_auth_credential_response_check_valid_contents(contents))
-    }
+    try super.init(contents, checkValid: signal_auth_credential_response_check_valid_contents)
   }
-
 }

--- a/swift/Sources/SignalClient/zkgroup/GroupPublicParams.swift
+++ b/swift/Sources/SignalClient/zkgroup/GroupPublicParams.swift
@@ -8,14 +8,8 @@ import SignalFfi
 
 public class GroupPublicParams: ByteArray {
 
-  public static let SIZE: Int = 97
-
   public required init(contents: [UInt8]) throws {
-    try super.init(newContents: contents, expectedLength: GroupPublicParams.SIZE)
-
-    try withUnsafePointerToSerialized { contents in
-      try checkError(signal_group_public_params_check_valid_contents(contents))
-    }
+    try super.init(contents, checkValid: signal_group_public_params_check_valid_contents)
   }
 
   public func getGroupIdentifier() throws -> GroupIdentifier {

--- a/swift/Sources/SignalClient/zkgroup/GroupSecretParams.swift
+++ b/swift/Sources/SignalClient/zkgroup/GroupSecretParams.swift
@@ -8,8 +8,6 @@ import SignalFfi
 
 public class GroupSecretParams: ByteArray {
 
-  public static let SIZE: Int = 289
-
   public static func generate() throws -> GroupSecretParams {
     return try generate(randomness: Randomness.generate())
   }
@@ -31,10 +29,7 @@ public class GroupSecretParams: ByteArray {
   }
 
   public required init(contents: [UInt8]) throws {
-    try super.init(newContents: contents, expectedLength: GroupSecretParams.SIZE, unrecoverable: true)
-    try withUnsafePointerToSerialized { contents in
-      try checkError(signal_group_secret_params_check_valid_contents(contents))
-    }
+    try super.init(contents, checkValid: signal_group_secret_params_check_valid_contents)
   }
 
   public func getMasterKey() throws -> GroupMasterKey {

--- a/swift/Sources/SignalClient/zkgroup/ProfileKeyCiphertext.swift
+++ b/swift/Sources/SignalClient/zkgroup/ProfileKeyCiphertext.swift
@@ -7,15 +7,7 @@ import Foundation
 import SignalFfi
 
 public class ProfileKeyCiphertext: ByteArray {
-
-  public static let SIZE: Int = 65
-
   public required init(contents: [UInt8]) throws {
-    try super.init(newContents: contents, expectedLength: ProfileKeyCiphertext.SIZE)
-
-    try withUnsafePointerToSerialized { contents in
-      try checkError(signal_profile_key_ciphertext_check_valid_contents(contents))
-    }
+    try super.init(contents, checkValid: signal_profile_key_ciphertext_check_valid_contents)
   }
-
 }

--- a/swift/Sources/SignalClient/zkgroup/ProfileKeyCommitment.swift
+++ b/swift/Sources/SignalClient/zkgroup/ProfileKeyCommitment.swift
@@ -7,15 +7,7 @@ import Foundation
 import SignalFfi
 
 public class ProfileKeyCommitment: ByteArray {
-
-  public static let SIZE: Int = 97
-
   public required init(contents: [UInt8]) throws {
-    try super.init(newContents: contents, expectedLength: ProfileKeyCommitment.SIZE)
-
-    try withUnsafePointerToSerialized { contents in
-      try checkError(signal_profile_key_commitment_check_valid_contents(contents))
-    }
+    try super.init(contents, checkValid: signal_profile_key_commitment_check_valid_contents)
   }
-
 }

--- a/swift/Sources/SignalClient/zkgroup/ProfileKeyCredential.swift
+++ b/swift/Sources/SignalClient/zkgroup/ProfileKeyCredential.swift
@@ -7,15 +7,7 @@ import Foundation
 import SignalFfi
 
 public class ProfileKeyCredential: ByteArray {
-
-  public static let SIZE: Int = 145
-
   public required init(contents: [UInt8]) throws {
-    try super.init(newContents: contents, expectedLength: ProfileKeyCredential.SIZE)
-
-    try withUnsafePointerToSerialized { contents in
-      try checkError(signal_profile_key_credential_check_valid_contents(contents))
-    }
+    try super.init(contents, checkValid: signal_profile_key_credential_check_valid_contents)
   }
-
 }

--- a/swift/Sources/SignalClient/zkgroup/ProfileKeyCredentialPresentation.swift
+++ b/swift/Sources/SignalClient/zkgroup/ProfileKeyCredentialPresentation.swift
@@ -8,14 +8,8 @@ import SignalFfi
 
 public class ProfileKeyCredentialPresentation: ByteArray {
 
-  public static let SIZE: Int = 713
-
   public required init(contents: [UInt8]) throws {
-    try super.init(newContents: contents, expectedLength: ProfileKeyCredentialPresentation.SIZE)
-
-    try withUnsafePointerToSerialized { contents in
-      try checkError(signal_profile_key_credential_presentation_check_valid_contents(contents))
-    }
+    try super.init(contents, checkValid: signal_profile_key_credential_presentation_check_valid_contents)
   }
 
   public func getUuidCiphertext() throws -> UuidCiphertext {

--- a/swift/Sources/SignalClient/zkgroup/ProfileKeyCredentialRequest.swift
+++ b/swift/Sources/SignalClient/zkgroup/ProfileKeyCredentialRequest.swift
@@ -7,15 +7,7 @@ import Foundation
 import SignalFfi
 
 public class ProfileKeyCredentialRequest: ByteArray {
-
-  public static let SIZE: Int = 329
-
   public required init(contents: [UInt8]) throws {
-    try super.init(newContents: contents, expectedLength: ProfileKeyCredentialRequest.SIZE)
-
-    try withUnsafePointerToSerialized { contents in
-      try checkError(signal_profile_key_credential_request_check_valid_contents(contents))
-    }
+    try super.init(contents, checkValid: signal_profile_key_credential_request_check_valid_contents)
   }
-
 }

--- a/swift/Sources/SignalClient/zkgroup/ProfileKeyCredentialRequestContext.swift
+++ b/swift/Sources/SignalClient/zkgroup/ProfileKeyCredentialRequestContext.swift
@@ -8,13 +8,8 @@ import SignalFfi
 
 public class ProfileKeyCredentialRequestContext: ByteArray {
 
-  public static let SIZE: Int = 473
-
   public required init(contents: [UInt8]) throws {
-    try super.init(newContents: contents, expectedLength: ProfileKeyCredentialRequestContext.SIZE)
-    try withUnsafePointerToSerialized { contents in
-      try checkError(signal_profile_key_credential_request_context_check_valid_contents(contents))
-    }
+    try super.init(contents, checkValid: signal_profile_key_credential_request_context_check_valid_contents)
   }
 
   public func getRequest() throws -> ProfileKeyCredentialRequest {

--- a/swift/Sources/SignalClient/zkgroup/ProfileKeyCredentialResponse.swift
+++ b/swift/Sources/SignalClient/zkgroup/ProfileKeyCredentialResponse.swift
@@ -7,15 +7,7 @@ import Foundation
 import SignalFfi
 
 public class ProfileKeyCredentialResponse: ByteArray {
-
-  public static let SIZE: Int = 457
-
   public required init(contents: [UInt8]) throws {
-    try super.init(newContents: contents, expectedLength: ProfileKeyCredentialResponse.SIZE)
-
-    try withUnsafePointerToSerialized { contents in
-      try checkError(signal_profile_key_credential_response_check_valid_contents(contents))
-    }
+    try super.init(contents, checkValid: signal_profile_key_credential_response_check_valid_contents)
   }
-
 }

--- a/swift/Sources/SignalClient/zkgroup/ReceiptCredential.swift
+++ b/swift/Sources/SignalClient/zkgroup/ReceiptCredential.swift
@@ -8,14 +8,8 @@ import SignalFfi
 
 public class ReceiptCredential: ByteArray {
 
-  public static let SIZE: Int = 129
-
   public required init(contents: [UInt8]) throws {
-    try super.init(newContents: contents, expectedLength: ReceiptCredential.SIZE)
-
-    try withUnsafePointerToSerialized { contents in
-      try checkError(signal_receipt_credential_check_valid_contents(contents))
-    }
+    try super.init(contents, checkValid: signal_receipt_credential_check_valid_contents)
   }
 
   public func getReceiptExpirationTime() throws -> UInt64 {

--- a/swift/Sources/SignalClient/zkgroup/ReceiptCredentialPresentation.swift
+++ b/swift/Sources/SignalClient/zkgroup/ReceiptCredentialPresentation.swift
@@ -8,14 +8,8 @@ import SignalFfi
 
 public class ReceiptCredentialPresentation: ByteArray {
 
-  public static let SIZE: Int = 329
-
   public required init(contents: [UInt8]) throws {
-    try super.init(newContents: contents, expectedLength: ReceiptCredentialPresentation.SIZE)
-
-    try withUnsafePointerToSerialized { contents in
-      try checkError(signal_receipt_credential_presentation_check_valid_contents(contents))
-    }
+    try super.init(contents, checkValid: signal_receipt_credential_presentation_check_valid_contents)
   }
 
   public func getReceiptExpirationTime() throws -> UInt64 {

--- a/swift/Sources/SignalClient/zkgroup/ReceiptCredentialRequest.swift
+++ b/swift/Sources/SignalClient/zkgroup/ReceiptCredentialRequest.swift
@@ -7,15 +7,7 @@ import Foundation
 import SignalFfi
 
 public class ReceiptCredentialRequest: ByteArray {
-
-  public static let SIZE: Int = 97
-
   public required init(contents: [UInt8]) throws {
-    try super.init(newContents: contents, expectedLength: ReceiptCredentialRequest.SIZE)
-
-    try withUnsafePointerToSerialized { contents in
-      try checkError(signal_receipt_credential_request_check_valid_contents(contents))
-    }
+    try super.init(contents, checkValid: signal_receipt_credential_request_check_valid_contents)
   }
-
 }

--- a/swift/Sources/SignalClient/zkgroup/ReceiptCredentialRequestContext.swift
+++ b/swift/Sources/SignalClient/zkgroup/ReceiptCredentialRequestContext.swift
@@ -8,14 +8,8 @@ import SignalFfi
 
 public class ReceiptCredentialRequestContext: ByteArray {
 
-  public static let SIZE: Int = 177
-
   public required init(contents: [UInt8]) throws {
-    try super.init(newContents: contents, expectedLength: ReceiptCredentialRequestContext.SIZE)
-
-    try withUnsafePointerToSerialized { contents in
-      try checkError(signal_receipt_credential_request_context_check_valid_contents(contents))
-    }
+    try super.init(contents, checkValid: signal_receipt_credential_request_context_check_valid_contents)
   }
 
   public func getRequest() throws -> ReceiptCredentialRequest {

--- a/swift/Sources/SignalClient/zkgroup/ReceiptCredentialResponse.swift
+++ b/swift/Sources/SignalClient/zkgroup/ReceiptCredentialResponse.swift
@@ -7,15 +7,7 @@ import Foundation
 import SignalFfi
 
 public class ReceiptCredentialResponse: ByteArray {
-
-  public static let SIZE: Int = 409
-
   public required init(contents: [UInt8]) throws {
-    try super.init(newContents: contents, expectedLength: ReceiptCredentialResponse.SIZE)
-
-    try withUnsafePointerToSerialized { contents in
-      try checkError(signal_receipt_credential_response_check_valid_contents(contents))
-    }
+    try super.init(contents, checkValid: signal_receipt_credential_response_check_valid_contents)
   }
-
 }

--- a/swift/Sources/SignalClient/zkgroup/ServerPublicParams.swift
+++ b/swift/Sources/SignalClient/zkgroup/ServerPublicParams.swift
@@ -8,14 +8,8 @@ import SignalFfi
 
 public class ServerPublicParams: ByteArray {
 
-  public static let SIZE: Int = 225
-
   public required init(contents: [UInt8]) throws {
-    try super.init(newContents: contents, expectedLength: ServerPublicParams.SIZE, unrecoverable: true)
-
-    try withUnsafePointerToSerialized { contents in
-      try checkError(signal_server_public_params_check_valid_contents(contents))
-    }
+    try super.init(contents, checkValid: signal_server_public_params_check_valid_contents)
   }
 
   public func verifySignature(message: [UInt8], notarySignature: NotarySignature) throws {

--- a/swift/Sources/SignalClient/zkgroup/ServerSecretParams.swift
+++ b/swift/Sources/SignalClient/zkgroup/ServerSecretParams.swift
@@ -8,8 +8,6 @@ import SignalFfi
 
 public class ServerSecretParams: ByteArray {
 
-  public static let SIZE: Int = 1121
-
   public static func generate() throws -> ServerSecretParams {
     return try generate(randomness: Randomness.generate())
   }
@@ -23,11 +21,7 @@ public class ServerSecretParams: ByteArray {
   }
 
   public required init(contents: [UInt8]) throws {
-    try super.init(newContents: contents, expectedLength: ServerSecretParams.SIZE, unrecoverable: true)
-
-    try withUnsafePointerToSerialized { contents in
-      try checkError(signal_server_secret_params_check_valid_contents(contents))
-    }
+    try super.init(contents, checkValid: signal_server_secret_params_check_valid_contents)
   }
 
   public func getPublicParams() throws -> ServerPublicParams {

--- a/swift/Sources/SignalClient/zkgroup/UuidCiphertext.swift
+++ b/swift/Sources/SignalClient/zkgroup/UuidCiphertext.swift
@@ -7,15 +7,7 @@ import Foundation
 import SignalFfi
 
 public class UuidCiphertext: ByteArray {
-
-  public static let SIZE: Int = 65
-
   public required init(contents: [UInt8]) throws {
-    try super.init(newContents: contents, expectedLength: UuidCiphertext.SIZE)
-
-    try self.withUnsafePointerToSerialized { contents in
-      try checkError(signal_uuid_ciphertext_check_valid_contents(contents))
-    }
+    try super.init(contents, checkValid: signal_uuid_ciphertext_check_valid_contents)
   }
-
 }

--- a/swift/Tests/SignalClientTests/ZKGroupTests.swift
+++ b/swift/Tests/SignalClientTests/ZKGroupTests.swift
@@ -259,11 +259,21 @@ class ZKGroupTests: TestCaseBase {
     }
   }
 
-  func testErrors() throws {
-    let ckp: [UInt8] = Array(repeating: 255, count: GroupSecretParams.SIZE)
+  func testInvalidSerialized() throws {
+    let ckp: [UInt8] = Array(repeating: 255, count: 289)
     do {
         _ = try GroupSecretParams(contents: ckp)
-        XCTAssert(false)
+        XCTFail("should have thrown")
+    } catch SignalError.invalidType(_) {
+        // good
+    }
+  }
+
+  func testWrongSizeSerialized() throws {
+    let ckp: [UInt8] = Array(repeating: 255, count: 5)
+    do {
+        _ = try GroupSecretParams(contents: ckp)
+        XCTFail("should have thrown")
     } catch SignalError.invalidType(_) {
         // good
     }
@@ -337,7 +347,8 @@ class ZKGroupTests: TestCaseBase {
       ("testAuthIntegration", testAuthIntegration),
       ("testProfileKeyIntegration", testProfileKeyIntegration),
       ("testServerSignatures", testServerSignatures),
-      ("testErrors", testErrors),
+      ("testInvalidSerialized", testInvalidSerialized),
+      ("testWrongSizeSerialized", testWrongSizeSerialized),
       ("testBlobEncryption", testBlobEncryption),
       ("testBlobEncryptionWithRandom", testBlobEncryptionWithRandom),
     ]


### PR DESCRIPTION
Don't validate sizes explicitly; they're already provided in the signatures of the *_check_valid_contents functions exposed in the FFI layer. Similar to #408.