### PR TITLE
Treat InvalidMacKeyLength as InvalidKeyException

### DIFF
--- a/java/java/src/main/java/org/whispersystems/libsignal/protocol/SignalMessage.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/protocol/SignalMessage.java
@@ -57,7 +57,7 @@ public class SignalMessage implements CiphertextMessage, NativeHandleGuard.Owner
   }
 
   public void verifyMac(IdentityKey senderIdentityKey, IdentityKey receiverIdentityKey, SecretKeySpec macKey)
-      throws InvalidMessageException
+      throws InvalidMessageException, InvalidKeyException
   {
     try (
       NativeHandleGuard guard = new NativeHandleGuard(this);

--- a/rust/bridge/ffi/src/util.rs
+++ b/rust/bridge/ffi/src/util.rs
@@ -62,8 +62,7 @@ impl From<&SignalFfiError> for SignalErrorCode {
             SignalFfiError::UnexpectedPanic(_)
             | SignalFfiError::Signal(SignalProtocolError::InternalError(_))
             | SignalFfiError::DeviceTransfer(DeviceTransferError::InternalError(_))
-            | SignalFfiError::Signal(SignalProtocolError::FfiBindingError(_))
-            | SignalFfiError::Signal(SignalProtocolError::InvalidMacKeyLength(_)) => {
+            | SignalFfiError::Signal(SignalProtocolError::FfiBindingError(_)) => {
                 SignalErrorCode::InternalError
             }
 
@@ -94,6 +93,7 @@ impl From<&SignalFfiError> for SignalErrorCode {
             SignalFfiError::Signal(SignalProtocolError::NoKeyTypeIdentifier)
             | SignalFfiError::Signal(SignalProtocolError::BadKeyType(_))
             | SignalFfiError::Signal(SignalProtocolError::BadKeyLength(_, _))
+            | SignalFfiError::Signal(SignalProtocolError::InvalidMacKeyLength(_))
             | SignalFfiError::DeviceTransfer(DeviceTransferError::KeyDecodingFailed)
             | SignalFfiError::HsmEnclave(HsmEnclaveError::InvalidPublicKeyError)
             | SignalFfiError::SignalCrypto(SignalCryptoError::InvalidKeySize) => {

--- a/rust/bridge/shared/src/jni/mod.rs
+++ b/rust/bridge/shared/src/jni/mod.rs
@@ -209,7 +209,6 @@ fn throw_error(env: &JNIEnv, error: SignalJniError) {
         | SignalJniError::Signal(SignalProtocolError::InternalError(_))
         | SignalJniError::DeviceTransfer(DeviceTransferError::InternalError(_))
         | SignalJniError::DeviceTransfer(DeviceTransferError::KeyDecodingFailed)
-        | SignalJniError::Signal(SignalProtocolError::InvalidMacKeyLength(_))
         | SignalJniError::Signal(SignalProtocolError::ProtobufEncodingError(_)) => {
             jni_class_name!(java.lang.RuntimeException)
         }
@@ -227,6 +226,7 @@ fn throw_error(env: &JNIEnv, error: SignalJniError) {
         | SignalJniError::Signal(SignalProtocolError::SignatureValidationFailed)
         | SignalJniError::Signal(SignalProtocolError::BadKeyType(_))
         | SignalJniError::Signal(SignalProtocolError::BadKeyLength(_, _))
+        | SignalJniError::Signal(SignalProtocolError::InvalidMacKeyLength(_))
         | SignalJniError::SignalCrypto(SignalCryptoError::InvalidKeySize) => {
             jni_class_name!(org.whispersystems.libsignal.InvalidKeyException)
         }


### PR DESCRIPTION
...not a generic RuntimeException. Now that it's only used for SignalMessage MAC keys (cf. #430), the only way it could be wrong is if it's provided incorrectly by the user.