### PR TITLE
Node: use a plain Buffer for the HsmEnclave public key

### DIFF
--- a/node/ts/index.ts
+++ b/node/ts/index.ts
@@ -1468,7 +1468,7 @@ export class HsmEnclaveClient {
     this._nativeHandle = nativeHandle;
   }
 
-  static new(public_key: PublicKey, code_hashes: Buffer[]): HsmEnclaveClient {
+  static new(public_key: Buffer, code_hashes: Buffer[]): HsmEnclaveClient {
     code_hashes.forEach(hash => {
       if (hash.length != 32) {
         throw new Error('code hash length must be 32');
@@ -1477,7 +1477,7 @@ export class HsmEnclaveClient {
     const concat_hashes = Buffer.concat(code_hashes);
 
     return new HsmEnclaveClient(
-      Native.HsmEnclaveClient_New(public_key.getPublicKeyBytes(), concat_hashes)
+      Native.HsmEnclaveClient_New(public_key, concat_hashes)
     );
   }
 

--- a/node/ts/test/HsmEnclaveTest.ts
+++ b/node/ts/test/HsmEnclaveTest.ts
@@ -21,11 +21,9 @@ SignalClient.initLogger(
 );
 
 describe('HsmEnclaveClient', () => {
-  const validKey = SignalClient.PublicKey.deserialize(
-    Buffer.from(
-      '0506863bc66d02b40d27b8d49ca7c09e9239236f9d7d25d6fcca5ce13c7064d868',
-      'hex'
-    )
+  const validKey = Buffer.from(
+    '06863bc66d02b40d27b8d49ca7c09e9239236f9d7d25d6fcca5ce13c7064d868',
+    'hex'
   );
 
   it('create client', () => {


### PR DESCRIPTION
The PublicKey type includes a type byte prefix to support different kinds of public keys in the future, but that doesn't really apply to HsmEnclave keys. This matches the Java implementation and the recently-updated Swift implementation (#448)