### PR TITLE
zkgroup: Move blob padding/unpadding into Rust

### DIFF
--- a/java/java/src/main/java/org/signal/client/internal/Native.java
+++ b/java/java/src/main/java/org/signal/client/internal/Native.java
@@ -160,11 +160,11 @@ public final class Native {
   public static native byte[] GroupPublicParams_GetGroupIdentifier(byte[] groupPublicParams);
 
   public static native void GroupSecretParams_CheckValidContents(byte[] obj);
-  public static native byte[] GroupSecretParams_DecryptBlob(byte[] params, byte[] ciphertext);
+  public static native byte[] GroupSecretParams_DecryptBlobWithPadding(byte[] params, byte[] ciphertext);
   public static native byte[] GroupSecretParams_DecryptProfileKey(byte[] params, byte[] profileKey, UUID uuid);
   public static native UUID GroupSecretParams_DecryptUuid(byte[] params, byte[] uuid);
   public static native byte[] GroupSecretParams_DeriveFromMasterKey(byte[] masterKey);
-  public static native byte[] GroupSecretParams_EncryptBlobDeterministic(byte[] params, byte[] randomness, byte[] plaintext);
+  public static native byte[] GroupSecretParams_EncryptBlobWithPaddingDeterministic(byte[] params, byte[] randomness, byte[] plaintext, int paddingLen);
   public static native byte[] GroupSecretParams_EncryptProfileKey(byte[] params, byte[] profileKey, UUID uuid);
   public static native byte[] GroupSecretParams_EncryptUuid(byte[] params, UUID uuid);
   public static native byte[] GroupSecretParams_GenerateDeterministic(byte[] randomness);

--- a/java/java/src/main/java/org/signal/zkgroup/groups/ClientZkGroupCipher.java
+++ b/java/java/src/main/java/org/signal/zkgroup/groups/ClientZkGroupCipher.java
@@ -62,35 +62,13 @@ public class ClientZkGroupCipher {
   }
 
   public byte[] encryptBlob(SecureRandom secureRandom, byte[] plaintext) throws VerificationFailedException {
-
-    byte[] paddedPlaintext = new byte[plaintext.length + 4];
-    System.arraycopy(plaintext, 0, paddedPlaintext, 4, plaintext.length);
-
     byte[] random      = new byte[RANDOM_LENGTH];
-
     secureRandom.nextBytes(random);
-
-    return Native.GroupSecretParams_EncryptBlobDeterministic(groupSecretParams.getInternalContentsForJNI(), random, paddedPlaintext);
+    return Native.GroupSecretParams_EncryptBlobWithPaddingDeterministic(groupSecretParams.getInternalContentsForJNI(), random, plaintext, 0);
   }
 
   public byte[] decryptBlob(byte[] blobCiphertext) throws VerificationFailedException {
-    byte[] newContents = Native.GroupSecretParams_DecryptBlob(groupSecretParams.getInternalContentsForJNI(), blobCiphertext);
-
-    if (newContents.length < 4) {
-        throw new VerificationFailedException();
-    }
-
-    byte[] padLenBytes = new byte[4];
-    System.arraycopy(newContents, 0, padLenBytes, 0, 4);
-    int padLen = ByteBuffer.wrap(newContents).getInt();
-    if (newContents.length < (4 + padLen))  {
-        throw new VerificationFailedException();
-    }
-
-    byte[] depaddedContents = new byte[newContents.length - (4 + padLen)];
-    System.arraycopy(newContents, 4, depaddedContents, 0, newContents.length - (4 + padLen));
-
-    return depaddedContents;
+    return Native.GroupSecretParams_DecryptBlobWithPadding(groupSecretParams.getInternalContentsForJNI(), blobCiphertext);
   }
 
 }

--- a/node/Native.d.ts
+++ b/node/Native.d.ts
@@ -74,11 +74,11 @@ export function GroupMasterKey_CheckValidContents(Obj: Serialized<GroupMasterKey
 export function GroupPublicParams_CheckValidContents(Obj: Serialized<GroupPublicParams>): void;
 export function GroupPublicParams_GetGroupIdentifier(groupPublicParams: Serialized<GroupPublicParams>): Buffer;
 export function GroupSecretParams_CheckValidContents(Obj: Serialized<GroupSecretParams>): void;
-export function GroupSecretParams_DecryptBlob(params: Serialized<GroupSecretParams>, ciphertext: Buffer): Buffer;
+export function GroupSecretParams_DecryptBlobWithPadding(params: Serialized<GroupSecretParams>, ciphertext: Buffer): Buffer;
 export function GroupSecretParams_DecryptProfileKey(params: Serialized<GroupSecretParams>, profileKey: Serialized<ProfileKeyCiphertext>, uuid: Uuid): Serialized<ProfileKey>;
 export function GroupSecretParams_DecryptUuid(params: Serialized<GroupSecretParams>, uuid: Serialized<UuidCiphertext>): Uuid;
 export function GroupSecretParams_DeriveFromMasterKey(masterKey: Serialized<GroupMasterKey>): Serialized<GroupSecretParams>;
-export function GroupSecretParams_EncryptBlobDeterministic(params: Serialized<GroupSecretParams>, randomness: Buffer, plaintext: Buffer): Buffer;
+export function GroupSecretParams_EncryptBlobWithPaddingDeterministic(params: Serialized<GroupSecretParams>, randomness: Buffer, plaintext: Buffer, paddingLen: number): Buffer;
 export function GroupSecretParams_EncryptProfileKey(params: Serialized<GroupSecretParams>, profileKey: Serialized<ProfileKey>, uuid: Uuid): Serialized<ProfileKeyCiphertext>;
 export function GroupSecretParams_EncryptUuid(params: Serialized<GroupSecretParams>, uuid: Uuid): Serialized<UuidCiphertext>;
 export function GroupSecretParams_GenerateDeterministic(randomness: Buffer): Serialized<GroupSecretParams>;

--- a/node/zkgroup/groups/ClientZkGroupCipher.ts
+++ b/node/zkgroup/groups/ClientZkGroupCipher.ts
@@ -13,7 +13,6 @@ import ProfileKeyCiphertext from './ProfileKeyCiphertext';
 import ProfileKey from '../profiles/ProfileKey';
 import GroupSecretParams from './GroupSecretParams';
 import { UUIDType, fromUUID, toUUID } from '../internal/UUIDUtil';
-import { SignalClientErrorBase } from '../../Errors';
 
 export default class ClientZkGroupCipher {
   groupSecretParams: GroupSecretParams;
@@ -73,41 +72,18 @@ export default class ClientZkGroupCipher {
   }
 
   encryptBlobWithRandom(random: Buffer, plaintext: Buffer): Buffer {
-    const paddedPlaintext = Buffer.alloc(plaintext.length + 4);
-    plaintext.copy(paddedPlaintext, 4);
-    return NativeImpl.GroupSecretParams_EncryptBlobDeterministic(
+    return NativeImpl.GroupSecretParams_EncryptBlobWithPaddingDeterministic(
       this.groupSecretParams.getContents(),
       random,
-      paddedPlaintext
+      plaintext,
+      0
     );
   }
 
   decryptBlob(blobCiphertext: Buffer): Buffer {
-    const newContents = NativeImpl.GroupSecretParams_DecryptBlob(
+    return NativeImpl.GroupSecretParams_DecryptBlobWithPadding(
       this.groupSecretParams.getContents(),
       blobCiphertext
     );
-
-    if (newContents.length < 4) {
-      throw new SignalClientErrorBase(
-        'BAD LENGTH',
-        'VerificationFailed',
-        'decryptBlob'
-      );
-    }
-
-    const padLen = newContents.readInt32BE(0);
-    if (newContents.length < 4 + padLen) {
-      throw new SignalClientErrorBase(
-        'BAD LENGTH',
-        'VerificationFailed',
-        'decryptBlob'
-      );
-    }
-
-    const depaddedContents = Buffer.alloc(newContents.length - (4 + padLen));
-    newContents.copy(depaddedContents, 0, 4, newContents.length - padLen);
-
-    return depaddedContents;
   }
 }

--- a/rust/bridge/jni/bin/gen_java_decl.py
+++ b/rust/bridge/jni/bin/gen_java_decl.py
@@ -39,7 +39,7 @@ ignore_this_warning = re.compile(
     "("
     r"WARN: Can't find .*\. This usually means that this type was incompatible or not found\.|"
     r"WARN: Missing `\[defines\]` entry for `feature = \".*\"` in cbindgen config\.|"
-    r"WARN: Skip libsignal-bridge::_ - \(not `pub`\)\.|"
+    r"WARN: Skip libsignal-bridge::.+ - \(not `pub`\)\.|"
     r"WARN: Couldn't find path for Array\(Path\(GenericPath \{ .+ \}\), Name\(\"LEN\"\)\), skipping associated constants"
     ")")
 

--- a/rust/bridge/shared/src/zkgroup.rs
+++ b/rust/bridge/shared/src/zkgroup.rs
@@ -152,20 +152,21 @@ fn GroupSecretParams_DecryptProfileKey(
 }
 
 #[bridge_fn_buffer]
-fn GroupSecretParams_EncryptBlobDeterministic(
+fn GroupSecretParams_EncryptBlobWithPaddingDeterministic(
     params: Serialized<GroupSecretParams>,
     randomness: &[u8; RANDOMNESS_LEN],
     plaintext: &[u8],
+    padding_len: u32,
 ) -> Result<Vec<u8>> {
-    params.encrypt_blob(*randomness, plaintext)
+    params.encrypt_blob_with_padding(*randomness, plaintext, padding_len)
 }
 
 #[bridge_fn_buffer]
-fn GroupSecretParams_DecryptBlob(
+fn GroupSecretParams_DecryptBlobWithPadding(
     params: Serialized<GroupSecretParams>,
     ciphertext: &[u8],
 ) -> Result<Vec<u8>> {
-    params.decrypt_blob(ciphertext)
+    params.decrypt_blob_with_padding(ciphertext)
 }
 
 #[bridge_fn]

--- a/swift/Sources/SignalFfi/signal_ffi.h
+++ b/swift/Sources/SignalFfi/signal_ffi.h
@@ -1201,18 +1201,19 @@ SignalFfiError *signal_group_secret_params_decrypt_profile_key(unsigned char (*o
                                                                const unsigned char (*profile_key)[SignalPROFILE_KEY_CIPHERTEXT_LEN],
                                                                const uint8_t (*uuid)[16]);
 
-SignalFfiError *signal_group_secret_params_encrypt_blob_deterministic(const unsigned char **out,
-                                                                      size_t *out_len,
-                                                                      const unsigned char (*params)[SignalGROUP_SECRET_PARAMS_LEN],
-                                                                      const uint8_t (*randomness)[SignalRANDOMNESS_LEN],
-                                                                      const unsigned char *plaintext,
-                                                                      size_t plaintext_len);
+SignalFfiError *signal_group_secret_params_encrypt_blob_with_padding_deterministic(const unsigned char **out,
+                                                                                   size_t *out_len,
+                                                                                   const unsigned char (*params)[SignalGROUP_SECRET_PARAMS_LEN],
+                                                                                   const uint8_t (*randomness)[SignalRANDOMNESS_LEN],
+                                                                                   const unsigned char *plaintext,
+                                                                                   size_t plaintext_len,
+                                                                                   uint32_t padding_len);
 
-SignalFfiError *signal_group_secret_params_decrypt_blob(const unsigned char **out,
-                                                        size_t *out_len,
-                                                        const unsigned char (*params)[SignalGROUP_SECRET_PARAMS_LEN],
-                                                        const unsigned char *ciphertext,
-                                                        size_t ciphertext_len);
+SignalFfiError *signal_group_secret_params_decrypt_blob_with_padding(const unsigned char **out,
+                                                                     size_t *out_len,
+                                                                     const unsigned char (*params)[SignalGROUP_SECRET_PARAMS_LEN],
+                                                                     const unsigned char *ciphertext,
+                                                                     size_t ciphertext_len);
 
 SignalFfiError *signal_server_secret_params_generate_deterministic(unsigned char (*out)[SignalSERVER_SECRET_PARAMS_LEN],
                                                                    const uint8_t (*randomness)[SignalRANDOMNESS_LEN]);


### PR DESCRIPTION
Previously this was defined in the app layers, because zkgroup's original codegen didn't support custom exception types. However, we can now move it to a common implementation in Rust.

~~This could live in libsignal-bridge, or in the zkgroup crate proper. I chose libsignal-bridge because padding isn't an inherent requirement for the zkgroup encryption format, but it could go either way.~~