### PR TITLE
node: Improve zkgroup's ByteArray helper class

### DIFF
--- a/node/test/ZKGroup-test.ts
+++ b/node/test/ZKGroup-test.ts
@@ -333,15 +333,16 @@ describe('ZKGroup', () => {
     // assertByteArray('31f2c60f86f4c5996e9e2568355591d9', groupPublicParams.getGroupIdentifier().serialize());
   });
 
-  it('testErrors', () => {
-    const ckp = Buffer.alloc(GroupSecretParams.SIZE);
+  it('testInvalidSerialized', () => {
+    const ckp = Buffer.alloc(289);
     ckp.fill(-127);
+    assert.throws(() => new GroupSecretParams(ckp));
+  });
 
-    try {
-      const _groupSecretParams = new GroupSecretParams(ckp);
-    } catch (error) {
-      // good
-    }
+  it('testWrongSizeSerialized', () => {
+    const ckp = Buffer.alloc(5);
+    ckp.fill(-127);
+    assert.throws(() => new GroupSecretParams(ckp));
   });
 
   it('testBlobEncryption', () => {

--- a/node/zkgroup/NotarySignature.ts
+++ b/node/zkgroup/NotarySignature.ts
@@ -9,6 +9,6 @@ export default class NotarySignature extends ByteArray {
   static SIZE = 64;
 
   constructor(contents: Buffer) {
-    super(contents, NotarySignature.SIZE, true);
+    super(contents, NotarySignature.checkLength(NotarySignature.SIZE));
   }
 }

--- a/node/zkgroup/ServerPublicParams.ts
+++ b/node/zkgroup/ServerPublicParams.ts
@@ -8,11 +8,8 @@ import NativeImpl from '../NativeImpl';
 import NotarySignature from './NotarySignature';
 
 export default class ServerPublicParams extends ByteArray {
-  static SIZE = 225;
-
   constructor(contents: Buffer) {
-    super(contents, ServerPublicParams.SIZE, true);
-    NativeImpl.ServerPublicParams_CheckValidContents(contents);
+    super(contents, NativeImpl.ServerPublicParams_CheckValidContents);
   }
 
   verifySignature(message: Buffer, notarySignature: NotarySignature): void {

--- a/node/zkgroup/ServerSecretParams.ts
+++ b/node/zkgroup/ServerSecretParams.ts
@@ -12,8 +12,6 @@ import ServerPublicParams from './ServerPublicParams';
 import NotarySignature from './NotarySignature';
 
 export default class ServerSecretParams extends ByteArray {
-  static SIZE = 1121;
-
   static generate(): ServerSecretParams {
     const random = randomBytes(RANDOM_LENGTH);
 
@@ -27,8 +25,7 @@ export default class ServerSecretParams extends ByteArray {
   }
 
   constructor(contents: Buffer) {
-    super(contents, ServerSecretParams.SIZE, true);
-    NativeImpl.ServerSecretParams_CheckValidContents(contents);
+    super(contents, NativeImpl.ServerSecretParams_CheckValidContents);
   }
 
   getPublicParams(): ServerPublicParams {

--- a/node/zkgroup/auth/AuthCredential.ts
+++ b/node/zkgroup/auth/AuthCredential.ts
@@ -7,10 +7,7 @@ import ByteArray from '../internal/ByteArray';
 import NativeImpl from '../../NativeImpl';
 
 export default class AuthCredential extends ByteArray {
-  static SIZE = 181;
-
   constructor(contents: Buffer) {
-    super(contents, AuthCredential.SIZE, true);
-    NativeImpl.AuthCredential_CheckValidContents(contents);
+    super(contents, NativeImpl.AuthCredential_CheckValidContents);
   }
 }

--- a/node/zkgroup/auth/AuthCredentialPresentation.ts
+++ b/node/zkgroup/auth/AuthCredentialPresentation.ts
@@ -8,11 +8,8 @@ import NativeImpl from '../../NativeImpl';
 import UuidCiphertext from '../groups/UuidCiphertext';
 
 export default class AuthCredentialPresentation extends ByteArray {
-  static SIZE = 493;
-
   constructor(contents: Buffer) {
-    super(contents, AuthCredentialPresentation.SIZE, true);
-    NativeImpl.AuthCredentialPresentation_CheckValidContents(contents);
+    super(contents, NativeImpl.AuthCredentialPresentation_CheckValidContents);
   }
 
   getUuidCiphertext(): UuidCiphertext {

--- a/node/zkgroup/auth/AuthCredentialResponse.ts
+++ b/node/zkgroup/auth/AuthCredentialResponse.ts
@@ -6,10 +6,7 @@
 import ByteArray from '../internal/ByteArray';
 import NativeImpl from '../../NativeImpl';
 export default class AuthCredentialResponse extends ByteArray {
-  static SIZE = 361;
-
   constructor(contents: Buffer) {
-    super(contents, AuthCredentialResponse.SIZE, true);
-    NativeImpl.AuthCredentialResponse_CheckValidContents(contents);
+    super(contents, NativeImpl.AuthCredentialResponse_CheckValidContents);
   }
 }

--- a/node/zkgroup/groups/GroupIdentifier.ts
+++ b/node/zkgroup/groups/GroupIdentifier.ts
@@ -9,6 +9,6 @@ export default class GroupIdentifier extends ByteArray {
   static SIZE = 32;
 
   constructor(contents: Buffer) {
-    super(contents, GroupIdentifier.SIZE, true);
+    super(contents, GroupIdentifier.checkLength(GroupIdentifier.SIZE));
   }
 }

--- a/node/zkgroup/groups/GroupMasterKey.ts
+++ b/node/zkgroup/groups/GroupMasterKey.ts
@@ -9,6 +9,6 @@ export default class GroupMasterKey extends ByteArray {
   static SIZE = 32;
 
   constructor(contents: Buffer) {
-    super(contents, GroupMasterKey.SIZE, true);
+    super(contents, GroupMasterKey.checkLength(GroupMasterKey.SIZE));
   }
 }

--- a/node/zkgroup/groups/GroupPublicParams.ts
+++ b/node/zkgroup/groups/GroupPublicParams.ts
@@ -8,11 +8,8 @@ import NativeImpl from '../../NativeImpl';
 import GroupIdentifier from './GroupIdentifier';
 
 export default class GroupPublicParams extends ByteArray {
-  static SIZE = 97;
-
   constructor(contents: Buffer) {
-    super(contents, GroupPublicParams.SIZE, true);
-    NativeImpl.GroupPublicParams_CheckValidContents(contents);
+    super(contents, NativeImpl.GroupPublicParams_CheckValidContents);
   }
 
   getGroupIdentifier(): GroupIdentifier {

--- a/node/zkgroup/groups/GroupSecretParams.ts
+++ b/node/zkgroup/groups/GroupSecretParams.ts
@@ -12,8 +12,6 @@ import GroupMasterKey from './GroupMasterKey';
 import GroupPublicParams from './GroupPublicParams';
 
 export default class GroupSecretParams extends ByteArray {
-  static SIZE = 289;
-
   static generate(): GroupSecretParams {
     const random = randomBytes(RANDOM_LENGTH);
 
@@ -37,8 +35,7 @@ export default class GroupSecretParams extends ByteArray {
   }
 
   constructor(contents: Buffer) {
-    super(contents, GroupSecretParams.SIZE, true);
-    NativeImpl.GroupSecretParams_CheckValidContents(this.contents);
+    super(contents, NativeImpl.GroupSecretParams_CheckValidContents);
   }
 
   getMasterKey(): GroupMasterKey {

--- a/node/zkgroup/groups/ProfileKeyCiphertext.ts
+++ b/node/zkgroup/groups/ProfileKeyCiphertext.ts
@@ -7,10 +7,7 @@ import ByteArray from '../internal/ByteArray';
 import NativeImpl from '../../NativeImpl';
 
 export default class ProfileKeyCiphertext extends ByteArray {
-  static SIZE = 65;
-
   constructor(contents: Buffer) {
-    super(contents, ProfileKeyCiphertext.SIZE, true);
-    NativeImpl.ProfileKeyCiphertext_CheckValidContents(contents);
+    super(contents, NativeImpl.ProfileKeyCiphertext_CheckValidContents);
   }
 }

--- a/node/zkgroup/groups/UuidCiphertext.ts
+++ b/node/zkgroup/groups/UuidCiphertext.ts
@@ -7,10 +7,7 @@ import ByteArray from '../internal/ByteArray';
 import NativeImpl from '../../NativeImpl';
 
 export default class UuidCiphertext extends ByteArray {
-  static SIZE = 65;
-
   constructor(contents: Buffer) {
-    super(contents, UuidCiphertext.SIZE, true);
-    NativeImpl.UuidCiphertext_CheckValidContents(contents);
+    super(contents, NativeImpl.UuidCiphertext_CheckValidContents);
   }
 }

--- a/node/zkgroup/internal/ByteArray.ts
+++ b/node/zkgroup/internal/ByteArray.ts
@@ -8,19 +8,23 @@ import { SignalClientErrorBase } from '../../Errors';
 export default class ByteArray {
   contents: Buffer;
 
-  constructor(
-    contents: Buffer,
-    expectedLength: number,
-    _unrecoverable: boolean
-  ) {
-    if (contents.length !== expectedLength) {
-      throw new SignalClientErrorBase(
-        `Length of array supplied was ${contents.length} expected ${expectedLength}`,
-        undefined,
-        this.constructor.name
-      );
-    }
+  constructor(contents: Buffer, checkValid: (contents: Buffer) => void) {
+    checkValid(contents);
     this.contents = Buffer.from(contents);
+  }
+
+  protected static checkLength(
+    expectedLength: number
+  ): (contents: Buffer) => void {
+    return contents => {
+      if (contents.length !== expectedLength) {
+        throw new SignalClientErrorBase(
+          `Length of array supplied was ${contents.length} expected ${expectedLength}`,
+          undefined,
+          this.name
+        );
+      }
+    };
   }
 
   public getContents(): Buffer {

--- a/node/zkgroup/profiles/ProfileKey.ts
+++ b/node/zkgroup/profiles/ProfileKey.ts
@@ -13,7 +13,7 @@ export default class ProfileKey extends ByteArray {
   static SIZE = 32;
 
   constructor(contents: Buffer) {
-    super(contents, ProfileKey.SIZE, true);
+    super(contents, ProfileKey.checkLength(ProfileKey.SIZE));
   }
 
   getCommitment(uuid: UUIDType): ProfileKeyCommitment {

--- a/node/zkgroup/profiles/ProfileKeyCommitment.ts
+++ b/node/zkgroup/profiles/ProfileKeyCommitment.ts
@@ -7,10 +7,7 @@ import ByteArray from '../internal/ByteArray';
 import NativeImpl from '../../NativeImpl';
 
 export default class ProfileKeyCommitment extends ByteArray {
-  static SIZE = 97;
-
   constructor(contents: Buffer) {
-    super(contents, ProfileKeyCommitment.SIZE, true);
-    NativeImpl.ProfileKeyCommitment_CheckValidContents(contents);
+    super(contents, NativeImpl.ProfileKeyCommitment_CheckValidContents);
   }
 }

--- a/node/zkgroup/profiles/ProfileKeyCredential.ts
+++ b/node/zkgroup/profiles/ProfileKeyCredential.ts
@@ -7,10 +7,7 @@ import ByteArray from '../internal/ByteArray';
 import NativeImpl from '../../NativeImpl';
 
 export default class ProfileKeyCredential extends ByteArray {
-  static SIZE = 145;
-
   constructor(contents: Buffer) {
-    super(contents, ProfileKeyCredential.SIZE, true);
-    NativeImpl.ProfileKeyCredential_CheckValidContents(contents);
+    super(contents, NativeImpl.ProfileKeyCredential_CheckValidContents);
   }
 }

--- a/node/zkgroup/profiles/ProfileKeyCredentialPresentation.ts
+++ b/node/zkgroup/profiles/ProfileKeyCredentialPresentation.ts
@@ -9,11 +9,11 @@ import UuidCiphertext from '../groups/UuidCiphertext';
 import ProfileKeyCiphertext from '../groups/ProfileKeyCiphertext';
 
 export default class ProfileKeyCredentialPresentation extends ByteArray {
-  static SIZE = 713;
-
   constructor(contents: Buffer) {
-    super(contents, ProfileKeyCredentialPresentation.SIZE, true);
-    NativeImpl.ProfileKeyCredentialPresentation_CheckValidContents(contents);
+    super(
+      contents,
+      NativeImpl.ProfileKeyCredentialPresentation_CheckValidContents
+    );
   }
 
   getUuidCiphertext(): UuidCiphertext {

--- a/node/zkgroup/profiles/ProfileKeyCredentialRequest.ts
+++ b/node/zkgroup/profiles/ProfileKeyCredentialRequest.ts
@@ -7,10 +7,7 @@ import ByteArray from '../internal/ByteArray';
 import NativeImpl from '../../NativeImpl';
 
 export default class ProfileKeyCredentialRequest extends ByteArray {
-  static SIZE = 329;
-
   constructor(contents: Buffer) {
-    super(contents, ProfileKeyCredentialRequest.SIZE, true);
-    NativeImpl.ProfileKeyCredentialRequest_CheckValidContents(contents);
+    super(contents, NativeImpl.ProfileKeyCredentialRequest_CheckValidContents);
   }
 }

--- a/node/zkgroup/profiles/ProfileKeyCredentialRequestContext.ts
+++ b/node/zkgroup/profiles/ProfileKeyCredentialRequestContext.ts
@@ -8,11 +8,11 @@ import NativeImpl from '../../NativeImpl';
 import ProfileKeyCredentialRequest from './ProfileKeyCredentialRequest';
 
 export default class ProfileKeyCredentialRequestContext extends ByteArray {
-  static SIZE = 473;
-
   constructor(contents: Buffer) {
-    super(contents, ProfileKeyCredentialRequestContext.SIZE, true);
-    NativeImpl.ProfileKeyCredentialRequestContext_CheckValidContents(contents);
+    super(
+      contents,
+      NativeImpl.ProfileKeyCredentialRequestContext_CheckValidContents
+    );
   }
 
   getRequest(): ProfileKeyCredentialRequest {

--- a/node/zkgroup/profiles/ProfileKeyCredentialResponse.ts
+++ b/node/zkgroup/profiles/ProfileKeyCredentialResponse.ts
@@ -7,10 +7,7 @@ import ByteArray from '../internal/ByteArray';
 import NativeImpl from '../../NativeImpl';
 
 export default class ProfileKeyCredentialResponse extends ByteArray {
-  static SIZE = 457;
-
   constructor(contents: Buffer) {
-    super(contents, ProfileKeyCredentialResponse.SIZE, true);
-    NativeImpl.ProfileKeyCredentialResponse_CheckValidContents(contents);
+    super(contents, NativeImpl.ProfileKeyCredentialResponse_CheckValidContents);
   }
 }

--- a/node/zkgroup/profiles/ProfileKeyVersion.ts
+++ b/node/zkgroup/profiles/ProfileKeyVersion.ts
@@ -11,8 +11,7 @@ export default class ProfileKeyVersion extends ByteArray {
   constructor(contents: Buffer | string) {
     super(
       typeof contents === 'string' ? Buffer.from(contents) : contents,
-      ProfileKeyVersion.SIZE,
-      false
+      ProfileKeyVersion.checkLength(ProfileKeyVersion.SIZE)
     );
   }
 

--- a/node/zkgroup/receipts/ReceiptCredential.ts
+++ b/node/zkgroup/receipts/ReceiptCredential.ts
@@ -7,11 +7,8 @@ import ByteArray from '../internal/ByteArray';
 import NativeImpl from '../../NativeImpl';
 
 export default class ReceiptCredential extends ByteArray {
-  static SIZE = 129;
-
   constructor(contents: Buffer) {
-    super(contents, ReceiptCredential.SIZE, true);
-    NativeImpl.ReceiptCredential_CheckValidContents(contents);
+    super(contents, NativeImpl.ReceiptCredential_CheckValidContents);
   }
 
   getReceiptExpirationTime(): bigint {

--- a/node/zkgroup/receipts/ReceiptCredentialPresentation.ts
+++ b/node/zkgroup/receipts/ReceiptCredentialPresentation.ts
@@ -11,8 +11,10 @@ export default class ReceiptCredentialPresentation extends ByteArray {
   static SIZE = 329;
 
   constructor(contents: Buffer) {
-    super(contents, ReceiptCredentialPresentation.SIZE, true);
-    NativeImpl.ReceiptCredentialPresentation_CheckValidContents(contents);
+    super(
+      contents,
+      NativeImpl.ReceiptCredentialPresentation_CheckValidContents
+    );
   }
 
   getReceiptExpirationTime(): bigint {

--- a/node/zkgroup/receipts/ReceiptCredentialRequest.ts
+++ b/node/zkgroup/receipts/ReceiptCredentialRequest.ts
@@ -7,10 +7,7 @@ import ByteArray from '../internal/ByteArray';
 import NativeImpl from '../../NativeImpl';
 
 export default class ReceiptCredentialRequest extends ByteArray {
-  static SIZE = 97;
-
   constructor(contents: Buffer) {
-    super(contents, ReceiptCredentialRequest.SIZE, true);
-    NativeImpl.ReceiptCredentialRequest_CheckValidContents(contents);
+    super(contents, NativeImpl.ReceiptCredentialRequest_CheckValidContents);
   }
 }

--- a/node/zkgroup/receipts/ReceiptCredentialRequestContext.ts
+++ b/node/zkgroup/receipts/ReceiptCredentialRequestContext.ts
@@ -11,8 +11,10 @@ export default class ReceiptCredentialRequestContext extends ByteArray {
   static SIZE = 177;
 
   constructor(contents: Buffer) {
-    super(contents, ReceiptCredentialRequestContext.SIZE, true);
-    NativeImpl.ReceiptCredentialRequestContext_CheckValidContents(contents);
+    super(
+      contents,
+      NativeImpl.ReceiptCredentialRequestContext_CheckValidContents
+    );
   }
 
   getRequest(): ReceiptCredentialRequest {

--- a/node/zkgroup/receipts/ReceiptCredentialResponse.ts
+++ b/node/zkgroup/receipts/ReceiptCredentialResponse.ts
@@ -7,10 +7,7 @@ import ByteArray from '../internal/ByteArray';
 import NativeImpl from '../../NativeImpl';
 
 export default class ReceiptCredentialResponse extends ByteArray {
-  static SIZE = 409;
-
   constructor(contents: Buffer) {
-    super(contents, ReceiptCredentialResponse.SIZE, true);
-    NativeImpl.ReceiptCredentialResponse_CheckValidContents(contents);
+    super(contents, NativeImpl.ReceiptCredentialResponse_CheckValidContents);
   }
 }

--- a/node/zkgroup/receipts/ReceiptSerial.ts
+++ b/node/zkgroup/receipts/ReceiptSerial.ts
@@ -9,6 +9,6 @@ export default class ReceiptSerial extends ByteArray {
   static SIZE = 16;
 
   constructor(contents: Buffer) {
-    super(contents, ReceiptSerial.SIZE, true);
+    super(contents, ReceiptSerial.checkLength(ReceiptSerial.SIZE));
   }
 }


### PR DESCRIPTION
Don't validate sizes explicitly; that's already handled by the *_CheckValidContents functions exposed in the bridge layer. Same idea as #408 and #412.