### PR TITLE
protocol: Tighten up error handling for internal crypto operations

### DIFF
--- a/rust/bridge/ffi/src/util.rs
+++ b/rust/bridge/ffi/src/util.rs
@@ -63,8 +63,6 @@ impl From<&SignalFfiError> for SignalErrorCode {
             | SignalFfiError::Signal(SignalProtocolError::InternalError(_))
             | SignalFfiError::DeviceTransfer(DeviceTransferError::InternalError(_))
             | SignalFfiError::Signal(SignalProtocolError::FfiBindingError(_))
-            | SignalFfiError::Signal(SignalProtocolError::InvalidChainKeyLength(_))
-            | SignalFfiError::Signal(SignalProtocolError::InvalidRootKeyLength(_))
             | SignalFfiError::Signal(SignalProtocolError::InvalidCipherCryptographicParameters(
                 _,
                 _,

--- a/rust/bridge/ffi/src/util.rs
+++ b/rust/bridge/ffi/src/util.rs
@@ -63,10 +63,6 @@ impl From<&SignalFfiError> for SignalErrorCode {
             | SignalFfiError::Signal(SignalProtocolError::InternalError(_))
             | SignalFfiError::DeviceTransfer(DeviceTransferError::InternalError(_))
             | SignalFfiError::Signal(SignalProtocolError::FfiBindingError(_))
-            | SignalFfiError::Signal(SignalProtocolError::InvalidCipherCryptographicParameters(
-                _,
-                _,
-            ))
             | SignalFfiError::Signal(SignalProtocolError::InvalidMacKeyLength(_)) => {
                 SignalErrorCode::InternalError
             }

--- a/rust/bridge/shared/src/jni/mod.rs
+++ b/rust/bridge/shared/src/jni/mod.rs
@@ -209,7 +209,6 @@ fn throw_error(env: &JNIEnv, error: SignalJniError) {
         | SignalJniError::Signal(SignalProtocolError::InternalError(_))
         | SignalJniError::DeviceTransfer(DeviceTransferError::InternalError(_))
         | SignalJniError::DeviceTransfer(DeviceTransferError::KeyDecodingFailed)
-        | SignalJniError::Signal(SignalProtocolError::InvalidCipherCryptographicParameters(_, _))
         | SignalJniError::Signal(SignalProtocolError::InvalidMacKeyLength(_))
         | SignalJniError::Signal(SignalProtocolError::ProtobufEncodingError(_)) => {
             jni_class_name!(java.lang.RuntimeException)

--- a/rust/bridge/shared/src/jni/mod.rs
+++ b/rust/bridge/shared/src/jni/mod.rs
@@ -209,10 +209,8 @@ fn throw_error(env: &JNIEnv, error: SignalJniError) {
         | SignalJniError::Signal(SignalProtocolError::InternalError(_))
         | SignalJniError::DeviceTransfer(DeviceTransferError::InternalError(_))
         | SignalJniError::DeviceTransfer(DeviceTransferError::KeyDecodingFailed)
-        | SignalJniError::Signal(SignalProtocolError::InvalidChainKeyLength(_))
         | SignalJniError::Signal(SignalProtocolError::InvalidCipherCryptographicParameters(_, _))
         | SignalJniError::Signal(SignalProtocolError::InvalidMacKeyLength(_))
-        | SignalJniError::Signal(SignalProtocolError::InvalidRootKeyLength(_))
         | SignalJniError::Signal(SignalProtocolError::ProtobufEncodingError(_)) => {
             jni_class_name!(java.lang.RuntimeException)
         }

--- a/rust/protocol/src/crypto.rs
+++ b/rust/protocol/src/crypto.rs
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use crate::{error::Result, SignalProtocolError};
+use std::convert::TryInto;
+use std::result::Result;
 
 use aes::cipher::{NewCipher, StreamCipher};
 use aes::{Aes256, Aes256Ctr};
@@ -13,135 +14,143 @@ use hmac::{Hmac, Mac, NewMac};
 use sha2::Sha256;
 use subtle::ConstantTimeEq;
 
-pub fn aes_256_ctr_encrypt(ptext: &[u8], key: &[u8]) -> Result<Vec<u8>> {
-    if key.len() != 32 {
-        return Err(SignalProtocolError::InvalidCipherCryptographicParameters(
-            32, 0,
-        ));
-    }
+#[derive(Debug)]
+pub(crate) enum EncryptionError {
+    /// The key or IV is the wrong length.
+    BadKeyOrIv,
+}
+
+#[derive(Debug)]
+pub(crate) enum DecryptionError {
+    /// The key or IV is the wrong length.
+    BadKeyOrIv,
+    /// Either the input is malformed, or the MAC doesn't match on decryption.
+    ///
+    /// These cases should not be distinguished; message corruption can cause either problem.
+    BadCiphertext(&'static str),
+}
+
+fn aes_256_ctr_encrypt(ptext: &[u8], key: &[u8]) -> Result<Vec<u8>, EncryptionError> {
+    let key: [u8; 32] = key.try_into().map_err(|_| EncryptionError::BadKeyOrIv)?;
 
     let zero_nonce = [0u8; 16];
-    let mut cipher = Aes256Ctr::new(key.into(), (&zero_nonce).into());
+    let mut cipher = Aes256Ctr::new(key[..].into(), zero_nonce[..].into());
 
     let mut ctext = ptext.to_vec();
     cipher.apply_keystream(&mut ctext);
     Ok(ctext)
 }
 
-pub fn aes_256_ctr_decrypt(ctext: &[u8], key: &[u8]) -> Result<Vec<u8>> {
-    aes_256_ctr_encrypt(ctext, key)
+fn aes_256_ctr_decrypt(ctext: &[u8], key: &[u8]) -> Result<Vec<u8>, DecryptionError> {
+    aes_256_ctr_encrypt(ctext, key).map_err(|e| match e {
+        EncryptionError::BadKeyOrIv => DecryptionError::BadKeyOrIv,
+    })
 }
 
-pub fn aes_256_cbc_encrypt(ptext: &[u8], key: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
+pub(crate) fn aes_256_cbc_encrypt(
+    ptext: &[u8],
+    key: &[u8],
+    iv: &[u8],
+) -> Result<Vec<u8>, EncryptionError> {
     match Cbc::<Aes256, Pkcs7>::new_from_slices(key, iv) {
         Ok(mode) => Ok(mode.encrypt_vec(ptext)),
-        Err(block_modes::InvalidKeyIvLength) => Err(
-            SignalProtocolError::InvalidCipherCryptographicParameters(key.len(), iv.len()),
-        ),
+        Err(block_modes::InvalidKeyIvLength) => Err(EncryptionError::BadKeyOrIv),
     }
 }
 
-pub fn aes_256_cbc_decrypt(ctext: &[u8], key: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
+pub(crate) fn aes_256_cbc_decrypt(
+    ctext: &[u8],
+    key: &[u8],
+    iv: &[u8],
+) -> Result<Vec<u8>, DecryptionError> {
     if ctext.is_empty() || ctext.len() % 16 != 0 {
-        return Err(SignalProtocolError::InvalidCiphertext);
+        return Err(DecryptionError::BadCiphertext(
+            "ciphertext length must be a non-zero multiple of 16",
+        ));
     }
 
-    let mode = match Cbc::<Aes256, Pkcs7>::new_from_slices(key, iv) {
-        Ok(mode) => mode,
-        Err(block_modes::InvalidKeyIvLength) => {
-            return Err(SignalProtocolError::InvalidCipherCryptographicParameters(
-                key.len(),
-                iv.len(),
-            ))
-        }
-    };
-
+    let mode =
+        Cbc::<Aes256, Pkcs7>::new_from_slices(key, iv).map_err(|_| DecryptionError::BadKeyOrIv)?;
     mode.decrypt_vec(ctext)
-        .map_err(|_| SignalProtocolError::InvalidCiphertext)
+        .map_err(|_| DecryptionError::BadCiphertext("failed to decrypt"))
 }
 
-pub fn hmac_sha256(key: &[u8], input: &[u8]) -> Result<[u8; 32]> {
+pub(crate) fn hmac_sha256(key: &[u8], input: &[u8]) -> [u8; 32] {
     let mut hmac =
         Hmac::<Sha256>::new_from_slice(key).expect("HMAC-SHA256 should accept any size key");
     hmac.update(input);
-    Ok(hmac.finalize().into_bytes().into())
+    hmac.finalize().into_bytes().into()
 }
 
-pub fn aes256_ctr_hmacsha256_encrypt(
+pub(crate) fn aes256_ctr_hmacsha256_encrypt(
     msg: &[u8],
     cipher_key: &[u8],
     mac_key: &[u8],
-) -> Result<Vec<u8>> {
-    let ctext = aes_256_ctr_encrypt(msg, cipher_key)?;
-    let mac = hmac_sha256(mac_key, &ctext)?;
-    let mut result = Vec::with_capacity(ctext.len() + 10);
-    result.extend_from_slice(&ctext);
-    result.extend_from_slice(&mac[..10]);
-    Ok(result)
+) -> Result<Vec<u8>, EncryptionError> {
+    let mut ctext = aes_256_ctr_encrypt(msg, cipher_key)?;
+    let mac = hmac_sha256(mac_key, &ctext);
+    ctext.extend_from_slice(&mac[..10]);
+    Ok(ctext)
 }
 
-pub fn aes256_ctr_hmacsha256_decrypt(
+pub(crate) fn aes256_ctr_hmacsha256_decrypt(
     ctext: &[u8],
     cipher_key: &[u8],
     mac_key: &[u8],
-) -> Result<Vec<u8>> {
+) -> Result<Vec<u8>, DecryptionError> {
     if ctext.len() < 10 {
-        return Err(SignalProtocolError::InvalidCiphertext);
+        return Err(DecryptionError::BadCiphertext("truncated ciphertext"));
     }
     let ptext_len = ctext.len() - 10;
-    let our_mac = hmac_sha256(mac_key, &ctext[..ptext_len])?;
+    let our_mac = hmac_sha256(mac_key, &ctext[..ptext_len]);
     let same: bool = our_mac[..10].ct_eq(&ctext[ptext_len..]).into();
     if !same {
-        return Err(SignalProtocolError::InvalidCiphertext);
+        return Err(DecryptionError::BadCiphertext("MAC verification failed"));
     }
     aes_256_ctr_decrypt(&ctext[..ptext_len], cipher_key)
 }
 
 #[cfg(test)]
 mod test {
-    use super::Result;
+    use super::*;
 
     #[test]
-    fn aes_cbc_test() -> Result<()> {
+    fn aes_cbc_test() {
         let key = hex::decode("4e22eb16d964779994222e82192ce9f747da72dc4abe49dfdeeb71d0ffe3796e")
             .expect("valid hex");
         let iv = hex::decode("6f8a557ddc0a140c878063a6d5f31d3d").expect("valid hex");
 
         let ptext = hex::decode("30736294a124482a4159").expect("valid hex");
 
-        let ctext = super::aes_256_cbc_encrypt(&ptext, &key, &iv)?;
+        let ctext = aes_256_cbc_encrypt(&ptext, &key, &iv).expect("valid key and IV");
         assert_eq!(
             hex::encode(ctext.clone()),
             "dd3f573ab4508b9ed0e45e0baf5608f3"
         );
 
-        let recovered = super::aes_256_cbc_decrypt(&ctext, &key, &iv)?;
+        let recovered = aes_256_cbc_decrypt(&ctext, &key, &iv).expect("valid");
         assert_eq!(hex::encode(ptext), hex::encode(recovered.clone()));
 
         // padding is invalid:
-        assert!(super::aes_256_cbc_decrypt(&recovered, &key, &iv).is_err());
-        assert!(super::aes_256_cbc_decrypt(&ctext, &key, &ctext).is_err());
+        assert!(aes_256_cbc_decrypt(&recovered, &key, &iv).is_err());
+        assert!(aes_256_cbc_decrypt(&ctext, &key, &ctext).is_err());
 
         // bitflip the IV to cause a change in the recovered text
         let bad_iv = hex::decode("ef8a557ddc0a140c878063a6d5f31d3d").expect("valid hex");
-        let recovered = super::aes_256_cbc_decrypt(&ctext, &key, &bad_iv)?;
+        let recovered = aes_256_cbc_decrypt(&ctext, &key, &bad_iv).expect("still valid");
         assert_eq!(hex::encode(recovered), "b0736294a124482a4159");
-
-        Ok(())
     }
 
     #[test]
-    fn aes_ctr_test() -> Result<()> {
+    fn aes_ctr_test() {
         let key = hex::decode("603DEB1015CA71BE2B73AEF0857D77811F352C073B6108D72D9810A30914DFF4")
             .expect("valid hex");
         let ptext = [0u8; 35];
 
-        let ctext = super::aes_256_ctr_encrypt(&ptext, &key)?;
+        let ctext = aes_256_ctr_encrypt(&ptext, &key).expect("valid key");
         assert_eq!(
             hex::encode(ctext),
             "e568f68194cf76d6174d4cc04310a85491151e5d0b7a1f1bc0d7acd0ae3e51e4170e23"
         );
-
-        Ok(())
     }
 }

--- a/rust/protocol/src/error.rs
+++ b/rust/protocol/src/error.rs
@@ -61,11 +61,6 @@ pub enum SignalProtocolError {
     /// invalid signed prekey identifier
     InvalidSignedPreKeyId,
 
-    /// invalid root key length <{0}>
-    InvalidRootKeyLength(usize),
-    /// invalid chain key length <{0}>
-    InvalidChainKeyLength(usize),
-
     /// invalid MAC key length <{0}>
     InvalidMacKeyLength(usize),
     /// invalid cipher key length <{0}> or nonce length <{1}>

--- a/rust/protocol/src/error.rs
+++ b/rust/protocol/src/error.rs
@@ -63,8 +63,6 @@ pub enum SignalProtocolError {
 
     /// invalid MAC key length <{0}>
     InvalidMacKeyLength(usize),
-    /// invalid cipher key length <{0}> or nonce length <{1}>
-    InvalidCipherCryptographicParameters(usize, usize),
     /// invalid ciphertext message
     InvalidCiphertext,
 

--- a/rust/protocol/src/ratchet.rs
+++ b/rust/protocol/src/ratchet.rs
@@ -6,6 +6,8 @@
 mod keys;
 mod params;
 
+use std::convert::TryInto;
+
 pub use self::keys::{ChainKey, MessageKeys, RootKey};
 pub use self::params::{AliceSignalProtocolParameters, BobSignalProtocolParameters};
 use crate::proto::storage::SessionStructure;
@@ -19,9 +21,10 @@ fn derive_keys(secret_input: &[u8]) -> Result<(RootKey, ChainKey)> {
     hkdf::Hkdf::<sha2::Sha256>::new(None, secret_input)
         .expand(b"WhisperText", &mut secrets)
         .expect("valid length");
+    let (root_key_bytes, chain_key_bytes) = secrets.split_at(32);
 
-    let root_key = RootKey::new(&secrets[0..32])?;
-    let chain_key = ChainKey::new(&secrets[32..64], 0)?;
+    let root_key = RootKey::new(root_key_bytes.try_into().expect("correct length"));
+    let chain_key = ChainKey::new(chain_key_bytes.try_into().expect("correct length"), 0);
 
     Ok((root_key, chain_key))
 }

--- a/rust/protocol/src/ratchet/keys.rs
+++ b/rust/protocol/src/ratchet/keys.rs
@@ -6,7 +6,7 @@
 use arrayref::array_ref;
 
 use crate::crypto;
-use crate::{PrivateKey, PublicKey, Result, SignalProtocolError};
+use crate::{PrivateKey, PublicKey, Result};
 use std::fmt;
 
 pub struct MessageKeys {
@@ -31,23 +31,13 @@ impl MessageKeys {
         })
     }
 
-    pub fn new(cipher_key: &[u8], mac_key: &[u8], iv: &[u8], counter: u32) -> Result<Self> {
-        if mac_key.len() != 32 {
-            return Err(SignalProtocolError::InvalidMacKeyLength(mac_key.len()));
-        }
-        if cipher_key.len() != 32 || iv.len() != 16 {
-            return Err(SignalProtocolError::InvalidCipherCryptographicParameters(
-                cipher_key.len(),
-                iv.len(),
-            ));
-        }
-
-        Ok(MessageKeys {
-            cipher_key: *array_ref![cipher_key, 0, 32],
-            mac_key: *array_ref![mac_key, 0, 32],
-            iv: *array_ref![iv, 0, 16],
+    pub fn new(cipher_key: [u8; 32], mac_key: [u8; 32], iv: [u8; 16], counter: u32) -> Self {
+        MessageKeys {
+            cipher_key,
+            mac_key,
+            iv,
             counter,
-        })
+        }
     }
 
     #[inline]

--- a/rust/protocol/src/ratchet/keys.rs
+++ b/rust/protocol/src/ratchet/keys.rs
@@ -97,19 +97,19 @@ impl ChainKey {
 
     pub fn next_chain_key(&self) -> Result<Self> {
         Ok(Self {
-            key: self.calculate_base_material(Self::CHAIN_KEY_SEED)?,
+            key: self.calculate_base_material(Self::CHAIN_KEY_SEED),
             index: self.index + 1,
         })
     }
 
     pub fn message_keys(&self) -> Result<MessageKeys> {
         MessageKeys::derive_keys(
-            &self.calculate_base_material(Self::MESSAGE_KEY_SEED)?,
+            &self.calculate_base_material(Self::MESSAGE_KEY_SEED),
             self.index,
         )
     }
 
-    fn calculate_base_material(&self, seed: [u8; 1]) -> Result<[u8; 32]> {
+    fn calculate_base_material(&self, seed: [u8; 1]) -> [u8; 32] {
         crypto::hmac_sha256(&self.key, &seed)
     }
 }

--- a/rust/protocol/src/ratchet/keys.rs
+++ b/rust/protocol/src/ratchet/keys.rs
@@ -81,15 +81,8 @@ impl ChainKey {
     const MESSAGE_KEY_SEED: [u8; 1] = [0x01u8];
     const CHAIN_KEY_SEED: [u8; 1] = [0x02u8];
 
-    pub fn new(key: &[u8], index: u32) -> Result<Self> {
-        if key.len() != 32 {
-            return Err(SignalProtocolError::InvalidChainKeyLength(key.len()));
-        }
-
-        Ok(Self {
-            key: *array_ref![key, 0, 32],
-            index,
-        })
+    pub fn new(key: [u8; 32], index: u32) -> Self {
+        Self { key, index }
     }
 
     #[inline]
@@ -127,13 +120,8 @@ pub struct RootKey {
 }
 
 impl RootKey {
-    pub fn new(key: &[u8]) -> Result<Self> {
-        if key.len() != 32 {
-            return Err(SignalProtocolError::InvalidRootKeyLength(key.len()));
-        }
-        Ok(Self {
-            key: *array_ref![key, 0, 32],
-        })
+    pub fn new(key: [u8; 32]) -> Self {
+        Self { key }
     }
 
     pub fn key(&self) -> &[u8; 32] {
@@ -196,7 +184,7 @@ mod tests {
             0xa2, 0x46, 0xd1, 0x5d,
         ];
 
-        let chain_key = ChainKey::new(&seed, 0)?;
+        let chain_key = ChainKey::new(seed, 0);
         assert_eq!(&seed, chain_key.key());
         assert_eq!(&message_key, chain_key.message_keys()?.cipher_key());
         assert_eq!(&mac_key, chain_key.message_keys()?.mac_key());

--- a/rust/protocol/src/sender_keys.rs
+++ b/rust/protocol/src/sender_keys.rs
@@ -99,17 +99,17 @@ impl SenderChainKey {
     pub fn next(&self) -> Result<SenderChainKey> {
         SenderChainKey::new(
             self.iteration + 1,
-            self.get_derivative(Self::CHAIN_KEY_SEED)?,
+            self.get_derivative(Self::CHAIN_KEY_SEED),
         )
     }
 
     pub fn sender_message_key(&self) -> Result<SenderMessageKey> {
-        SenderMessageKey::new(self.iteration, self.get_derivative(Self::MESSAGE_KEY_SEED)?)
+        SenderMessageKey::new(self.iteration, self.get_derivative(Self::MESSAGE_KEY_SEED))
     }
 
-    fn get_derivative(&self, label: u8) -> Result<Vec<u8>> {
+    fn get_derivative(&self, label: u8) -> Vec<u8> {
         let label = [label];
-        Ok(hmac_sha256(&self.chain_key, &label)?.to_vec())
+        hmac_sha256(&self.chain_key, &label).to_vec()
     }
 
     pub fn as_protobuf(&self) -> Result<storage_proto::sender_key_state_structure::SenderChainKey> {


### PR DESCRIPTION
Use fixed-length arrays and dedicated error types to force the callers of crate-internal crypto operations to deal with errors, usually by treating a session as corrupted (i.e. something that should not happen using only the libsignal-client APIs to manipulate sessions). This keeps from propagating context-less errors out to callers, and removes the need for error propagation altogether in some cases. It also ends up removing three specific flavors of SignalProtocolError that were already being treated as unexpected runtime exceptions.