### PR TITLE
java: Add PlaintextContent(byte[]) constructor

### DIFF
--- a/java/java/src/main/java/org/whispersystems/libsignal/protocol/PlaintextContent.java
+++ b/java/java/src/main/java/org/whispersystems/libsignal/protocol/PlaintextContent.java
@@ -9,6 +9,7 @@ import org.signal.client.internal.Native;
 import org.signal.client.internal.NativeHandleGuard;
 
 import org.whispersystems.libsignal.InvalidMessageException;
+import org.whispersystems.libsignal.InvalidVersionException;
 import org.whispersystems.libsignal.util.guava.Optional;
 
 public final class PlaintextContent implements CiphertextMessage, NativeHandleGuard.Owner {
@@ -34,6 +35,10 @@ public final class PlaintextContent implements CiphertextMessage, NativeHandleGu
     try (NativeHandleGuard messageGuard = new NativeHandleGuard(message)) {
       this.unsafeHandle = Native.PlaintextContent_FromDecryptionErrorMessage(messageGuard.nativeHandle());
     }
+  }
+
+  public PlaintextContent(byte[] serialized) throws InvalidMessageException, InvalidVersionException {
+    unsafeHandle = Native.PlaintextContent_Deserialize(serialized);
   }
 
   @Override

--- a/java/tests/src/test/java/org/whispersystems/libsignal/PlaintextContentTest.java
+++ b/java/tests/src/test/java/org/whispersystems/libsignal/PlaintextContentTest.java
@@ -1,0 +1,66 @@
+//
+// Copyright 2022 Signal Messenger, LLC.
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+package org.whispersystems.libsignal;
+
+import org.junit.Test;
+import org.whispersystems.libsignal.protocol.CiphertextMessage;
+import org.whispersystems.libsignal.protocol.DecryptionErrorMessage;
+import org.whispersystems.libsignal.protocol.PlaintextContent;
+import org.whispersystems.libsignal.util.Hex;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.fail;
+
+public class PlaintextContentTest {
+  @Test
+  public void testRoundTripSerialization() throws Exception {
+    // We don't have the whole Content proto exposed at the Java level in this project,
+    // so just check the literal bytes that we expect.
+    byte[] expectedPlaintextBody = new byte[] {
+      // DecryptionErrorMessage field, 9 bytes long
+      (byte)0x42, (byte)0x09,
+      // The serialized DecryptionErrorMessage
+      (byte)0x10, (byte)0x80, (byte)0xb8, (byte)0xbe,
+      (byte)0x97, (byte)0xe1, (byte)0x2f, (byte)0x18,
+      (byte)0x08,
+      // Tail padding marker
+      (byte)0x80,
+    };
+
+    long timestamp = 1640995200000L;
+    int originalDeviceId = 8;
+
+    // DEMs don't extract any information from the original message for a SenderKey message,
+    // so we use that here to avoid having to construct a valid original message.
+    DecryptionErrorMessage decryptionErrorMessage = DecryptionErrorMessage.forOriginalMessage(
+      new byte[] {}, CiphertextMessage.SENDERKEY_TYPE, timestamp, originalDeviceId);
+
+    byte[] serializedDEM = decryptionErrorMessage.serialize();
+    assertArrayEquals(
+      "expectedBody needs updating",
+      serializedDEM,
+      Arrays.copyOfRange(expectedPlaintextBody, 2, 2 + serializedDEM.length));
+
+    byte[] serializedPlaintextContent = new PlaintextContent(decryptionErrorMessage).serialize();
+    byte[] deserializedPlaintextBody = new PlaintextContent(serializedPlaintextContent).getBody();
+    assertArrayEquals(deserializedPlaintextBody, expectedPlaintextBody);
+  }
+
+  @Test
+  public void testDeserializationRejectsGarbage() throws Exception {
+    try {
+      new PlaintextContent(new byte[] {});
+      fail();
+    } catch (InvalidMessageException e) {}
+
+    try {
+      new PlaintextContent(new byte[] {(byte)0});
+      fail();
+    } catch (InvalidVersionException e) {}
+  }
+}


### PR DESCRIPTION
This is necessary when handling PlaintextContent *not* sent via sealed sender.