### PR TITLE
Added message type to sealed sender decryption result.

### DIFF
--- a/java/java/src/main/java/org/signal/libsignal/metadata/SealedSessionCipher.java
+++ b/java/java/src/main/java/org/signal/libsignal/metadata/SealedSessionCipher.java
@@ -160,6 +160,7 @@ public class SealedSessionCipher {
       return new DecryptionResult(content.getSenderCertificate().getSenderUuid(),
                                   content.getSenderCertificate().getSenderE164(),
                                   content.getSenderCertificate().getSenderDeviceId(),
+                                  content.getType(),
                                   content.getGroupId(),
                                   decrypt(content));
     } catch (InvalidMessageException e) {
@@ -212,13 +213,15 @@ public class SealedSessionCipher {
     private final String           senderUuid;
     private final Optional<String> senderE164;
     private final int              deviceId;
+    private final int              messageType;
     private final Optional<byte[]> groupId;
     private final byte[]           paddedMessage;
 
-    private DecryptionResult(String senderUuid, Optional<String> senderE164, int deviceId, Optional<byte[]> groupId, byte[] paddedMessage) {
+    private DecryptionResult(String senderUuid, Optional<String> senderE164, int deviceId, int messageType, Optional<byte[]> groupId, byte[] paddedMessage) {
       this.senderUuid    = senderUuid;
       this.senderE164    = senderE164;
       this.deviceId      = deviceId;
+      this.messageType   = messageType;
       this.groupId       = groupId;
       this.paddedMessage = paddedMessage;
     }
@@ -233,6 +236,10 @@ public class SealedSessionCipher {
 
     public int getDeviceId() {
       return deviceId;
+    }
+
+    public int getCiphertextMessageType() {
+      return messageType;
     }
 
     public byte[] getPaddedMessage() {


### PR DESCRIPTION
We'd like to be able to know what kind of message the SealedSessionCipher processed.