### PR TITLE
protocol: Tidy up some error strings

### DIFF
--- a/rust/bridge/shared/src/ffi/storage.rs
+++ b/rust/bridge/shared/src/ffi/storage.rs
@@ -68,7 +68,10 @@ impl IdentityKeyStore for &FfiIdentityKeyStoreStruct {
         }
 
         if key.is_null() {
-            return Err(SignalProtocolError::InternalError("No identity key pair"));
+            return Err(SignalProtocolError::InvalidState(
+                "get_identity_key_pair",
+                "no local identity key".to_string(),
+            ));
         }
 
         let priv_key = unsafe { Box::from_raw(key) };

--- a/rust/bridge/shared/src/jni/storage.rs
+++ b/rust/bridge/shared/src/jni/storage.rs
@@ -40,9 +40,11 @@ impl<'a> JniIdentityKeyStore<'a> {
         )?;
 
         match bits {
-            None => Err(SignalJniError::Signal(SignalProtocolError::InternalError(
-                "getIdentityKeyPair returned null",
-            ))),
+            None => Err(SignalProtocolError::InvalidState(
+                "get_identity_key_pair",
+                "no local identity key".to_string(),
+            )
+            .into()),
             Some(k) => Ok(IdentityKeyPair::try_from(k.as_ref())?),
         }
     }

--- a/rust/protocol/src/session_cipher.rs
+++ b/rust/protocol/src/session_cipher.rs
@@ -159,9 +159,10 @@ pub async fn message_decrypt<R: Rng + CryptoRng>(
             )
             .await
         }
-        _ => Err(SignalProtocolError::InvalidArgument(
-            "SessionCipher::decrypt cannot decrypt this message type".to_owned(),
-        )),
+        _ => Err(SignalProtocolError::InvalidArgument(format!(
+            "message_decrypt cannot be used to decrypt {:?} messages",
+            ciphertext.message_type()
+        ))),
     }
 }
 

--- a/rust/protocol/src/state/session.rs
+++ b/rust/protocol/src/state/session.rs
@@ -570,9 +570,8 @@ impl SessionRecord {
         updated_session: SessionState,
     ) -> Result<()> {
         if old_session >= self.previous_sessions.len() {
-            return Err(SignalProtocolError::InvalidState(
-                "promote_old_session",
-                "out of range".into(),
+            return Err(SignalProtocolError::InternalError(
+                "tried to promote an old session that no longer exists (index out of range)",
             ));
         }
         self.previous_sessions.remove(old_session);


### PR DESCRIPTION
And straighten out InvalidState (a precondition the caller failed to enforce) vs. InternalError (something went wrong that the caller couldn't have checked for).