### PR TITLE
bridge: add jni_class_name and jni_args helper macros

### DIFF
--- a/rust/bridge/jni/src/logging.rs
+++ b/rust/bridge/jni/src/logging.rs
@@ -6,7 +6,7 @@
 use jni::objects::{GlobalRef, JClass, JObject, JValue};
 use jni::sys::jint;
 use jni::{JNIEnv, JavaVM};
-use libsignal_bridge::{describe_panic, jni_signature};
+use libsignal_bridge::{describe_panic, jni_args};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::process::abort;
 
@@ -81,17 +81,12 @@ impl JniLogger {
             record.line().unwrap_or(0),
             record.args(),
         );
-        let args: [JValue; 3] = [
-            level.into(),
-            env.new_string("libsignal-client")?.into(),
-            env.new_string(message)?.into(),
-        ];
-        let result = env.call_static_method(
-            &self.logger_class,
-            "log",
-            jni_signature!((int, java.lang.String, java.lang.String) -> void),
-            &args,
-        );
+        let args = jni_args!((
+            level.into() => int,
+            env.new_string("libsignal-client")? => java.lang.String,
+            env.new_string(message)? => java.lang.String,
+        ) -> void);
+        let result = env.call_static_method(&self.logger_class, "log", args.sig, &args.args);
 
         let throwable = env.exception_occurred()?;
         if **throwable == *JObject::null() {

--- a/rust/bridge/shared/src/jni/args.rs
+++ b/rust/bridge/shared/src/jni/args.rs
@@ -1,0 +1,260 @@
+//
+// Copyright 2021 Signal Messenger, LLC.
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+use std::marker::PhantomData;
+
+use jni_crate::objects::JValue;
+
+/// Takes a Java-esque class name of the form `org.signal.Outer::Inner` and turns it into a
+/// JNI-style name `org/signal/Outer$Inner`.
+#[macro_export]
+macro_rules! jni_class_name {
+    ( $arg_base:tt $(. $arg_rest:ident)+ $(:: $nested:ident)* ) => {
+        concat!(
+            stringify!($arg_base),
+            $("/", stringify!($arg_rest),)+
+            $("$", stringify!($nested),)*
+        )
+    }
+}
+
+#[test]
+fn test_jni_class_name() {
+    assert_eq!(jni_class_name!(foo.bar), "foo/bar");
+    assert_eq!(jni_class_name!(foo.bar.baz), "foo/bar/baz");
+    assert_eq!(jni_class_name!(foo.bar.baz::garply), "foo/bar/baz$garply");
+    assert_eq!(
+        jni_class_name!(foo.bar.baz::garply::qux),
+        "foo/bar/baz$garply$qux"
+    );
+}
+
+/// Converts a function or type signature to a JNI signature string.
+///
+/// This macro uses Rust function syntax `(Foo, Bar) -> Baz`, and uses Rust syntax for Java arrays
+/// `[Foo]`, but otherwise uses Java names for types: `boolean`, `byte`, `void`. Like
+/// [`jni_class_name`], inner classes are indicated with `::` rather than `.`.
+#[macro_export]
+macro_rules! jni_signature {
+    ( boolean ) => ("Z");
+    ( bool ) => (compile_error!("use Java type 'boolean'"));
+    ( byte ) => ("B");
+    ( char ) => ("C");
+    ( short ) => ("S");
+    ( int ) => ("I");
+    ( long ) => ("J");
+    ( float ) => ("F");
+    ( double ) => ("D");
+    ( void ) => ("V");
+
+    // Escape hatch: provide a literal string.
+    ( $x:literal ) => ($x);
+
+    // Arrays
+    ( [$($contents:tt)+] ) => {
+        concat!("[", $crate::jni_signature!($($contents)+))
+    };
+
+    // Classes
+    ( $arg_base:tt $(. $arg_rest:ident)+ $(:: $nested:ident)* ) => {
+        concat!(
+            "L",
+            $crate::jni_class_name!($arg_base $(. $arg_rest)* $(:: $nested)*),
+            ";"
+        )
+    };
+
+    // Functions
+    (
+        (
+            $( $arg_base:tt $(. $arg_rest:ident)* $(:: $arg_nested:ident)* ),* $(,)?
+        ) -> $ret_base:tt $(. $ret_rest:ident)* $(:: $ret_nested:ident)*
+    ) => {
+        concat!(
+            "(",
+            $( $crate::jni_signature!($arg_base $(. $arg_rest)* $(:: $arg_nested)*), )*
+            ")",
+            $crate::jni_signature!($ret_base $(. $ret_rest)* $(:: $ret_nested)*)
+        )
+    };
+}
+
+#[test]
+fn test_jni_signature() {
+    // Literals
+    #[allow(clippy::eq_op)]
+    {
+        assert_eq!(jni_signature!("Lfoo/bar;"), "Lfoo/bar;");
+    }
+
+    // Classes
+    assert_eq!(jni_signature!(foo.bar), "Lfoo/bar;");
+    assert_eq!(jni_signature!(foo.bar.baz), "Lfoo/bar/baz;");
+    assert_eq!(jni_signature!(foo.bar.baz::garply), "Lfoo/bar/baz$garply;");
+    assert_eq!(
+        jni_signature!(foo.bar.baz::garply::qux),
+        "Lfoo/bar/baz$garply$qux;"
+    );
+
+    // Arrays
+    assert_eq!(jni_signature!([byte]), "[B");
+    assert_eq!(jni_signature!([[byte]]), "[[B");
+    assert_eq!(jni_signature!([foo.bar]), "[Lfoo/bar;");
+    assert_eq!(
+        jni_signature!([foo.bar.baz::garply::qux]),
+        "[Lfoo/bar/baz$garply$qux;"
+    );
+
+    // Functions
+    assert_eq!(jni_signature!(() -> void), "()V");
+    assert_eq!(jni_signature!((byte, int) -> float), "(BI)F");
+    assert_eq!(
+        jni_signature!(([byte], foo.bar, foo.bar.baz::garply::qux) -> [byte]),
+        "([BLfoo/bar;Lfoo/bar/baz$garply$qux;)[B"
+    );
+    assert_eq!(jni_signature!(() -> foo.bar), "()Lfoo/bar;");
+    assert_eq!(
+        jni_signature!(() -> foo.bar.baz::garply::qux),
+        "()Lfoo/bar/baz$garply$qux;"
+    );
+}
+
+#[macro_export]
+macro_rules! jni_arg {
+    ( $arg:expr => boolean ) => {
+        <JValue as From<bool>>::from($arg)
+    };
+    // jni_signature will reject this, but having it do something reasonable avoids multiple errors.
+    ( $arg:expr => bool ) => {
+        <JValue as From<bool>>::from($arg)
+    };
+    ( $arg:expr => byte ) => {
+        JValue::Byte($arg)
+    };
+    ( $arg:expr => char ) => {
+        JValue::Char($arg)
+    };
+    ( $arg:expr => short ) => {
+        JValue::Short($arg)
+    };
+    ( $arg:expr => int ) => {
+        JValue::Int($arg)
+    };
+    ( $arg:expr => long ) => {
+        JValue::Long($arg)
+    };
+    ( $arg:expr => float ) => {
+        JValue::Float($arg)
+    };
+    ( $arg:expr => double ) => {
+        JValue::Double($arg)
+    };
+    // Assume anything else is an object. This includes arrays and classes.
+    ( $arg:expr => $($_:tt)+) => {
+        JValue::Object($arg.into())
+    };
+}
+
+#[allow(clippy::float_cmp)]
+#[test]
+fn test_jni_arg() {
+    assert!(matches!(jni_arg!(true => boolean), JValue::Bool(1)));
+    assert!(matches!(jni_arg!(0x8000 => char), JValue::Char(0x8000)));
+    assert!(matches!(jni_arg!(-80 => byte), JValue::Byte(-80)));
+    assert!(matches!(jni_arg!(-80 => short), JValue::Short(-80)));
+    assert!(matches!(jni_arg!(-80 => int), JValue::Int(-80)));
+    assert!(matches!(jni_arg!(-80 => long), JValue::Long(-80)));
+    assert!(matches!(jni_arg!(-8.5 => float), JValue::Float(val) if val == -8.5));
+    assert!(matches!(jni_arg!(-8.5 => double), JValue::Double(val) if val == -8.5));
+    assert!(matches!(
+        jni_arg!(jni_crate::objects::JObject::null() => java.lang.Object),
+        JValue::Object(val) if val.is_null()
+    ));
+}
+
+#[macro_export]
+macro_rules! jni_return_type {
+    // Unfortunately there's not a conversion directly from JValue to bool, only jboolean.
+    (boolean) => {
+        u8
+    };
+    // jni_signature will reject this, but having it do something reasonable avoids multiple errors.
+    (bool) => {
+        u8
+    };
+    (byte) => {
+        i8,
+    };
+    (char) => {
+        u16,
+    };
+    (short) => {
+        i16
+    };
+    (int) => {
+        i32
+    };
+    (long) => {
+        i64
+    };
+    (float) => {
+        f32
+    };
+    (double) => {
+        f64
+    };
+    (void) => {
+        ()
+    };
+    // Assume anything else is an object. This includes arrays and classes.
+    ($($_:tt)+) => {
+        JObject
+    };
+}
+
+/// Represents a return type, used by [`JniArgs`].
+///
+/// This is an implementation detail of [`jni_args`] and [`JniArgs`]. Using a function type makes
+/// `JniArgs` covariant, which allows the compiler to be less strict about the lifetime marker.
+pub type PhantomReturnType<R> = PhantomData<fn() -> R>;
+
+/// A JNI argument list, type-checked with its signature.
+#[derive(Debug, Clone, Copy)]
+pub struct JniArgs<'a, R, const LEN: usize> {
+    pub sig: &'static str,
+    pub args: [JValue<'a>; LEN],
+    pub _return: PhantomReturnType<R>,
+}
+
+/// Produces a JniArgs struct from the given arguments and return type.
+///
+/// # Example
+///
+/// ```
+/// # use libsignal_bridge::jni_args;
+/// # use jni_crate::objects::JValue;
+/// # let name = jni_crate::objects::JObject::null();
+/// let args = jni_args!((name => java.lang.String, 0x3FFF => short) -> void);
+/// assert_eq!(args.sig, "(Ljava/lang/String;S)V");
+/// assert_eq!(args.args.len(), 2);
+/// ```
+#[macro_export]
+macro_rules! jni_args {
+    (
+        (
+            $( $arg:expr => $arg_base:tt $(. $arg_rest:ident)* $(:: $arg_nested:ident)* ),* $(,)?
+        ) -> $ret_base:tt $(. $ret_rest:ident)* $(:: $ret_nested:ident)*
+    ) => {
+        $crate::jni::JniArgs {
+            sig: $crate::jni_signature!(
+                (
+                    $( $arg_base $(. $arg_rest)* $(:: $arg_nested)* ),*
+                ) -> $ret_base $(. $ret_rest)* $(:: $ret_nested)*
+            ),
+            args: [$($crate::jni_arg!($arg => $arg_base)),*],
+            _return: $crate::jni::PhantomReturnType::<$crate::jni_return_type!($ret_base)> {},
+        }
+    }
+}

--- a/rust/bridge/shared/src/jni/error.rs
+++ b/rust/bridge/shared/src/jni/error.rs
@@ -146,8 +146,7 @@ impl ThrownException {
             env,
             class_type,
             "getCanonicalName",
-            jni_signature!(() -> java.lang.String),
-            &[],
+            jni_args!(() -> java.lang.String),
         )?;
 
         Ok(env.get_string(JString::from(class_name))?.into())
@@ -158,8 +157,7 @@ impl ThrownException {
             env,
             self.exception_ref.as_obj(),
             "getMessage",
-            jni_signature!(() -> java.lang.String),
-            &[],
+            jni_args!(() -> java.lang.String),
         )?;
         Ok(env.get_string(JString::from(message))?.into())
     }

--- a/rust/bridge/shared/src/jni/mod.rs
+++ b/rust/bridge/shared/src/jni/mod.rs
@@ -20,41 +20,9 @@ pub(crate) use jni::objects::{AutoArray, JClass, JObject, JString, ReleaseMode};
 pub(crate) use jni::sys::{jboolean, jbyteArray, jint, jlong, jlongArray, jstring};
 pub(crate) use jni::JNIEnv;
 
-/// Converts a function signature to a JNI signature string.
-///
-/// This macro uses Rust function syntax `(Foo, Bar) -> Baz`, and uses Rust syntax for Java arrays
-/// `[Foo]`, but otherwise uses Java names for types: `boolean`, `byte`, `void`.
-// Placed here so that it can be used in submodules.
-// (Unlike regular Rust declarations, macros rely on lexical ordering.)
-#[macro_export]
-macro_rules! jni_signature {
-    ( boolean ) => ("Z");
-    ( bool ) => (compile_error!("use Java type 'boolean'"));
-    ( byte ) => ("B");
-    ( char ) => ("C");
-    ( short ) => ("S");
-    ( int ) => ("I");
-    ( long ) => ("J");
-    ( float ) => ("F");
-    ( double ) => ("D");
-    ( void ) => ("V");
-    ( $x:literal ) => ($x);
-
-    // Functions
-    ( ( $($arg_base:tt $(. $arg_rest:ident)*),* $(,)? ) -> $ret_base:tt $(. $ret_rest:ident)* ) => {
-        concat!("(" $(, jni_signature!($arg_base $(. $arg_rest)*))*, ")", jni_signature!($ret_base $(. $ret_rest)*))
-    };
-
-    // Arrays
-    ( [$arg_base:tt $(. $arg_rest:ident)*] ) => {
-        concat!("[", jni_signature!($arg_base $(. $arg_rest)*))
-    };
-
-    // Objects
-    ( $arg_base:tt $(. $arg_rest:ident)* ) => {
-        concat!("L", stringify!($arg_base) $(, "/", stringify!($arg_rest))*, ";")
-    };
-}
+#[macro_use]
+mod args;
+pub use args::*;
 
 #[macro_use]
 mod convert;
@@ -106,7 +74,7 @@ fn throw_error(env: &JNIEnv, error: SignalJniError) {
 
         SignalJniError::Signal(SignalProtocolError::UntrustedIdentity(ref addr)) => {
             let result = env.throw_new(
-                "org/whispersystems/libsignal/UntrustedIdentityException",
+                jni_class_name!(org.whispersystems.libsignal.UntrustedIdentityException),
                 addr.name(),
             );
             if let Err(e) = result {
@@ -119,15 +87,16 @@ fn throw_error(env: &JNIEnv, error: SignalJniError) {
             let throwable = protocol_address_to_jobject(env, addr)
                 .and_then(|addr_object| Ok((addr_object, env.new_string(error.to_string())?)))
                 .and_then(|(addr_object, message)| {
+                    let args = jni_args!((
+                        addr_object => org.whispersystems.libsignal.SignalProtocolAddress,
+                        message => java.lang.String,
+                    ) -> void);
                     Ok(env.new_object(
-                        "org/whispersystems/libsignal/InvalidRegistrationIdException",
-                        jni_signature!(
-                            (
-                                org.whispersystems.libsignal.SignalProtocolAddress,
-                                java.lang.String,
-                            ) -> void
+                        jni_class_name!(
+                            org.whispersystems.libsignal.InvalidRegistrationIdException
                         ),
-                        &[JValue::from(addr_object), JValue::from(message)],
+                        args.sig,
+                        &args.args,
                     )?)
                 });
 
@@ -144,10 +113,16 @@ fn throw_error(env: &JNIEnv, error: SignalJniError) {
         }
 
         SignalJniError::Signal(SignalProtocolError::FingerprintVersionMismatch(theirs, ours)) => {
+            let args = jni_args!((theirs as jint => int, ours as jint => int) -> void);
             let throwable = env.new_object(
-                "org/whispersystems/libsignal/fingerprint/FingerprintVersionMismatchException",
-                jni_signature!((int, int) -> void),
-                &[JValue::from(theirs as jint), JValue::from(ours as jint)],
+                jni_class_name!(
+                    org.whispersystems
+                        .libsignal
+                        .fingerprint
+                        .FingerprintVersionMismatchException
+                ),
+                args.sig,
+                &args.args,
             );
 
             match throwable {
@@ -164,7 +139,7 @@ fn throw_error(env: &JNIEnv, error: SignalJniError) {
 
         SignalJniError::Signal(SignalProtocolError::SealedSenderSelfSend) => {
             let throwable = env.new_object(
-                "org/signal/libsignal/metadata/SelfSendException",
+                jni_class_name!(org.signal.libsignal.metadata.SelfSendException),
                 jni_signature!(() -> void),
                 &[],
             );
@@ -186,10 +161,11 @@ fn throw_error(env: &JNIEnv, error: SignalJniError) {
         | SignalJniError::UnexpectedJniResultType(_, _) => {
             // java.lang.AssertionError has a slightly different signature.
             let throwable = env.new_string(error.to_string()).and_then(|message| {
+                let args = jni_args!((message => java.lang.Object) -> void);
                 env.new_object(
-                    "java/lang/AssertionError",
-                    jni_signature!((java.lang.Object) -> void),
-                    &[JValue::from(message)],
+                    jni_class_name!(java.lang.AssertionError),
+                    args.sig,
+                    &args.args,
                 )
             });
 
@@ -209,20 +185,22 @@ fn throw_error(env: &JNIEnv, error: SignalJniError) {
     };
 
     let exception_type = match error {
-        SignalJniError::NullHandle => "java/lang/NullPointerException",
+        SignalJniError::NullHandle => jni_class_name!(java.lang.NullPointerException),
 
         SignalJniError::Signal(SignalProtocolError::InvalidState(_, _))
         | SignalJniError::Signal(SignalProtocolError::NoSenderKeyState)
         | SignalJniError::SignalCrypto(SignalCryptoError::InvalidState)
         | SignalJniError::Signal(SignalProtocolError::InvalidSessionStructure) => {
-            "java/lang/IllegalStateException"
+            jni_class_name!(java.lang.IllegalStateException)
         }
 
         SignalJniError::Signal(SignalProtocolError::InvalidArgument(_))
         | SignalJniError::SignalCrypto(SignalCryptoError::UnknownAlgorithm(_, _))
         | SignalJniError::SignalCrypto(SignalCryptoError::InvalidInputSize)
         | SignalJniError::SignalCrypto(SignalCryptoError::InvalidNonceSize)
-        | SignalJniError::DeserializationFailed(_) => "java/lang/IllegalArgumentException",
+        | SignalJniError::DeserializationFailed(_) => {
+            jni_class_name!(java.lang.IllegalArgumentException)
+        }
 
         SignalJniError::IntegerOverflow(_)
         | SignalJniError::Jni(_)
@@ -236,16 +214,16 @@ fn throw_error(env: &JNIEnv, error: SignalJniError) {
         | SignalJniError::Signal(SignalProtocolError::InvalidMacKeyLength(_))
         | SignalJniError::Signal(SignalProtocolError::InvalidRootKeyLength(_))
         | SignalJniError::Signal(SignalProtocolError::ProtobufEncodingError(_)) => {
-            "java/lang/RuntimeException"
+            jni_class_name!(java.lang.RuntimeException)
         }
 
         SignalJniError::Signal(SignalProtocolError::DuplicatedMessage(_, _)) => {
-            "org/whispersystems/libsignal/DuplicateMessageException"
+            jni_class_name!(org.whispersystems.libsignal.DuplicateMessageException)
         }
 
         SignalJniError::Signal(SignalProtocolError::InvalidPreKeyId)
         | SignalJniError::Signal(SignalProtocolError::InvalidSignedPreKeyId) => {
-            "org/whispersystems/libsignal/InvalidKeyIdException"
+            jni_class_name!(org.whispersystems.libsignal.InvalidKeyIdException)
         }
 
         SignalJniError::Signal(SignalProtocolError::NoKeyTypeIdentifier)
@@ -253,11 +231,11 @@ fn throw_error(env: &JNIEnv, error: SignalJniError) {
         | SignalJniError::Signal(SignalProtocolError::BadKeyType(_))
         | SignalJniError::Signal(SignalProtocolError::BadKeyLength(_, _))
         | SignalJniError::SignalCrypto(SignalCryptoError::InvalidKeySize) => {
-            "org/whispersystems/libsignal/InvalidKeyException"
+            jni_class_name!(org.whispersystems.libsignal.InvalidKeyException)
         }
 
         SignalJniError::Signal(SignalProtocolError::SessionNotFound(_)) => {
-            "org/whispersystems/libsignal/NoSessionException"
+            jni_class_name!(org.whispersystems.libsignal.NoSessionException)
         }
 
         SignalJniError::Signal(SignalProtocolError::InvalidMessage(_))
@@ -267,22 +245,27 @@ fn throw_error(env: &JNIEnv, error: SignalJniError) {
         | SignalJniError::Signal(SignalProtocolError::ProtobufDecodingError(_))
         | SignalJniError::Signal(SignalProtocolError::InvalidSealedSenderMessage(_))
         | SignalJniError::SignalCrypto(SignalCryptoError::InvalidTag) => {
-            "org/whispersystems/libsignal/InvalidMessageException"
+            jni_class_name!(org.whispersystems.libsignal.InvalidMessageException)
         }
 
         SignalJniError::Signal(SignalProtocolError::UnrecognizedCiphertextVersion(_))
         | SignalJniError::Signal(SignalProtocolError::UnrecognizedMessageVersion(_))
         | SignalJniError::Signal(SignalProtocolError::UnknownSealedSenderVersion(_)) => {
-            "org/whispersystems/libsignal/InvalidVersionException"
+            jni_class_name!(org.whispersystems.libsignal.InvalidVersionException)
         }
 
         SignalJniError::Signal(SignalProtocolError::LegacyCiphertextVersion(_)) => {
-            "org/whispersystems/libsignal/LegacyMessageException"
+            jni_class_name!(org.whispersystems.libsignal.LegacyMessageException)
         }
 
         SignalJniError::Signal(SignalProtocolError::FingerprintIdentifierMismatch)
         | SignalJniError::Signal(SignalProtocolError::FingerprintParsingError) => {
-            "org/whispersystems/libsignal/fingerprint/FingerprintParsingException"
+            jni_class_name!(
+                org.whispersystems
+                    .libsignal
+                    .fingerprint
+                    .FingerprintParsingException
+            )
         }
 
         SignalJniError::Signal(SignalProtocolError::SealedSenderSelfSend)
@@ -296,28 +279,33 @@ fn throw_error(env: &JNIEnv, error: SignalJniError) {
         }
 
         SignalJniError::HsmEnclave(HsmEnclaveError::HSMCommunicationError(_)) => {
-            "org/signal/libsignal/hsmenclave/EnclaveCommunicationFailureException"
+            jni_class_name!(
+                org.signal
+                    .libsignal
+                    .hsmenclave
+                    .EnclaveCommunicationFailureException
+            )
         }
         SignalJniError::HsmEnclave(HsmEnclaveError::TrustedCodeError) => {
-            "org/signal/libsignal/hsmenclave/TrustedCodeMismatchException"
+            jni_class_name!(org.signal.libsignal.hsmenclave.TrustedCodeMismatchException)
         }
         SignalJniError::HsmEnclave(HsmEnclaveError::InvalidPublicKeyError)
         | SignalJniError::HsmEnclave(HsmEnclaveError::InvalidCodeHashError) => {
-            "java/lang/IllegalArgumentException"
+            jni_class_name!(java.lang.IllegalArgumentException)
         }
         SignalJniError::HsmEnclave(HsmEnclaveError::InvalidBridgeStateError) => {
-            "java/lang/IllegalStateException"
+            jni_class_name!(java.lang.IllegalStateException)
         }
 
         SignalJniError::ZkGroup(ZkGroupError::BadArgs) => {
-            "org/signal/zkgroup/InvalidInputException"
+            jni_class_name!(org.signal.zkgroup.InvalidInputException)
         }
         SignalJniError::ZkGroup(
             ZkGroupError::DecryptionFailure
             | ZkGroupError::MacVerificationFailure
             | ZkGroupError::ProofVerificationFailure
             | ZkGroupError::SignatureVerificationFailure,
-        ) => "org/signal/zkgroup/VerificationFailedException",
+        ) => jni_class_name!(org.signal.zkgroup.VerificationFailedException),
     };
 
     if let Err(e) = env.throw_new(exception_type, error.to_string()) {
@@ -432,16 +420,15 @@ where
 /// Wraps [`JNIEnv::call_method`]; all arguments are the same.
 /// The result must have the correct type, or [`SignalJniError::UnexpectedJniResultType`] will be
 /// returned instead.
-pub fn call_method_checked<'a, O: Into<JObject<'a>>, R: TryFrom<JValue<'a>>>(
+pub fn call_method_checked<'a, O: Into<JObject<'a>>, R: TryFrom<JValue<'a>>, const LEN: usize>(
     env: &JNIEnv<'a>,
     obj: O,
     fn_name: &'static str,
-    sig: &'static str,
-    args: &[JValue<'_>],
+    args: JniArgs<'a, R, LEN>,
 ) -> Result<R, SignalJniError> {
     // Note that we are *not* unwrapping the result yet!
     // We need to check for exceptions *first*.
-    let result = env.call_method(obj, fn_name, sig, args);
+    let result = env.call_method(obj, fn_name, args.sig, &args.args);
 
     let throwable = env.exception_occurred()?;
     if **throwable == *JObject::null() {
@@ -469,9 +456,10 @@ pub fn jobject_from_native_handle<'a>(
     boxed_handle: ObjectHandle,
 ) -> Result<JObject<'a>, SignalJniError> {
     let class_type = env.find_class(class_name)?;
-    let ctor_sig = jni_signature!((long) -> void);
-    let ctor_args = [JValue::from(boxed_handle)];
-    Ok(env.new_object(class_type, ctor_sig, &ctor_args)?)
+    let args = jni_args!((
+        boxed_handle => long,
+    ) -> void);
+    Ok(env.new_object(class_type, args.sig, &args.args)?)
 }
 
 /// Constructs a Java object from its serialized form.
@@ -483,9 +471,10 @@ pub fn jobject_from_serialized<'a>(
     serialized: &[u8],
 ) -> Result<JObject<'a>, SignalJniError> {
     let class_type = env.find_class(class_name)?;
-    let ctor_sig = jni_signature!(([byte]) -> void);
-    let ctor_args = [JValue::from(env.byte_array_from_slice(serialized)?)];
-    Ok(env.new_object(class_type, ctor_sig, &ctor_args)?)
+    let args = jni_args!((
+        env.byte_array_from_slice(serialized)? => [byte],
+    ) -> void);
+    Ok(env.new_object(class_type, args.sig, &args.args)?)
 }
 
 /// Constructs a Java SignalProtocolAddress from a ProtocolAddress value.
@@ -493,14 +482,14 @@ fn protocol_address_to_jobject<'a>(
     env: &'a JNIEnv,
     address: &ProtocolAddress,
 ) -> Result<JObject<'a>, SignalJniError> {
-    let address_class = env.find_class("org/whispersystems/libsignal/SignalProtocolAddress")?;
-    let address_ctor_args = [
-        JObject::from(env.new_string(address.name())?).into(),
-        JValue::from(address.device_id().convert_into(env)?),
-    ];
-
-    let address_ctor_sig = jni_signature!((java.lang.String, int) -> void);
-    let address_jobject = env.new_object(address_class, address_ctor_sig, &address_ctor_args)?;
+    let address_class = env.find_class(jni_class_name!(
+        org.whispersystems.libsignal.SignalProtocolAddress
+    ))?;
+    let args = jni_args!((
+        env.new_string(address.name())? => java.lang.String,
+        address.device_id().convert_into(env)? => int,
+    ) -> void);
+    let address_jobject = env.new_object(address_class, args.sig, &args.args)?;
     Ok(address_jobject)
 }
 
@@ -527,21 +516,14 @@ pub fn check_jobject_type(
 ///
 /// The method is assumed to return a type with a `long nativeHandle()` method, which in turn must
 /// produce a boxed Rust value.
-pub fn get_object_with_native_handle<T: 'static + Clone>(
+pub fn get_object_with_native_handle<T: 'static + Clone, const LEN: usize>(
     env: &JNIEnv,
     store_obj: JObject,
-    callback_args: &[JValue],
-    callback_sig: &'static str,
+    callback_args: JniArgs<JObject, LEN>,
     callback_fn: &'static str,
 ) -> Result<Option<T>, SignalJniError> {
     with_local_frame_no_jobject_result(env, 64, || -> SignalJniResult<Option<T>> {
-        let obj = call_method_checked::<_, JObject>(
-            env,
-            store_obj,
-            callback_fn,
-            callback_sig,
-            callback_args,
-        )?;
+        let obj = call_method_checked(env, store_obj, callback_fn, callback_args)?;
         if obj.is_null() {
             return Ok(None);
         }
@@ -561,33 +543,20 @@ pub fn get_object_with_native_handle<T: 'static + Clone>(
 /// Calls a method, then serializes the result.
 ///
 /// The method is assumed to return a type with a `byte[] serialize()` method.
-pub fn get_object_with_serialization(
+pub fn get_object_with_serialization<const LEN: usize>(
     env: &JNIEnv,
     store_obj: JObject,
-    callback_args: &[JValue],
-    callback_sig: &'static str,
+    callback_args: JniArgs<JObject, LEN>,
     callback_fn: &'static str,
 ) -> Result<Option<Vec<u8>>, SignalJniError> {
     with_local_frame_no_jobject_result(env, 64, || -> SignalJniResult<Option<Vec<u8>>> {
-        let obj = call_method_checked::<_, JObject>(
-            env,
-            store_obj,
-            callback_fn,
-            callback_sig,
-            callback_args,
-        )?;
+        let obj = call_method_checked(env, store_obj, callback_fn, callback_args)?;
 
         if obj.is_null() {
             return Ok(None);
         }
 
-        let bytes = call_method_checked::<_, JObject>(
-            env,
-            obj,
-            "serialize",
-            jni_signature!(() -> [byte]),
-            &[],
-        )?;
+        let bytes = call_method_checked(env, obj, "serialize", jni_args!(() -> [byte]))?;
 
         Ok(Some(env.convert_byte_array(*bytes)?))
     })


### PR DESCRIPTION
- `jni_class_name` turns Java-style dotted class names into JNI-style slash-separated names.

- `jni_args` builds on `jni_signature` to make sure the arguments passed to a function match the declared signature. It also records the expected return type so `call_method_checked` can convert to it automatically.