### PR TITLE
NPM: publish releases for Linux arm64

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -28,6 +28,8 @@ jobs:
           arm64-rust-target: aarch64-apple-darwin
         - os: windows-latest
           arm64-rust-target: aarch64-pc-windows-msvc
+        - os: ubuntu-latest
+          arm64-rust-target: aarch64-unknown-linux-gnu
 
     steps:
     - uses: actions/checkout@v2
@@ -56,9 +58,14 @@ jobs:
     - run: yarn install --ignore-scripts --frozen-lockfile
       working-directory: node
 
-    - run: npx prebuildify --napi -t ${{ steps.get-nvm-version.outputs.node-version }} --arch arm64
+    - run: |
+        if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+          sudo apt-get install -y crossbuild-essential-arm64
+          export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+        fi
+        npx prebuildify --napi -t ${{ steps.get-nvm-version.outputs.node-version }} --arch arm64
       working-directory: node
-      if: matrix.arm64-rust-target != ''
+      shell: bash
 
     - run: npx prebuildify --napi -t ${{ steps.get-nvm-version.outputs.node-version }}
       working-directory: node

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -58,14 +58,14 @@ jobs:
     - run: yarn install --ignore-scripts --frozen-lockfile
       working-directory: node
 
-    - run: |
-        if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
-          sudo apt-get install -y crossbuild-essential-arm64
-          export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
-        fi
-        npx prebuildify --napi -t ${{ steps.get-nvm-version.outputs.node-version }} --arch arm64
+    - name: Install crossbuild for Linux arm64
+      run: |
+        sudo apt-get install -y crossbuild-essential-arm64
+        echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+      if: matrix.os == 'ubuntu-latest'
+
+    - run: npx prebuildify --napi -t ${{ steps.get-nvm-version.outputs.node-version }} --arch arm64
       working-directory: node
-      shell: bash
 
     - run: npx prebuildify --napi -t ${{ steps.get-nvm-version.outputs.node-version }}
       working-directory: node


### PR DESCRIPTION
As mentioned in https://github.com/signalapp/libsignal-client/pull/426#issuecomment-1035334639

Linux is a bit of a special case in that we need to explicitly define things like the arm64 linker. Without the cross dependencies, I got linker errors: https://github.com/dennisameling/libsignal-client/runs/5229605777?check_suite_focus=true

Example of a successful build: https://github.com/dennisameling/libsignal-client/actions/runs/1858014293

I've been using this setup in my `signal-native-deps` repo for a few months: https://github.com/dennisameling/signal-native-deps/blob/75f22a11a11d18b1ed3b85b51d032816579cce00/.github/workflows/build.yaml#L132-L140