### PR TITLE
Add signAlternateIdentity and verifyAlternateIdentity operations

### DIFF
--- a/java/java/src/main/java/org/signal/client/internal/Native.java
+++ b/java/java/src/main/java/org/signal/client/internal/Native.java
@@ -185,6 +185,9 @@ public final class Native {
 
   public static native long[] IdentityKeyPair_Deserialize(byte[] data);
   public static native byte[] IdentityKeyPair_Serialize(long publicKey, long privateKey);
+  public static native byte[] IdentityKeyPair_SignAlternateIdentity(long publicKey, long privateKey, long otherIdentity);
+
+  public static native boolean IdentityKey_VerifyAlternateIdentity(long publicKey, long otherIdentity, byte[] signature);
 
   public static native void Logger_Initialize(int maxLevel, Class loggerClass);
   public static native void Logger_SetMaxLevel(int maxLevel);

--- a/java/java/src/main/java/org/whispersystems/libsignal/IdentityKey.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/IdentityKey.java
@@ -5,6 +5,8 @@
  */
 package org.whispersystems.libsignal;
 
+import org.signal.client.internal.Native;
+import org.signal.client.internal.NativeHandleGuard;
 
 import org.whispersystems.libsignal.ecc.Curve;
 import org.whispersystems.libsignal.ecc.ECPublicKey;
@@ -47,7 +49,16 @@ public class IdentityKey {
   public String getFingerprint() {
     return Hex.toString(publicKey.serialize());
   }
-	
+
+  public boolean verifyAlternateIdentity(IdentityKey other, byte[] signature) {
+    try (
+      NativeHandleGuard guard = new NativeHandleGuard(this.publicKey);
+      NativeHandleGuard otherGuard = new NativeHandleGuard(other.publicKey);
+    ) {
+      return Native.IdentityKey_VerifyAlternateIdentity(guard.nativeHandle(), otherGuard.nativeHandle(), signature);
+    }
+  }
+
   @Override
   public boolean equals(Object other) {
     if (other == null)                   return false;

--- a/java/java/src/main/java/org/whispersystems/libsignal/IdentityKeyPair.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/IdentityKeyPair.java
@@ -8,7 +8,10 @@ package org.whispersystems.libsignal;
 import org.signal.client.internal.Native;
 import org.signal.client.internal.NativeHandleGuard;
 
+import org.whispersystems.libsignal.ecc.Curve;
+import org.whispersystems.libsignal.ecc.ECKeyPair;
 import org.whispersystems.libsignal.ecc.ECPrivateKey;
+import org.whispersystems.libsignal.ecc.ECPublicKey;
 
 /**
  * Holder for public and private identity key pair.
@@ -33,6 +36,13 @@ public class IdentityKeyPair {
     this.privateKey = new ECPrivateKey(privateKeyHandle);
   }
 
+  public static IdentityKeyPair generate() {
+    ECKeyPair keyPair = Curve.generateKeyPair();
+    ECPrivateKey privateKey = keyPair.getPrivateKey();
+    ECPublicKey publicKey = keyPair.getPublicKey();
+    return new IdentityKeyPair(new IdentityKey(publicKey), privateKey);
+  }
+
   public IdentityKey getPublicKey() {
     return publicKey;
   }
@@ -47,6 +57,16 @@ public class IdentityKeyPair {
       NativeHandleGuard privateKey = new NativeHandleGuard(this.privateKey);
     ) {
       return Native.IdentityKeyPair_Serialize(publicKey.nativeHandle(), privateKey.nativeHandle());
+    }
+  }
+
+  public byte[] signAlternateIdentity(IdentityKey other) {
+    try (
+      NativeHandleGuard publicKey = new NativeHandleGuard(this.publicKey.getPublicKey());
+      NativeHandleGuard privateKey = new NativeHandleGuard(this.privateKey);
+      NativeHandleGuard otherPublic = new NativeHandleGuard(other.getPublicKey());
+    ) {
+      return Native.IdentityKeyPair_SignAlternateIdentity(publicKey.nativeHandle(), privateKey.nativeHandle(), otherPublic.nativeHandle());
     }
   }
 }

--- a/java/tests/src/test/java/org/whispersystems/libsignal/IdentityKeyTest.java
+++ b/java/tests/src/test/java/org/whispersystems/libsignal/IdentityKeyTest.java
@@ -1,0 +1,19 @@
+//
+// Copyright 2021 Signal Messenger, LLC.
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+package org.whispersystems.libsignal;
+
+import junit.framework.TestCase;
+import org.whispersystems.libsignal.IdentityKey;
+import org.whispersystems.libsignal.IdentityKeyPair;
+
+public class IdentityKeyTest extends TestCase {
+  public void testSignAlternateKey() {
+    IdentityKeyPair primary = IdentityKeyPair.generate();
+    IdentityKeyPair secondary = IdentityKeyPair.generate();
+    byte[] signature = secondary.signAlternateIdentity(primary.getPublicKey());
+    assertTrue(secondary.getPublicKey().verifyAlternateIdentity(primary.getPublicKey(), signature));
+  }
+}

--- a/node/Native.d.ts
+++ b/node/Native.d.ts
@@ -91,6 +91,8 @@ export function HsmEnclaveClient_EstablishedSend(cli: Wrapper<HsmEnclaveClient>,
 export function HsmEnclaveClient_InitialRequest(obj: Wrapper<HsmEnclaveClient>): Buffer;
 export function HsmEnclaveClient_New(trustedPublicKey: Buffer, trustedCodeHashes: Buffer): HsmEnclaveClient;
 export function IdentityKeyPair_Serialize(publicKey: Wrapper<PublicKey>, privateKey: Wrapper<PrivateKey>): Buffer;
+export function IdentityKeyPair_SignAlternateIdentity(publicKey: Wrapper<PublicKey>, privateKey: Wrapper<PrivateKey>, otherIdentity: Wrapper<PublicKey>): Buffer;
+export function IdentityKey_VerifyAlternateIdentity(publicKey: Wrapper<PublicKey>, otherIdentity: Wrapper<PublicKey>, signature: Buffer): boolean;
 export function PlaintextContent_Deserialize(data: Buffer): PlaintextContent;
 export function PlaintextContent_FromDecryptionErrorMessage(m: Wrapper<DecryptionErrorMessage>): PlaintextContent;
 export function PlaintextContent_GetBody(obj: Wrapper<PlaintextContent>): Buffer;

--- a/node/ts/index.ts
+++ b/node/ts/index.ts
@@ -197,6 +197,10 @@ export class PublicKey {
   verify(msg: Buffer, sig: Buffer): boolean {
     return Native.PublicKey_Verify(this, msg, sig);
   }
+
+  verifyAlternateIdentity(other: PublicKey, signature: Buffer): boolean {
+    return Native.IdentityKey_VerifyAlternateIdentity(this, other, signature);
+  }
 }
 
 export class PrivateKey {
@@ -236,20 +240,29 @@ export class PrivateKey {
 }
 
 export class IdentityKeyPair {
-  private readonly publicKey: PublicKey;
-  private readonly privateKey: PrivateKey;
+  readonly publicKey: PublicKey;
+  readonly privateKey: PrivateKey;
 
   constructor(publicKey: PublicKey, privateKey: PrivateKey) {
     this.publicKey = publicKey;
     this.privateKey = privateKey;
   }
 
-  static new(publicKey: PublicKey, privateKey: PrivateKey): IdentityKeyPair {
-    return new IdentityKeyPair(publicKey, privateKey);
+  static generate(): IdentityKeyPair {
+    const privateKey = PrivateKey.generate();
+    return new IdentityKeyPair(privateKey.getPublicKey(), privateKey);
   }
 
   serialize(): Buffer {
     return Native.IdentityKeyPair_Serialize(this.publicKey, this.privateKey);
+  }
+
+  signAlternateIdentity(other: PublicKey): Buffer {
+    return Native.IdentityKeyPair_SignAlternateIdentity(
+      this.publicKey,
+      this.privateKey,
+      other
+    );
   }
 }
 

--- a/node/ts/test/PublicAPITest.ts
+++ b/node/ts/test/PublicAPITest.ts
@@ -1685,4 +1685,13 @@ describe('SignalClient', () => {
       SignalClient.PublicKey.deserialize(invalid_key);
     }, 'bad key type <0xab>');
   });
+
+  it('can sign and verify alternate identity keys', () => {
+    const primary = SignalClient.IdentityKeyPair.generate();
+    const secondary = SignalClient.IdentityKeyPair.generate();
+    const signature = secondary.signAlternateIdentity(primary.publicKey);
+    assert(
+      secondary.publicKey.verifyAlternateIdentity(primary.publicKey, signature)
+    );
+  });
 });

--- a/rust/bridge/shared/src/protocol.rs
+++ b/rust/bridge/shared/src/protocol.rs
@@ -169,6 +169,31 @@ fn IdentityKeyPair_Serialize(public_key: &PublicKey, private_key: &PrivateKey) -
     identity_key_pair.serialize().into_vec()
 }
 
+#[bridge_fn_buffer(ffi = "identitykeypair_sign_alternate_identity")]
+fn IdentityKeyPair_SignAlternateIdentity(
+    public_key: &PublicKey,
+    private_key: &PrivateKey,
+    other_identity: &PublicKey,
+) -> Result<Vec<u8>> {
+    let mut rng = rand::rngs::OsRng;
+    let identity_key_pair = IdentityKeyPair::new(IdentityKey::new(*public_key), *private_key);
+    let other_identity = IdentityKey::new(*other_identity);
+    Ok(identity_key_pair
+        .sign_alternate_identity(&other_identity, &mut rng)?
+        .into_vec())
+}
+
+#[bridge_fn(ffi = "identitykey_verify_alternate_identity")]
+fn IdentityKey_VerifyAlternateIdentity(
+    public_key: &PublicKey,
+    other_identity: &PublicKey,
+    signature: &[u8],
+) -> Result<bool> {
+    let identity = IdentityKey::new(*public_key);
+    let other_identity = IdentityKey::new(*other_identity);
+    identity.verify_alternate_identity(&other_identity, signature)
+}
+
 #[bridge_fn(jni = false)]
 fn Fingerprint_New(
     iterations: u32,

--- a/rust/protocol/src/curve.rs
+++ b/rust/protocol/src/curve.rs
@@ -81,8 +81,8 @@ impl PublicKey {
     }
 
     pub fn public_key_bytes(&self) -> Result<&[u8]> {
-        match self.key {
-            PublicKeyData::DjbPublicKey(ref v) => Ok(v),
+        match &self.key {
+            PublicKeyData::DjbPublicKey(v) => Ok(v),
         }
     }
 
@@ -96,25 +96,25 @@ impl PublicKey {
     }
 
     pub fn serialize(&self) -> Box<[u8]> {
-        let value_len = match self.key {
+        let value_len = match &self.key {
             PublicKeyData::DjbPublicKey(v) => v.len(),
         };
         let mut result = Vec::with_capacity(1 + value_len);
         result.push(self.key_type().value());
-        match self.key {
-            PublicKeyData::DjbPublicKey(v) => result.extend_from_slice(&v),
+        match &self.key {
+            PublicKeyData::DjbPublicKey(v) => result.extend_from_slice(v),
         }
         result.into_boxed_slice()
     }
 
     pub fn verify_signature(&self, message: &[u8], signature: &[u8]) -> Result<bool> {
-        match self.key {
+        match &self.key {
             PublicKeyData::DjbPublicKey(pub_key) => {
                 if signature.len() != curve25519::SIGNATURE_LENGTH {
                     return Ok(false);
                 }
                 Ok(curve25519::PrivateKey::verify_signature(
-                    &pub_key,
+                    pub_key,
                     message,
                     array_ref![signature, 0, curve25519::SIGNATURE_LENGTH],
                 ))
@@ -123,13 +123,13 @@ impl PublicKey {
     }
 
     fn key_data(&self) -> &[u8] {
-        match self.key {
+        match &self.key {
             PublicKeyData::DjbPublicKey(ref k) => k.as_ref(),
         }
     }
 
     pub fn key_type(&self) -> KeyType {
-        match self.key {
+        match &self.key {
             PublicKeyData::DjbPublicKey(_) => KeyType::Djb,
         }
     }
@@ -223,23 +223,23 @@ impl PrivateKey {
     }
 
     pub fn serialize(&self) -> Vec<u8> {
-        match self.key {
+        match &self.key {
             PrivateKeyData::DjbPrivateKey(v) => v.to_vec(),
         }
     }
 
     pub fn public_key(&self) -> Result<PublicKey> {
-        match self.key {
+        match &self.key {
             PrivateKeyData::DjbPrivateKey(private_key) => {
                 let public_key =
-                    curve25519::PrivateKey::from(private_key).derive_public_key_bytes();
+                    curve25519::PrivateKey::from(*private_key).derive_public_key_bytes();
                 Ok(PublicKey::new(PublicKeyData::DjbPublicKey(public_key)))
             }
         }
     }
 
     pub fn key_type(&self) -> KeyType {
-        match self.key {
+        match &self.key {
             PrivateKeyData::DjbPrivateKey(_) => KeyType::Djb,
         }
     }

--- a/swift/Sources/SignalFfi/signal_ffi.h
+++ b/swift/Sources/SignalFfi/signal_ffi.h
@@ -557,6 +557,18 @@ SignalFfiError *signal_identitykeypair_serialize(const unsigned char **out,
                                                  const SignalPublicKey *public_key,
                                                  const SignalPrivateKey *private_key);
 
+SignalFfiError *signal_identitykeypair_sign_alternate_identity(const unsigned char **out,
+                                                               size_t *out_len,
+                                                               const SignalPublicKey *public_key,
+                                                               const SignalPrivateKey *private_key,
+                                                               const SignalPublicKey *other_identity);
+
+SignalFfiError *signal_identitykey_verify_alternate_identity(bool *out,
+                                                             const SignalPublicKey *public_key,
+                                                             const SignalPublicKey *other_identity,
+                                                             const unsigned char *signature,
+                                                             size_t signature_len);
+
 SignalFfiError *signal_fingerprint_new(SignalFingerprint **out,
                                        uint32_t iterations,
                                        uint32_t version,

--- a/swift/Tests/SignalClientTests/PublicAPITests.swift
+++ b/swift/Tests/SignalClientTests/PublicAPITests.swift
@@ -321,6 +321,13 @@ class PublicAPITests: TestCaseBase {
         XCTAssertEqual(cert[0], 0x30)
     }
 
+    func testSignAlternateIdentity() {
+        let primary = IdentityKeyPair.generate()
+        let secondary = IdentityKeyPair.generate()
+        let signature = secondary.signAlternateIdentity(primary.identityKey)
+        XCTAssert(try! secondary.identityKey.verifyAlternateIdentity(primary.identityKey, signature: signature))
+    }
+
     static var allTests: [(String, (PublicAPITests) -> () throws -> Void)] {
         return [
             ("testAddreses", testAddress),
@@ -332,6 +339,7 @@ class PublicAPITests: TestCaseBase {
             ("testGroupCipher", testGroupCipher),
             ("testSenderCertifications", testSenderCertificates),
             ("testSerializationRoundTrip", testSerializationRoundTrip),
+            ("testSignAlternateIdentity", testSignAlternateIdentity),
         ]
     }
 }


### PR DESCRIPTION
This can be used for one identity to attest that another identity represents the same account. For instance, a PNI can sign an ACI to demonstrate that the ACI is associated with the phone number in question.