### PR TITLE
NPM: Publish releases for M1 Macs too

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -22,7 +22,10 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-11]
+        include:
+        - os: macos-11
+          additional-rust-target: aarch64-apple-darwin
 
     steps:
     - uses: actions/checkout@v2
@@ -33,6 +36,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
+        target: ${{ matrix.additional-rust-target }}
 
     - name: Get Node version from .nvmrc
       id: get-nvm-version
@@ -49,6 +53,10 @@ jobs:
 
     - run: yarn install --ignore-scripts --frozen-lockfile
       working-directory: node
+
+    - run: npx prebuildify --napi -t ${{ steps.get-nvm-version.outputs.node-version }} --arch arm64
+      working-directory: node
+      if: matrix.os == 'macos-11'
 
     - run: npx prebuildify --napi -t ${{ steps.get-nvm-version.outputs.node-version }}
       working-directory: node

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -115,6 +115,8 @@ jobs:
         # The tests use an Electron-based runner, so we need to set up a dummy display for them.
         run: yarn test
         working-directory: node
+      env:
+        PREBUILDS_ONLY: 1
 
     - name: Publish to NPM
       uses: JS-DevTools/npm-publish@v1


### PR DESCRIPTION
This requires building on the macOS 11 GitHub runner; the 10.15 runner isn't set up for cross-compiling when not using Xcode.

Also, ensure that when we test the NPM package before publishing, we're using the libraries we're going to submit, rather than ones built on the final runner.