### PR TITLE
Tweaks the Swift interface for HSM Enclave Client

### DIFF
--- a/swift/Tests/SignalClientTests/HsmEnclaveTests.swift
+++ b/swift/Tests/SignalClientTests/HsmEnclaveTests.swift
@@ -19,7 +19,7 @@ class HsmEnclaveTests: TestCaseBase {
             0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
             0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
         ])
-        let hsmEnclaveClient = try! HsmEnclaveClient(publicKey: validKey, codeHashes: hashes)
+        let hsmEnclaveClient = try! HsmEnclaveClient(publicKey: validKey.keyBytes, codeHashes: hashes)
         let initialMessage = try! hsmEnclaveClient.initialRequest()
         XCTAssertEqual(112, initialMessage.count)
     }
@@ -27,7 +27,7 @@ class HsmEnclaveTests: TestCaseBase {
     func testCreateClientFailsWithNoHashes() {
         let validKey = IdentityKeyPair.generate().publicKey
         let hashes = HsmCodeHashList()
-        XCTAssertThrowsError(try HsmEnclaveClient(publicKey: validKey, codeHashes: hashes))
+        XCTAssertThrowsError(try HsmEnclaveClient(publicKey: validKey.keyBytes, codeHashes: hashes))
     }
 
     func testCompleteHandshakeWithoutInitialRequest() {
@@ -37,7 +37,7 @@ class HsmEnclaveTests: TestCaseBase {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ])
-        let hsmEnclaveClient = try! HsmEnclaveClient(publicKey: validKey, codeHashes: hashes)
+        let hsmEnclaveClient = try! HsmEnclaveClient(publicKey: validKey.keyBytes, codeHashes: hashes)
         let handshakeResponse: [UInt8] = [0x01, 0x02, 0x03]
         XCTAssertThrowsError(try hsmEnclaveClient.completeHandshake(handshakeResponse))
     }
@@ -49,7 +49,7 @@ class HsmEnclaveTests: TestCaseBase {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ])
-        let hsmEnclaveClient = try! HsmEnclaveClient(publicKey: validKey, codeHashes: hashes)
+        let hsmEnclaveClient = try! HsmEnclaveClient(publicKey: validKey.keyBytes, codeHashes: hashes)
         let plaintextToSend: [UInt8] = [0x01, 0x02, 0x03]
         XCTAssertThrowsError(try hsmEnclaveClient.establishedSend(plaintextToSend))
     }
@@ -61,7 +61,7 @@ class HsmEnclaveTests: TestCaseBase {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ])
-        let hsmEnclaveClient = try! HsmEnclaveClient(publicKey: validKey, codeHashes: hashes)
+        let hsmEnclaveClient = try! HsmEnclaveClient(publicKey: validKey.keyBytes, codeHashes: hashes)
         let receivedCiphertext: [UInt8] = [0x01, 0x02, 0x03]
         XCTAssertThrowsError(try hsmEnclaveClient.establishedRecv(receivedCiphertext))
     }


### PR DESCRIPTION
commit a7a874d8195f803609a2c3a5925699ee71d20d12
Author: Michelle Linington <michelle@signal.org>
Date:   Fri Feb 11 14:14:15 2022 -0800

    Fix broken tests

commit e2fe069d38c303f6a049613ddef99fd087677578
Author: Michelle Linington <michelle@signal.org>
Date:   Thu Feb 10 15:25:08 2022 -0800

    Tweaks the Swift interface for HSM Enclave Client
    
    - Fixes an issue where a call to decrypt would instead re-encrypt the
      ciphertext.
    - Tweaks the interface for the initializer to instead take raw public
      key bytes. This matches the java interface. Framework clients have no
      way to construct a PublicKey from raw bytes.